### PR TITLE
[query] add `RowSeq` to reduce copying

### DIFF
--- a/hail/hail/src/is/hail/annotations/Annotation.scala
+++ b/hail/hail/src/is/hail/annotations/Annotation.scala
@@ -7,11 +7,13 @@ import is.hail.utils._
 import org.apache.spark.sql.Row
 
 object Annotation {
-  val empty: Annotation = Row()
+  val empty: Annotation = RowSeq()
 
-  def apply(args: Any*): Annotation = Row.fromSeq(args)
+  def apply(args: Any*): Annotation =
+    RowSeq(args: _*)
 
-  def fromSeq(values: Seq[Any]): Annotation = Row.fromSeq(values)
+  def fromSeq(values: Seq[Any]): Annotation =
+    RowSeq.fromSeq(values)
 
   def copy(t: Type, a: Annotation): Annotation = {
     if (a == null)
@@ -20,7 +22,7 @@ object Annotation {
     t match {
       case t: TBaseStruct =>
         val r = a.asInstanceOf[Row]
-        Row.fromSeq(ArraySeq.tabulate(r.size)(i => Annotation.copy(t.types(i), r(i))))
+        RowSeq.fromSeq(ArraySeq.tabulate(r.size)(i => Annotation.copy(t.types(i), r(i))))
 
       case t: TArray =>
         val arr = a.asInstanceOf[IndexedSeq[Annotation]]
@@ -52,4 +54,22 @@ object Annotation {
         a
     }
   }
+}
+
+private[annotations] class RowSeq(values: ArraySeq[Any]) extends Row {
+  override def length: Int = values.length
+  override def get(i: Int): Any = values(i)
+  override def copy(): Row = this
+  override def toSeq: Seq[Any] = values
+}
+
+object RowSeq {
+  def apply(values: Any*): Row =
+    if (values.isEmpty) Row.empty else new RowSeq(ArraySeq(values: _*))
+
+  def fromSeq(values: Seq[Any]): Row =
+    if (values.isEmpty) Row.empty else new RowSeq(ArraySeq.from(values))
+
+  def fromTuple(p: Product): Row =
+    if (p.productArity == 0) Row.empty else new RowSeq(ArraySeq.from(p.productIterator))
 }

--- a/hail/hail/src/is/hail/annotations/BroadcastValue.scala
+++ b/hail/hail/src/is/hail/annotations/BroadcastValue.scala
@@ -28,7 +28,7 @@ case class SerializableRegionValue(
 }
 
 object BroadcastRow {
-  def empty(ctx: ExecuteContext): BroadcastRow = apply(ctx, Row(), TStruct.empty)
+  def empty(ctx: ExecuteContext): BroadcastRow = apply(ctx, RowSeq(), TStruct.empty)
 
   def apply(ctx: ExecuteContext, value: Row, t: TBaseStruct): BroadcastRow = {
     val pType = PType.literalPType(t, value).asInstanceOf[PStruct]

--- a/hail/hail/src/is/hail/annotations/ExtendedOrdering.scala
+++ b/hail/hail/src/is/hail/annotations/ExtendedOrdering.scala
@@ -158,7 +158,7 @@ object ExtendedOrdering {
       val missingEqual = _missingEqual
 
       private def toArrayOfT(x: T): Array[T] =
-        x.asInstanceOf[Map[_, _]].iterator.map { case (k, v) => Row(k, v): T }.toArray
+        x.asInstanceOf[Map[_, _]].iterator.map { case (k, v) => RowSeq(k, v): T }.toArray
 
       override def compareNonnull(x: T, y: T): Int =
         saOrd.compareNonnull(

--- a/hail/hail/src/is/hail/annotations/UnsafeRow.scala
+++ b/hail/hail/src/is/hail/annotations/UnsafeRow.scala
@@ -224,7 +224,7 @@ object SafeRow {
 
   def selectFields(t: PBaseStruct, region: Region, off: Long)(selectIdx: IndexedSeq[Int]): Row = {
     val fullRow = new UnsafeRow(t, region, off)
-    Row.fromSeq(selectIdx.map(i => Annotation.copy(t.types(i).virtualType, fullRow.get(i))))
+    RowSeq.fromSeq(selectIdx.map(i => Annotation.copy(t.types(i).virtualType, fullRow.get(i))))
   }
 
   def selectFields(t: PBaseStruct, rv: RegionValue)(selectIdx: IndexedSeq[Int]): Row =

--- a/hail/hail/src/is/hail/expr/AnnotationImpex.scala
+++ b/hail/hail/src/is/hail/expr/AnnotationImpex.scala
@@ -1,6 +1,6 @@
 package is.hail.expr
 
-import is.hail.annotations.{Annotation, NDArray, SafeNDArray}
+import is.hail.annotations.{Annotation, NDArray, RowSeq, SafeNDArray}
 import is.hail.collection.compat.immutable.ArraySeq
 import is.hail.collection.implicits._
 import is.hail.types.physical.{
@@ -180,7 +180,7 @@ object JSONAnnotationImpex extends Logging {
   def irImportAnnotation(s: String, t: Type, warnContext: mutable.HashSet[String]): Row = {
     try
       // wraps in a Row to handle returned missingness
-      Row(importAnnotation(JsonMethods.parse(s), t, true, warnContext))
+      RowSeq(importAnnotation(JsonMethods.parse(s), t, true, warnContext))
     catch {
       case e: Throwable =>
         fatal(s"Error parsing JSON:\n  type: $t\n  value: $s", e)
@@ -210,138 +210,150 @@ object JSONAnnotationImpex extends Logging {
   ): Annotation = {
     def imp(jv: JValue, t: Type, parent: String): Annotation =
       importAnnotationInternal(jv, t, parent, padNulls, warnContext)
-    def warnOnce(msg: String, path: String): Unit =
-      if (!warnContext.contains(path)) {
-        logger.warn(msg)
-        warnContext += path
-      }
 
-    (jv, t) match {
-      case (JNull | JNothing, _) => null
-      case (JInt(x), TInt32) => x.toInt
-      case (JInt(x), TInt64) => x.toLong
-      case (JInt(x), TFloat64) => x.toDouble
-      case (JInt(x), TString) => x.toString
-      case (JDouble(x), TFloat64) => x
-      case (JDouble(x), TFloat32) => x.toFloat
-      case (JString(x), TFloat64) if doubleConv.contains(x) => doubleConv(x)
-      case (JString(x), TFloat32) if floatConv.contains(x) => floatConv(x)
-      case (JString(x), TString) => x
-      case (JString(x), TInt32) =>
-        x.toInt
-      case (JString(x), TFloat64) =>
-        if (x.startsWith("-:"))
-          x.drop(2).toDouble
-        else
-          x.toDouble
-      case (JBool(x), TBoolean) => x
+    def warnOnce(msg: String, parent: String): Unit =
+      if (warnContext.add(parent)) logger.warn(msg)
 
-      // back compatibility
-      case (JObject(a), TDict(TString, valueType)) =>
-        a.map { case (key, value) =>
-          (key, imp(value, valueType, parent))
+    def warnCoerce(): Annotation = {
+      warnOnce(s"Can't convert JSON value $jv to type $t at $parent.", parent)
+      null
+    }
+
+    jv match {
+      case JNull | JNothing => null
+      case JInt(x) => t match {
+          case TInt32 => x.toInt
+          case TInt64 => x.toLong
+          case TFloat32 => x.toFloat
+          case TFloat64 => x.toDouble
+          case TString => x.toString
+          case _ => warnCoerce()
         }
-          .toMap
+      case JDouble(x) => t match {
+          case TFloat64 => x
+          case TFloat32 => x.toFloat
+          case _ => warnCoerce()
+        }
+      case JString(x) => t match {
+          case TFloat64 if doubleConv.contains(x) => doubleConv(x)
+          case TFloat32 if floatConv.contains(x) => floatConv(x)
+          case TString => x
+          case TInt32 => x.toInt
+          case TFloat64 =>
+            if (x.startsWith("-:")) x.drop(2).toDouble
+            else x.toDouble
+          case TCall => Call.parse(x)
+          case _ => warnCoerce()
+        }
+      case JBool(x) => t match {
+          case TBoolean => x
+          case _ => warnCoerce()
+        }
+      case JObject(jfields) => t match {
+          // back compatibility
+          case TDict(TString, valueType) =>
+            jfields
+              .foldLeft(Map.newBuilder[String, Annotation]) {
+                (b, f) => b += (f._1 -> imp(f._2, valueType, parent))
+              }
+              .result()
 
-      case (JArray(arr), TDict(keyType, valueType)) =>
-        val keyPath = parent + "[key]"
-        val valuePath = parent + "[value]"
-        arr.map {
-          case JObject(a) =>
-            a match {
-              case List(k, v) =>
-                (k, v) match {
-                  case (("key", ka), ("value", va)) =>
-                    (imp(ka, keyType, keyPath), imp(va, valueType, valuePath))
+          case t: TStruct =>
+            if (t.size == 0) Annotation.empty
+            else {
+              val annotationSize =
+                if (padNulls) t.size
+                else if (jfields.isEmpty) 0
+                else 1 + jfields.foldLeft(-1) { (max, f) =>
+                  t.selfField(f._1).fold(max)(k => math.max(max, k.index))
                 }
-              case _ =>
-                warnOnce(s"Can't convert JSON value $jv to type $t at $parent.", parent)
-                null
 
+              val a = Array.fill[Any](annotationSize)(null)
+
+              for ((name, jv2) <- jfields) {
+                t.selfField(name) match {
+                  case Some(f) =>
+                    a(f.index) = imp(jv2, f.typ, parent + "." + name)
+                  case None =>
+                    warnOnce(
+                      s"$t has no field $name at $parent for value $jv2",
+                      parent + "/" + name,
+                    )
+                }
+              }
+
+              Annotation.fromSeq(ArraySeq.unsafeWrapArray(a))
             }
-          case _ =>
-            warnOnce(s"Can't convert JSON value $jv to type $t at $parent.", parent)
-            null
-        }.toMap
-
-      case (JObject(jfields), t: TStruct) =>
-        if (t.size == 0)
-          Annotation.empty
-        else {
-          val annotationSize = if (padNulls) {
-            t.size
-          } else if (jfields.size == 0) {
-            0
-          } else {
-            jfields.map { case (name, _) =>
-              t.selfField(name).map(_.index).getOrElse(-1)
-            }.max + 1
-          }
-          val a = Array.fill[Any](annotationSize)(null)
-
-          for ((name, jv2) <- jfields) {
-            t.selfField(name) match {
-              case Some(f) =>
-                a(f.index) = imp(jv2, f.typ, parent + "." + name)
-
-              case None =>
-                warnOnce(s"$t has no field $name at $parent for value $jv2", parent + "/" + name)
+          case t @ TNDArray(_, _) =>
+            jfields match {
+              case List(("shape", shapeJson: JArray), ("data", dataJson: JArray)) =>
+                val shapeArray =
+                  shapeJson.arr.view.map(imp(_, TInt64, parent).asInstanceOf[Long]).to(ArraySeq)
+                val dataArray = dataJson.arr.view.map(imp(_, t.elementType, parent)).to(ArraySeq)
+                SafeNDArray(shapeArray, dataArray)
+              case _ => warnCoerce()
             }
-          }
+          case TInterval(pointType) =>
+            val m = jfields.toMap
+            val interval: Option[Annotation] =
+              for {
+                s <- m.get("start")
+                start = imp(s, pointType, parent + ".start")
 
-          Annotation.fromSeq(ArraySeq.unsafeWrapArray(a))
-        }
-      case (JArray(elts), t: TTuple) =>
-        if (t.size == 0)
-          Annotation.empty
-        else {
-          val b = ArraySeq.newBuilder[Any]
-          b.sizeHint(if (padNulls) t.size else elts.length)
-          b ++= elts.lazyZip(t.types).map(imp(_, _, parent))
-          if (padNulls) for (_ <- elts.length until t.size) b += null
-          Annotation.fromSeq(b.result())
-        }
-      case (_, TLocus(_)) =>
-        jv.extract[Locus]
-      case (
-            JObject(List(("shape", shapeJson: JArray), ("data", dataJson: JArray))),
-            t @ TNDArray(_, _),
-          ) =>
-        val shapeArray =
-          shapeJson.arr.map(imp(_, TInt64, parent)).map(_.asInstanceOf[Long]).toIndexedSeq
-        val dataArray = dataJson.arr.map(imp(_, t.elementType, parent)).toIndexedSeq
+                e <- m.get("end")
+                end = imp(e, pointType, parent + ".end")
 
-        new SafeNDArray(shapeArray, dataArray)
-      case (_, TInterval(pointType)) =>
-        jv match {
-          case JObject(list) =>
-            val m = list.toMap
-            (m.get("start"), m.get("end"), m.get("includeStart"), m.get("includeEnd")) match {
-              case (Some(sjv), Some(ejv), Some(isjv), Some(iejv)) =>
-                Interval(
-                  imp(sjv, pointType, parent + ".start"),
-                  imp(ejv, pointType, parent + ".end"),
-                  imp(isjv, TBoolean, parent + ".includeStart").asInstanceOf[Boolean],
-                  imp(iejv, TBoolean, parent + ".includeEnd").asInstanceOf[Boolean],
-                )
-              case _ =>
-                warnOnce(s"Can't convert JSON value $jv to type $t at $parent.", parent)
-                null
+                is <- m.get("includeStart")
+                includesStart = imp(is, TBoolean, parent + ".includeStart").asInstanceOf[Boolean]
+
+                ie <- m.get("includeEnd")
+                includesEnd = imp(ie, TBoolean, parent + ".includeEnd").asInstanceOf[Boolean]
+              } yield Interval(start, end, includesStart, includesEnd)
+
+            interval.getOrElse(warnCoerce())
+
+          case TLocus(_) => jv.extract[Locus]
+          case _ => warnCoerce()
+        }
+      case JArray(elts) => t match {
+          case TDict(keyType, valueType) =>
+            val keyPath = parent + "[key]"
+            val valuePath = parent + "[value]"
+            elts.foldLeft(Map.newBuilder[Annotation, Annotation]) { (b, elem) =>
+              elem match {
+                case JObject(List(("key", k), ("value", v))) =>
+                  b += (imp(k, keyType, keyPath) -> imp(v, valueType, valuePath))
+                case _ =>
+                  warnCoerce()
+                  b
+              }
+            }.result()
+          case t: TTuple =>
+            if (t.size == 0) Annotation.empty
+            else {
+              val b = ArraySeq.newBuilder[Any]
+              b.sizeHint(t.size)
+
+              var i = 0
+              for (e <- elts) {
+                b += imp(e, t.types(i), parent)
+                i += 1
+              }
+
+              if (padNulls && t.size > i) {
+                b.sizeHint(t.size)
+                for (_ <- i until t.size) b += null
+              }
+
+              Annotation.fromSeq(b.result())
             }
-          case _ =>
-            warnOnce(s"Can't convert JSON value $jv to type $t at $parent.", parent)
-            null
+          case TArray(elementType) =>
+            elts.view.map(jv2 => imp(jv2, elementType, parent + "[element]")).to(ArraySeq)
+          case TSet(elementType) =>
+            elts.view.map(jv2 => imp(jv2, elementType, parent + "[element]")).toSet
+          case _ => warnCoerce()
         }
-      case (JString(x), TCall) => Call.parse(x)
-
-      case (JArray(a), TArray(elementType)) =>
-        a.view.map(jv2 => imp(jv2, elementType, parent + "[element]")).to(ArraySeq)
-
-      case (JArray(a), TSet(elementType)) =>
-        a.iterator.map(jv2 => imp(jv2, elementType, parent + "[element]")).toSet[Any]
-      case _ =>
-        warnOnce(s"Can't convert JSON value $jv to type $t at $parent.", parent)
-        null
+      case _ => warnCoerce()
     }
   }
 }

--- a/hail/hail/src/is/hail/expr/ir/ExtractIntervalFilters.scala
+++ b/hail/hail/src/is/hail/expr/ir/ExtractIntervalFilters.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir
 
-import is.hail.annotations.{ExtendedOrdering, IntervalEndpointOrdering, SafeRow}
+import is.hail.annotations.{ExtendedOrdering, IntervalEndpointOrdering, RowSeq, SafeRow}
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
 import is.hail.collection.compat.immutable.ArraySeq
@@ -93,19 +93,19 @@ object ExtractIntervalFilters extends Logging {
     val ord = PartitionBoundOrdering(ctx, TTuple(TInt32))
     val nonNull = rg.contigs.indices.flatMap { cont =>
       pos.flatMap { i =>
-        i.intersect(ord, Interval(Row(1), Row(rg.contigLength(cont)), true, false))
+        i.intersect(ord, Interval(RowSeq(1), RowSeq(rg.contigLength(cont)), true, false))
           .map { interval =>
             Interval(
-              Row(Locus(rg.contigs(cont), interval.start.asInstanceOf[Row].getAs[Int](0))),
-              Row(Locus(rg.contigs(cont), interval.right.point.asInstanceOf[Row].getAs[Int](0))),
+              RowSeq(Locus(rg.contigs(cont), interval.start.asInstanceOf[Row].getAs[Int](0))),
+              RowSeq(Locus(rg.contigs(cont), interval.right.point.asInstanceOf[Row].getAs[Int](0))),
               interval.includesStart,
               interval.includesEnd,
             )
           }
       }
     }
-    if (pos.nonEmpty && pos.last.contains(ord, Row(null)))
-      nonNull :+ Interval(Row(null), Row(), true, true)
+    if (pos.nonEmpty && pos.last.contains(ord, RowSeq(null)))
+      nonNull :+ Interval(RowSeq(null), RowSeq(), true, true)
     else
       nonNull
   }
@@ -134,12 +134,12 @@ class KeySetLattice(ctx: ExecuteContext, keyType: TStruct) extends Lattice {
         val reducedLast = if (intervalIsReduced(last))
           last
         else
-          Interval(last.left, IntervalEndpoint(Row(), 1))
+          Interval(last.left, IntervalEndpoint(RowSeq(), 1))
         (init :+ reducedLast).toFastSeq
     }
 
     private def intervalIsReduced(interval: Interval): Boolean =
-      interval.right != IntervalEndpoint(Row(null), 1)
+      interval.right != IntervalEndpoint(RowSeq(null), 1)
   }
 
   def keyOrd: ExtendedOrdering = PartitionBoundOrdering(ctx, keyType)
@@ -157,7 +157,7 @@ class KeySetLattice(ctx: ExecuteContext, keyType: TStruct) extends Lattice {
       )
     }
 
-  override def top: Value = KeySet(Interval(Row(), Row(), true, true))
+  override def top: Value = KeySet(Interval(RowSeq(), RowSeq(), true, true))
 
   override def bottom: Value = KeySet.empty
 
@@ -178,13 +178,13 @@ class KeySetLattice(ctx: ExecuteContext, keyType: TStruct) extends Lattice {
     if (v.isEmpty) return top
 
     val builder = ArraySeq.newBuilder[Interval]
-    if (v.head.left != IntervalEndpoint(Row(), -1)) {
-      builder += Interval(IntervalEndpoint(Row(), -1), v.head.left)
+    if (v.head.left != IntervalEndpoint(RowSeq(), -1)) {
+      builder += Interval(IntervalEndpoint(RowSeq(), -1), v.head.left)
     }
     for (i <- 0 until v.length - 1)
       builder += Interval(v(i).right, v(i + 1).left)
-    if (v.last.right != IntervalEndpoint(Row(), 1)) {
-      builder += Interval(v.last.right, IntervalEndpoint(Row(), 1))
+    if (v.last.right != IntervalEndpoint(RowSeq(), 1)) {
+      builder += Interval(v.last.right, IntervalEndpoint(RowSeq(), 1))
     }
 
     KeySet(builder.result())
@@ -746,10 +746,10 @@ class ExtractIntervalFilters(ctx: ExecuteContext, keyType: TStruct) extends Logg
 
   private def getIntervalFromContig(c: String, rg: ReferenceGenome): Option[Interval] = {
     if (rg.contigsSet.contains(c))
-      Some(Interval(Row(Locus(c, 1)), Row(Locus(c, rg.contigLength(c))), true, false))
+      Some(Interval(RowSeq(Locus(c, 1)), RowSeq(Locus(c, rg.contigLength(c))), true, false))
     else if (c == null) {
       logger.warn(s"Filtered with null contig")
-      Some(Interval(Row(null), Row(), true, true))
+      Some(Interval(RowSeq(null), RowSeq(), true, true))
     } else {
       logger.warn(
         s"Filtered with contig '$c', but '$c' is not a valid contig in reference genome ${rg.name}"
@@ -759,14 +759,14 @@ class ExtractIntervalFilters(ctx: ExecuteContext, keyType: TStruct) extends Logg
   }
 
   def endpoint(value: Any, sign: Int, wrapped: Boolean = true): IntervalEndpoint =
-    IntervalEndpoint(if (wrapped) Row(value) else value, sign)
+    IntervalEndpoint(if (wrapped) RowSeq(value) else value, sign)
 
   private def literalSizeOkay(lit: Any): Boolean = lit.asInstanceOf[Iterable[_]].size <=
     MAX_LITERAL_SIZE
 
-  private def posInf: IntervalEndpoint = IntervalEndpoint(Row(), 1)
+  private def posInf: IntervalEndpoint = IntervalEndpoint(RowSeq(), 1)
 
-  private def negInf: IntervalEndpoint = IntervalEndpoint(Row(), -1)
+  private def negInf: IntervalEndpoint = IntervalEndpoint(RowSeq(), -1)
 
   def analyze(
     x: IR,
@@ -850,8 +850,8 @@ class ExtractIntervalFilters(ctx: ExecuteContext, keyType: TStruct) extends Logg
         case null => BoolValue.allNA(keySet)
         case i: Interval => queryVal match {
             case KeyField(0) =>
-              val l = IntervalEndpoint(Row(i.left.point), i.left.sign)
-              val r = IntervalEndpoint(Row(i.right.point), i.right.sign)
+              val l = IntervalEndpoint(RowSeq(i.left.point), i.left.sign)
+              val r = IntervalEndpoint(RowSeq(i.right.point), i.right.sign)
               BoolValue(
                 KeySet(Interval(l, r)),
                 KeySet(Interval(negInf, l), Interval(r, endpoint(null, -1))),

--- a/hail/hail/src/is/hail/expr/ir/GenericLines.scala
+++ b/hail/hail/src/is/hail/expr/ir/GenericLines.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir
 
+import is.hail.annotations.RowSeq
 import is.hail.backend.spark.SparkBackend
 import is.hail.collection.implicits.toRichIterator
 import is.hail.io.compress.BGzipInputStream
@@ -308,14 +309,14 @@ object GenericLines extends Logging {
             var end = partScan(i + 1)
             if (codec != null)
               end = makeVirtualOffset(end, 0)
-            Row(i, fileNum, fileListEntry.getPath, start, end, true)
+            RowSeq(i, fileNum, fileListEntry.getPath, start, end, true)
           }
       } else {
         if (!allowSerialRead && !filePerPartition)
           fatal(s"Cowardly refusing to read file serially: ${fileListEntry.getPath}.")
 
         Iterator.single {
-          Row(0, fileNum, fileListEntry.getPath, 0L, size, false)
+          RowSeq(0, fileNum, fileListEntry.getPath, 0L, size, false)
         }
       }
     }
@@ -343,7 +344,7 @@ object GenericLines extends Logging {
       val start = interval.start.asInstanceOf[Row].getAs[Locus](0)
       val end = interval.end.asInstanceOf[Row].getAs[Locus](0)
       val contig = reverseContigMapping.getOrElse(start.contig, start.contig)
-      Row(i, path, contig, start.position, end.position)
+      RowSeq(i, path, contig, start.position, end.position)
     }
     val body: (FS, Any) => CloseableIterator[GenericLine] = { (fs: FS, context: Any) =>
       val contextRow = context.asInstanceOf[Row]

--- a/hail/hail/src/is/hail/expr/ir/Interpret.scala
+++ b/hail/hail/src/is/hail/expr/ir/Interpret.scala
@@ -380,7 +380,7 @@ object Interpret extends Logging {
             case s: Set[_] =>
               ArraySeq.sorted(s.asInstanceOf[Set[Any]])(implicitly, ordering)
             case d: Map[_, _] =>
-              ArraySeq.sorted[Any](d.iterator.map { case (k, v) => Row(k, v) })(
+              ArraySeq.sorted[Any](d.iterator.map { case (k, v) => RowSeq(k, v) })(
                 implicitly,
                 ordering,
               )
@@ -793,14 +793,14 @@ object Interpret extends Logging {
         throw LoopCtrl(name, exprs.map(e => interpret(e, env, args)))
 
       case MakeStruct(fields) =>
-        Row.fromSeq(fields.map { case (_, fieldIR) => interpret(fieldIR, env, args) })
+        RowSeq.fromSeq(fields.map { case (_, fieldIR) => interpret(fieldIR, env, args) })
       case SelectFields(old, fields) =>
         val oldt = tcoerce[TStruct](old.typ)
         val oldRow = interpret(old, env, args).asInstanceOf[Row]
         if (oldRow == null)
           null
         else
-          Row.fromSeq(fields.map(id => oldRow.get(oldt.fieldIdx(id))))
+          RowSeq.fromSeq(fields.map(id => oldRow.get(oldt.fieldIdx(id))))
       case InsertFields(old, fields, fieldOrder) =>
         var struct = interpret(old, env, args)
         if (struct != null)
@@ -809,7 +809,7 @@ object Interpret extends Logging {
               val m = fields.toMap
               val oldIndices =
                 old.typ.asInstanceOf[TStruct].fields.map(f => f.name -> f.index).toMap
-              Row.fromSeq(fds.map(name =>
+              RowSeq.fromSeq(fds.map(name =>
                 m.get(name).map(interpret(_, env, args)).getOrElse(
                   struct.asInstanceOf[Row].get(oldIndices(name))
                 )
@@ -836,7 +836,7 @@ object Interpret extends Logging {
           oValue.asInstanceOf[Row].get(fieldIndex)
         }
       case MakeTuple(types) =>
-        Row.fromSeq(types.map { case (_, x) => interpret(x, env, args) })
+        RowSeq.fromSeq(types.map { case (_, x) => interpret(x, env, args) })
       case GetTupleElement(o, idx) =>
         val oValue = interpret(o, env, args)
         if (oValue == null)
@@ -932,7 +932,7 @@ object Interpret extends Logging {
         ExecuteRelational(ctx, child).asTableValue(ctx).globals.safeJavaValue
       case TableCollect(child) =>
         val tv = ExecuteRelational(ctx, child).asTableValue(ctx)
-        Row(tv.rvd.collect(ctx), tv.globals.safeJavaValue)
+        RowSeq(tv.rvd.collect(ctx), tv.globals.safeJavaValue)
       case TableMultiWrite(children, writer) =>
         val tvs = children.map(child => ExecuteRelational(ctx, child).asTableValue(ctx))
         writer(ctx, tvs)

--- a/hail/hail/src/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/MatrixIR.scala
@@ -75,7 +75,7 @@ object MatrixLiteral {
           tt,
           BroadcastRow(
             ctx,
-            Row.fromSeq(globals.toSeq :+ colValues),
+            RowSeq.fromSeq(globals.toSeq :+ colValues),
             typ.canonicalTableType.globalType,
           ),
           rvd,

--- a/hail/hail/src/is/hail/expr/ir/MatrixValue.scala
+++ b/hail/hail/src/is/hail/expr/ir/MatrixValue.scala
@@ -143,7 +143,7 @@ case class MatrixValue(
       path + "/globals",
       PCanonicalStruct.empty(required = true),
       bufferSpec,
-      ArraySeq[Annotation](Row()),
+      ArraySeq[Annotation](RowSeq()),
     ): Unit
 
     val globalsSpec = TableSpecParameters(

--- a/hail/hail/src/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/MatrixWriter.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir
 
-import is.hail.annotations.Region
+import is.hail.annotations.{Region, RowSeq}
 import is.hail.asm4s._
 import is.hail.asm4s.implicits.{valueToRichCodeOutputBuffer, valueToRichCodeRegion}
 import is.hail.backend.ExecuteContext
@@ -38,7 +38,6 @@ import java.io.{InputStream, OutputStream}
 import java.nio.file.{FileSystems, Path}
 import java.util.UUID
 
-import org.apache.spark.sql.Row
 import org.json4s.{DefaultFormats, Formats, ShortTypeHints}
 import org.json4s.jackson.JsonMethods
 
@@ -2085,7 +2084,7 @@ case class MatrixPLINKWriter(
       val files = Literal(
         TArray(TTuple(TString, TString)),
         ArraySeq.tabulate(ts.numPartitions)(i =>
-          Row(s"$tmpBedDir/${partFile(d, i)}-", s"$tmpBimDir/${partFile(d, i)}-")
+          RowSeq(s"$tmpBedDir/${partFile(d, i)}-", s"$tmpBimDir/${partFile(d, i)}-")
         ),
       )
 
@@ -2351,7 +2350,7 @@ case class MatrixBlockMatrixWriter(
      * accordingly. */
     val inputRowIntervals =
       inputPartStarts.zip(inputPartStops).map { case (intervalStart, intervalEnd) =>
-        Interval(Row(intervalStart.toInt), Row(intervalEnd.toInt), true, false)
+        Interval(RowSeq(intervalStart.toInt), RowSeq(intervalEnd.toInt), true, false)
       }
 
     val rowIdxPartitioner =
@@ -2365,7 +2364,7 @@ case class MatrixBlockMatrixWriter(
       desiredRowStarts
         .view
         .zip(desiredRowStops)
-        .map { case (start, end) => Interval(Row(start), Row(end), true, false) }
+        .map { case (start, end) => Interval(RowSeq(start), RowSeq(end), true, false) }
         .to(ArraySeq)
 
     val blockSizeGroupsPartitioner =

--- a/hail/hail/src/is/hail/expr/ir/TableIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableIR.scala
@@ -330,7 +330,7 @@ object LoweredTableReader extends Logging {
       )
 
       def selectPK(r: Row): Row =
-        Row.fromSeq(ArraySeq.tabulate(partitionKey)(r.get))
+        RowSeq.fromSeq(ArraySeq.tabulate(partitionKey)(r.get))
 
       (
         ctx: ExecuteContext,
@@ -1952,7 +1952,7 @@ case class TableFromBlockMatrixNativeReader(
     )
 
     val partitionBounds = partitionRanges.map { r =>
-      Interval(Row(r.start), Row(r.end), true, false)
+      Interval(RowSeq(r.start), RowSeq(r.end), true, false)
     }
     val partitioner = new RVDPartitioner(ctx.stateManager, fullType.keyType, partitionBounds)
 

--- a/hail/hail/src/is/hail/expr/ir/TableValue.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableValue.scala
@@ -189,7 +189,7 @@ object TableValue extends Logging {
       }.toCRDDPtr,
     )
 
-    val newGlobals = BroadcastRow(ctx, Row(childValues.map(_.globals.javaValue)), newGlobalType)
+    val newGlobals = BroadcastRow(ctx, RowSeq(childValues.map(_.globals.javaValue)), newGlobalType)
 
     TableValue(ctx, typ, newGlobals, rvd)
   }
@@ -284,7 +284,7 @@ object TableValue extends Logging {
           ArraySeq.tabulate(nPartitions) { i =>
             val start = partStarts(i)
             val end = partStarts(i + 1)
-            Interval(Row(start), Row(end), includesStart = true, includesEnd = false)
+            Interval(RowSeq(start), RowSeq(end), includesStart = true, includesEnd = false)
           },
         ),
         ContextRDD.parallelize(Range(0, nPartitions), nPartitions)

--- a/hail/hail/src/is/hail/expr/ir/functions/ApproxCDFFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/ApproxCDFFunctions.scala
@@ -1,6 +1,6 @@
 package is.hail.expr.ir.functions
 
-import is.hail.annotations.Region
+import is.hail.annotations.{Region, RowSeq}
 import is.hail.asm4s.{valueToCodeObject, Code, Value}
 import is.hail.collection.implicits.toRichIterable
 import is.hail.expr.ir.EmitCodeBuilder
@@ -39,7 +39,7 @@ object ApproxCDFFunctions extends RegistryFunctions {
   }
 
   def stateManagerToRow(state: ApproxCDFStateManager): Row =
-    Row(state.levels.toFastSeq, state.items.toFastSeq, state.compactionCounts.toFastSeq)
+    RowSeq(state.levels.toFastSeq, state.items.toFastSeq, state.compactionCounts.toFastSeq)
 
   def fromStateManager(cb: EmitCodeBuilder, r: Value[Region], state: Value[ApproxCDFStateManager])
     : SBaseStructValue = {

--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerBlockMatrixIR.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir.lowering
 
+import is.hail.annotations.RowSeq
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
 import is.hail.collection.compat.immutable.ArraySeq
@@ -187,7 +188,7 @@ object BMSContexts {
         case sparsity: MatrixSparsity.Sparse =>
           ToStream(Literal(
             TArray(TTuple(TInt32, TInt32)),
-            sparsity.definedCoords.map(Row.fromTuple),
+            sparsity.definedCoords.map(RowSeq.fromTuple),
           ))
       }
 
@@ -454,7 +455,7 @@ case class SparseContexts(
     }
     val blockSparsitiesTuples = blockSparsities.map { sparsity =>
       val csc = sparsity.toCSC
-      Row(sparsity.nRows, sparsity.nCols, csc.rowPos, csc.rowIdx)
+      RowSeq(sparsity.nRows, sparsity.nCols, csc.rowPos, csc.rowIdx)
     }
     val coordToPos = sparsity.definedCoords.zipWithIndex.toMap
     val blockNewToOld = newSparsity.definedCoords.zip(blockSparsities).map {
@@ -1321,7 +1322,7 @@ object LowerBlockMatrixIR {
               val nSelected = math.min(maxFromBlock, outputBlockElems - outputProduced)
               assert(nSelected > 0, s"block d=$d should contribute at least one element")
               outputProduced += nSelected
-              Row(localStart, math.min(childBlockElems, localStart + nSelected * step), step)
+              RowSeq(localStart, math.min(childBlockElems, localStart + nSelected * step), step)
             }
           }
 

--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerDistributedSort.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerDistributedSort.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir.lowering
 
+import is.hail.annotations.RowSeq
 import is.hail.backend.{ExecuteContext, HailStateManager}
 import is.hail.collection.FastSeq
 import is.hail.collection.compat.immutable.ArraySeq
@@ -151,7 +152,7 @@ object LowerDistributedSort extends Logging {
       val perPartStatsCDAContextData =
         partitionDataPerSegment.flatten.zip(numSamplesPerPartition).map {
           case (partData, numSamples) =>
-            Row(
+            RowSeq(
               partData.indices.last,
               partData.files,
               coerceToInt(partData.currentPartSize),
@@ -364,7 +365,7 @@ object LowerDistributedSort extends Logging {
                 .foldLeft((0, ArraySeq.newBuilder[Row])) {
                   case (s, ((_, pivotIdx), indexIntoPivotsArray)) =>
                     partitionDataPerSegment(pivotIdx).foldLeft(s) { case ((partIdx, b), x) =>
-                      val r = Row(x.indices.last, x.files, partIdx, indexIntoPivotsArray)
+                      val r = RowSeq(x.indices.last, x.files, partIdx, indexIntoPivotsArray)
                       (partIdx + 1, b += r)
                     }
                 }
@@ -785,7 +786,7 @@ case class DistributionSortReader(
     val (partitionerKey, intervals) = if (keyed) {
       (key, orderedOutputPartitions.map(segment => segment.interval))
     } else {
-      (TStruct(), orderedOutputPartitions.map(_ => Interval(Row(), Row(), true, false)))
+      (TStruct(), orderedOutputPartitions.map(_ => Interval(RowSeq(), RowSeq(), true, false)))
     }
 
     new RVDPartitioner(sm, partitionerKey, intervals)
@@ -818,7 +819,7 @@ case class DistributionSortReader(
         segment.files.map { partPath =>
           val partIdx = filesCount
           filesCount += 1
-          Row(partIdx, partPath)
+          RowSeq(partIdx, partPath)
         }
       }
 

--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -1,5 +1,6 @@
 package is.hail.expr.ir.lowering
 
+import is.hail.annotations.RowSeq
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
 import is.hail.collection.compat.immutable.ArraySeq
@@ -412,7 +413,7 @@ class TableStage(
 
       val boundType = RVDPartitioner.intervalIRRepresentation(newPartitioner.kType)
       val partitionMapping: IndexedSeq[Row] = newPartitioner.rangeBounds.map { i =>
-        Row(
+        RowSeq(
           RVDPartitioner.intervalToIRRepresentation(i, newPartitioner.kType.size),
           partitioner.queryInterval(i),
         )
@@ -644,7 +645,7 @@ class TableStage(
       Some(1),
       TStruct.concat(TStruct("__partNum" -> TInt32), right.kType),
       ArraySeq.tabulate(partitioner.numPartitions)(i =>
-        Interval(Row(i), Row(i), includesStart = true, includesEnd = true)
+        Interval(RowSeq(i), RowSeq(i), includesStart = true, includesEnd = true)
       ),
     )
     val repartitioned =
@@ -1040,7 +1041,7 @@ object LowerTableIR extends Logging {
             Array("idx"),
             tir.typ.rowType,
             ranges.map { case (start, end) =>
-              Interval(Row(start), Row(end), includesStart = true, includesEnd = false)
+              Interval(RowSeq(start), RowSeq(end), includesStart = true, includesEnd = false)
             },
           ),
           TableStageDependency.none,
@@ -1172,7 +1173,7 @@ object LowerTableIR extends Logging {
                 ToStream(Literal(TArray(TInt32), includedIndices)),
                 ToStream(Literal(
                   TArray(TTuple(TInt32, TInt32)),
-                  startAndEndInterval.map(Row.fromTuple),
+                  startAndEndInterval.map(RowSeq.fromTuple),
                 )),
                 ArrayZipBehavior.AssumeSameLength,
               ) { (idx, bound) =>

--- a/hail/hail/src/is/hail/io/bgen/LoadBgen.scala
+++ b/hail/hail/src/is/hail/io/bgen/LoadBgen.scala
@@ -1,6 +1,6 @@
 package is.hail.io.bgen
 
-import is.hail.annotations.Region
+import is.hail.annotations.{Region, RowSeq}
 import is.hail.asm4s._
 import is.hail.asm4s.implicits.valueToRichCodeRegion
 import is.hail.backend.ExecuteContext
@@ -567,7 +567,7 @@ class MatrixBGENReader(
               arraysToZip += sampleIds.indices.map(_.toLong)
 
             val fields = arraysToZip.result()
-            Literal(ta, sampleIds.indices.map(i => Row.fromSeq(fields.map(_.apply(i)))))
+            Literal(ta, sampleIds.indices.map(i => RowSeq.fromSeq(fields.map(_.apply(i)))))
           },
         )))
       case None => MakeStruct(FastSeq())
@@ -604,7 +604,7 @@ class MatrixBGENReader(
           rangeBounds ++= strictBgenKey.rangeBounds
 
           strictShortKey.partitionBoundsIRRepresentation.value.asInstanceOf[IndexedSeq[_]]
-            .foreach(interval => contexts += Row(fileIdx, interval))
+            .foreach(interval => contexts += RowSeq(fileIdx, interval))
         }
 
         val partitioner =
@@ -644,7 +644,7 @@ class MatrixBGENReader(
             file.intervals.length == file.partN.length && file.intervals.length == file.partStarts.length
           )
           file.intervals.indices.foreach { idxInFile =>
-            contexts += Row(fileIdx, file.partStarts(idxInFile), file.partN(idxInFile), partIdx)
+            contexts += RowSeq(fileIdx, file.partStarts(idxInFile), file.partN(idxInFile), partIdx)
             partIdx += 1
           }
           fileIdx += 1

--- a/hail/hail/src/is/hail/io/plink/LoadPlink.scala
+++ b/hail/hail/src/is/hail/io/plink/LoadPlink.scala
@@ -1,11 +1,12 @@
 package is.hail.io.plink
 
-import is.hail.annotations.{Region, RegionValueBuilder}
+import is.hail.annotations.{Region, RegionValueBuilder, RowSeq}
 import is.hail.asm4s.HailClassLoader
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
 import is.hail.collection.compat._
 import is.hail.collection.compat.immutable.ArraySeq
+import is.hail.collection.implicits.toRichArray
 import is.hail.expr.JSONAnnotationImpex
 import is.hail.expr.ir._
 import is.hail.expr.ir.defs.Literal
@@ -63,7 +64,7 @@ object LoadPlink extends Logging {
                     FastSeq(allele2, allele1)
                   else
                     FastSeq(allele1, allele2)
-                val locusAlleles = Row(locus, alleles)
+                val locusAlleles = RowSeq(locus, alleles)
                 vs += new PlinkVariant(n, locusAlleles, cmPos.toDouble, rsId)
               }
 
@@ -94,7 +95,7 @@ object LoadPlink extends Logging {
     val ffConfig = FamFileConfig(isQuantPheno, delimiter, missingValue)
     val (data, ptyp) = LoadPlink.parseFam(fs, path, ffConfig)
     JSONAnnotationImpex.exportAnnotation(
-      Row(ptyp.virtualType.toString, data),
+      RowSeq(ptyp.virtualType.toString, data),
       TStruct("type" -> TString, "data" -> TArray(ptyp.virtualType)),
     )
   }
@@ -172,7 +173,7 @@ object LoadPlink extends Logging {
               case _ => null
             }
         idBuilder += kid
-        structBuilder += Row(kid, fam1, dad1, mom1, isFemale1, pheno1)
+        structBuilder += RowSeq(kid, fam1, dad1, mom1, isFemale1, pheno1)
       }
     }
 
@@ -289,7 +290,7 @@ object MatrixPLINKReader extends Logging {
         )
           end += 1
 
-        cb += Row(start, end, variants.slice(start, end))
+        cb += RowSeq(start, end, variants.slice(start, end))
 
         ib += Interval(
           variants(start).locusAlleles,
@@ -379,9 +380,14 @@ class MatrixPLINKReader(
 
   override def partitionCounts: Option[IndexedSeq[Long]] = None
 
-  val globals = Row(sampleInfo.zipWithIndex.map { case (s, idx) =>
-    Row((0 until s.length).map(s.apply) :+ idx.toLong: _*)
-  })
+  val globals: Row =
+    RowSeq(sampleInfo.zipWithIndex.map { case (s, idx) =>
+      val N = s.length
+      val array = new Array[Any](N + 1)
+      (0 until N).foreach(i => array(i) = s(i))
+      array(N) = idx.toLong
+      RowSeq.fromSeq(array.unsafeToArraySeq)
+    })
 
   override def concreteRowRequiredness(ctx: ExecuteContext, requestedType: TableType)
     : VirtualTypeWithReq =
@@ -412,7 +418,7 @@ class MatrixPLINKReader(
     val fullContexts = contexts.zipWithIndex.map { case (Row(start, end, vars), idx) =>
       val path = ctx.createTmpPath(s"load_plink_variants_$idx")
       ctx.fs.writePDOS(path)(os => using(new ObjectOutputStream(os))(oos => oos.writeObject(vars)))
-      Row(params.bed, path, start, end, idx)
+      RowSeq(params.bed, path, start, end, idx)
     }
 
     val fullRowPType = PCanonicalStruct(

--- a/hail/hail/src/is/hail/io/vcf/LoadVCF.scala
+++ b/hail/hail/src/is/hail/io/vcf/LoadVCF.scala
@@ -183,11 +183,11 @@ case class VCFHeaderInfo(
     rvb.addAnnotation(rvb.currentType().virtualType, sampleIds.toFastSeq)
     rvb.addAnnotation(
       rvb.currentType().virtualType,
-      infoFields.map { case (x1, x2) => Row(x1, x2.parsableString()) }.toFastSeq,
+      infoFields.map { case (x1, x2) => RowSeq(x1, x2.parsableString()) }.toFastSeq,
     )
     rvb.addAnnotation(
       rvb.currentType().virtualType,
-      formatFields.map { case (x1, x2) => Row(x1, x2.parsableString()) }.toFastSeq,
+      formatFields.map { case (x1, x2) => RowSeq(x1, x2.parsableString()) }.toFastSeq,
     )
     rvb.addAnnotation(rvb.currentType().virtualType, if (dropAttrs) Map.empty else filtersAttrs)
     rvb.addAnnotation(rvb.currentType().virtualType, if (dropAttrs) Map.empty else infoAttrs)
@@ -2041,7 +2041,9 @@ class MatrixVCFReader(
         )
     }
 
-    val globals = Row(sampleIDs.zipWithIndex.map { case (s, i) => Row(s, i.toLong) }.toFastSeq)
+    val globals = RowSeq(sampleIDs.zipWithIndex.map { case (s, i) =>
+      RowSeq(s, i.toLong)
+    }.toFastSeq)
 
     val fullRowPType: PType = fullRVDType.rowType
 
@@ -2129,7 +2131,7 @@ class MatrixVCFReader(
   }
 
   override def lowerGlobals(ctx: ExecuteContext, requestedGlobalsType: TStruct): IR = {
-    val globals = Row(sampleIDs.zipWithIndex.map(t => Row(t._1, t._2.toLong)).toFastSeq)
+    val globals = RowSeq(sampleIDs.zipWithIndex.map(t => RowSeq(t._1, t._2.toLong)).toFastSeq)
     Literal.coerce(
       requestedGlobalsType,
       fullType.globalType.valueSubsetter(requestedGlobalsType)

--- a/hail/hail/src/is/hail/linalg/RowMatrix.scala
+++ b/hail/hail/src/is/hail/linalg/RowMatrix.scala
@@ -1,5 +1,6 @@
 package is.hail.linalg
 
+import is.hail.annotations.RowSeq
 import is.hail.backend.{BroadcastValue, ExecuteContext, HailStateManager}
 import is.hail.backend.spark.SparkBackend
 import is.hail.collection.compat.immutable.ArraySeq
@@ -13,7 +14,6 @@ import is.hail.utils._
 import breeze.linalg.DenseMatrix
 import org.apache.spark.{Partition, Partitioner, TaskContext}
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.Row
 
 object RowMatrix {
   def apply(rows: RDD[(Long, Array[Double])], nCols: Int): RowMatrix =
@@ -97,7 +97,7 @@ class RowMatrix(
       ArraySeq.tabulate(partStarts.length - 1) { i =>
         val start = partStarts(i)
         val end = partStarts(i + 1)
-        Interval(Row(start), Row(end), includesStart = true, includesEnd = false)
+        Interval(RowSeq(start), RowSeq(end), includesStart = true, includesEnd = false)
       },
     )
   }

--- a/hail/hail/src/is/hail/methods/IBD.scala
+++ b/hail/hail/src/is/hail/methods/IBD.scala
@@ -82,7 +82,7 @@ case class ExtendedIBDInfo(ibd: IBDInfo, ibs0: Long, ibs1: Long, ibs2: Long) {
 
   def hasNaNs: Boolean = ibd.hasNaNs
 
-  def makeRow(i: Any, j: Any): Row = Row(i, j, ibd.toAnnotation, ibs0, ibs1, ibs2)
+  def makeRow(i: Any, j: Any): Row = RowSeq(i, j, ibd.toAnnotation, ibs0, ibs1, ibs2)
 
   def toRegionValue(rvb: RegionValueBuilder): Unit = {
     rvb.startStruct()

--- a/hail/hail/src/is/hail/methods/PCA.scala
+++ b/hail/hail/src/is/hail/methods/PCA.scala
@@ -55,7 +55,7 @@ case class PCA(entryField: String, k: Int, computeLoadings: Boolean)
       val rowKeyTypes = mv.typ.rowKeyStruct.types
 
       mv.rvd.toUnsafeRows.map[Any] { r =>
-        Row.fromSeq(rowKeyIdx.map(i => Annotation.copy(rowKeyTypes(i), r(i))))
+        RowSeq.fromSeq(rowKeyIdx.map(i => Annotation.copy(rowKeyTypes(i), r(i))))
       }
         .collect()
     }

--- a/hail/hail/src/is/hail/methods/PCRelate.scala
+++ b/hail/hail/src/is/hail/methods/PCRelate.scala
@@ -1,5 +1,6 @@
 package is.hail.methods
 
+import is.hail.annotations.RowSeq
 import is.hail.backend.ExecuteContext
 import is.hail.collection.compat.immutable.ArraySeq
 import is.hail.expr.ir.TableValue
@@ -102,7 +103,7 @@ object PCRelate {
               val k0 = if (lmK0 == null) null else lmK0(ii, jj)
               val k1 = if (lmK1 == null) null else lmK1(ii, jj)
               val k2 = if (lmK2 == null) null else lmK2(ii, jj)
-              pairs += Row(iOffset + ii, jOffset + jj, kin, k0, k1, k2)
+              pairs += RowSeq(iOffset + ii, jOffset + jj, kin, k0, k1, k2)
             }
             ii += 1
           }

--- a/hail/hail/src/is/hail/methods/Skat.scala
+++ b/hail/hail/src/is/hail/methods/Skat.scala
@@ -1,6 +1,6 @@
 package is.hail.methods
 
-import is.hail.annotations.{Annotation, Region, UnsafeRow}
+import is.hail.annotations.{Annotation, Region, RowSeq, UnsafeRow}
 import is.hail.backend.ExecuteContext
 import is.hail.collection.{FastSeq, IntArrayBuilder}
 import is.hail.expr.ir.{MatrixValue, TableValue}
@@ -243,9 +243,9 @@ case class Skat(
             val (pval, fault) = Skat.computePval(q / sigmaSq, gramian, accuracy, iterations)
 
             // returning qstat = q / (2 * sigmaSq) to agree with skat R table convention
-            Row(key, size, q / (2 * sigmaSq), pval, fault)
+            RowSeq(key, size, q / (2 * sigmaSq), pval, fault)
           } else {
-            Row(key, size, null, null, null)
+            RowSeq(key, size, null, null, null)
           }
         }
     }
@@ -305,9 +305,9 @@ case class Skat(
           val (pval, fault) = Skat.computePval(q, gramian, accuracy, iterations)
 
           // returning qstat = q / 2 to agree with skat R table convention
-          Row(key, size, q / 2, pval, fault)
+          RowSeq(key, size, q / 2, pval, fault)
         } else {
-          Row(key, size, null, null, null)
+          RowSeq(key, size, null, null, null)
         }
       }.persist()
     }

--- a/hail/hail/src/is/hail/methods/VEP.scala
+++ b/hail/hail/src/is/hail/methods/VEP.scala
@@ -230,12 +230,12 @@ class VEP(private val params: VEPParameters, conf: VEPConfiguration)
 
     val globalValue =
       if (params.csq)
-        Row(getCSQHeaderDefinition(cmd, conf.env).getOrElse {
+        RowSeq(getCSQHeaderDefinition(cmd, conf.env).getOrElse {
           logger.warn(f"Could not get VEP CSQ header, cmd = ${cmd.mkString(" ")}")
           ""
         })
       else
-        Row()
+        RowSeq()
 
     TableValue(ctx, outType, BroadcastRow(ctx, globalValue, outType.globalType), vepRVD)
   }

--- a/hail/hail/src/is/hail/rvd/AbstractRVDSpec.scala
+++ b/hail/hail/src/is/hail/rvd/AbstractRVDSpec.scala
@@ -132,7 +132,7 @@ object AbstractRVDSpec {
         val contextsValue: IndexedSeq[Any] =
           (leftParts lazyZip rightParts lazyZip leftParts.indices)
             .map { (path1, path2, partIdx) =>
-              Row(Row(partIdx.toLong, path1), Row(partIdx.toLong, path2))
+              RowSeq(RowSeq(partIdx.toLong, path1), RowSeq(partIdx.toLong, path2))
             }
 
         val ctxIR = ToStream(Literal(TArray(reader.contextType), contextsValue))
@@ -187,7 +187,7 @@ object AbstractRVDSpec {
         val kSize = specLeft.key.size
         val contextsValues: IndexedSeq[Row] =
           partsAndIntervals.zipWithIndex.map { case ((partPath, interval), partIdx) =>
-            Row(
+            RowSeq(
               partIdx.toLong,
               s"$absPathLeft/parts/$partPath",
               s"$absPathRight/parts/$partPath",
@@ -257,7 +257,7 @@ abstract class AbstractRVDSpec {
       val contexts = ToStream(Literal(
         TArray(ctxType),
         absolutePartPaths(path).zipWithIndex.map {
-          case (x, i) => Row(i.toLong, x)
+          case (x, i) => RowSeq(i.toLong, x)
         },
       ))
 
@@ -510,7 +510,7 @@ case class IndexedRVDSpec2(
         val intersectionInterval =
           extendedNP.rangeBounds(newPartIdx)
             .intersect(extendedNP.kord, oldInterval).get
-        Row(
+        RowSeq(
           oldPartIdx.toLong,
           s"$path/parts/$partFile",
           s"$path/${indexSpec.relPath}/$partFile.idx",

--- a/hail/hail/src/is/hail/rvd/RVD.scala
+++ b/hail/hail/src/is/hail/rvd/RVD.scala
@@ -675,7 +675,7 @@ class RVD(
 
     val pred: (RVDContext, Long) => Boolean = (ctx: RVDContext, ptr: Long) => {
       val ur = new UnsafeRow(localRowPType, ctx.r, ptr)
-      val key = Row.fromSeq(
+      val key = RowSeq.fromSeq(
         kRowFieldIdx.map(i => ur.get(i))
       )
       intervalsBc.value.contains(key)
@@ -1010,8 +1010,8 @@ class RVD(
         val interval = r.getAs[Interval](rightTyp.kFieldIdx(0))
         if (interval != null) {
           val wrappedInterval = interval.copy(
-            start = Row(interval.start),
-            end = Row(interval.end),
+            start = RowSeq(interval.start),
+            end = RowSeq(interval.end),
           )
           val bytes = encoder.regionValueToBytes(ctx.r, ptr)
           partBc.value.queryInterval(wrappedInterval).map(i => ((i, interval), bytes))

--- a/hail/hail/src/is/hail/rvd/RVDPartitioner.scala
+++ b/hail/hail/src/is/hail/rvd/RVDPartitioner.scala
@@ -316,7 +316,7 @@ object RVDPartitioner extends Logging {
     new RVDPartitioner(sm, typ, ArraySeq.empty)
 
   def unkeyed(sm: HailStateManager, numPartitions: Int): RVDPartitioner = {
-    val unkeyedInterval = Interval(Row(), Row(), true, true)
+    val unkeyedInterval = Interval(RowSeq(), RowSeq(), true, true)
     new RVDPartitioner(
       sm,
       TStruct.empty,
@@ -437,7 +437,10 @@ object RVDPartitioner extends Logging {
     def processEndpoint(p: IntervalEndpoint): IntervalEndpoint = {
       val r = p.point.asInstanceOf[Row]
       val newr =
-        Row(Row.fromSeq((0 until len).map(i => if (i >= r.length) null else r.get(i))), r.length)
+        RowSeq(
+          RowSeq.fromSeq((0 until len).map(i => if (i >= r.length) null else r.get(i))),
+          r.length,
+        )
       p.copy(point = newr)
     }
 

--- a/hail/hail/src/is/hail/sparkextras/implicits/RichContextRDDRegionValue.scala
+++ b/hail/hail/src/is/hail/sparkextras/implicits/RichContextRDDRegionValue.scala
@@ -46,7 +46,7 @@ object RichContextRDDRegionValue {
       if (iw != null) {
         val off = en.indexOffset()
         val key = SafeRow.selectFields(rowType, ctx.r, ptr)(indexKeyFieldIndices)
-        iw.appendRow(key, off, Row())
+        iw.appendRow(key, off, RowSeq())
       }
       en.writeByte(1)
       en.writeRegionValue(ctx.region, ptr)
@@ -128,7 +128,7 @@ object RichContextRDDRegionValue {
                 val rows_off = rowsEN.indexOffset()
                 val ents_off = entriesEN.indexOffset()
                 val key = SafeRow.selectFields(fullRowType, ctx.r, ptr)(t.kFieldIdx)
-                iw.appendRow(key, rows_off, Row(ents_off))
+                iw.appendRow(key, rows_off, RowSeq(ents_off))
 
                 rowsEN.writeByte(1)
                 rowsEN.writeRegionValue(ctx.r, ptr)

--- a/hail/hail/src/is/hail/sparkextras/implicits/RichRow.scala
+++ b/hail/hail/src/is/hail/sparkextras/implicits/RichRow.scala
@@ -1,5 +1,6 @@
 package is.hail.sparkextras.implicits
 
+import is.hail.annotations.RowSeq
 import is.hail.collection.compat.immutable.ArraySeq
 
 import org.apache.spark.sql.Row
@@ -9,10 +10,10 @@ class RichRow(r: Row) {
   def update(i: Int, a: Any): Row = {
     val arr = Array.tabulate(r.size)(r.get)
     arr(i) = a
-    Row.fromSeq(ArraySeq.unsafeWrapArray(arr))
+    RowSeq.fromSeq(ArraySeq.unsafeWrapArray(arr))
   }
 
-  def select(indices: IndexedSeq[Int]): Row = Row.fromSeq(indices.map(r.get))
+  def select(indices: IndexedSeq[Int]): Row = RowSeq.fromSeq(indices.map(r.get))
 
   def deleteField(i: Int): Row = {
     require(i >= 0 && i < r.length)
@@ -21,7 +22,7 @@ class RichRow(r: Row) {
 
   def truncate(newSize: Int): Row = {
     require(newSize <= r.size)
-    Row.fromSeq(ArraySeq.tabulate(newSize)(i => r.get(i)))
+    RowSeq.fromSeq(ArraySeq.tabulate(newSize)(i => r.get(i)))
   }
 
   def iterator: Iterator[Any] =

--- a/hail/hail/src/is/hail/types/physical/PCanonicalDict.scala
+++ b/hail/hail/src/is/hail/types/physical/PCanonicalDict.scala
@@ -1,12 +1,10 @@
 package is.hail.types.physical
 
-import is.hail.annotations.{Annotation, Region}
+import is.hail.annotations.{Annotation, Region, RowSeq}
 import is.hail.backend.HailStateManager
 import is.hail.types.physical.stypes.concrete.{SIndexablePointer, SIndexablePointerValue}
 import is.hail.types.physical.stypes.interfaces.SIndexableValue
 import is.hail.types.virtual.{TDict, Type}
-
-import org.apache.spark.sql.Row
 
 object PCanonicalDict {
   def coerceArrayCode(contents: SIndexableValue): SIndexableValue =
@@ -48,7 +46,7 @@ final case class PCanonicalDict(keyType: PType, valueType: PType, required: Bool
   override def unstagedStoreJavaObject(sm: HailStateManager, annotation: Annotation, region: Region)
     : Long = {
     val annotMap = annotation.asInstanceOf[Map[Annotation, Annotation]]
-    val sortedArray = annotMap.map { case (k, v) => Row(k, v) }
+    val sortedArray = annotMap.map { case (k, v) => RowSeq(k, v) }
       .toArray
       .sorted(elementType.virtualType.ordering(sm).toOrdering)
       .toIndexedSeq

--- a/hail/hail/src/is/hail/types/physical/PCanonicalInterval.scala
+++ b/hail/hail/src/is/hail/types/physical/PCanonicalInterval.scala
@@ -14,8 +14,6 @@ import is.hail.types.physical.stypes.primitives.SBooleanValue
 import is.hail.types.virtual.{TInterval, Type}
 import is.hail.utils.Interval
 
-import org.apache.spark.sql.Row
-
 final case class PCanonicalInterval(pointType: PType, override val required: Boolean = false)
     extends PInterval {
 
@@ -211,7 +209,7 @@ final case class PCanonicalInterval(pointType: PType, override val required: Boo
     representation.unstagedStoreJavaObjectAtAddress(
       sm,
       addr,
-      Row(jInterval.start, jInterval.end, jInterval.includesStart, jInterval.includesEnd),
+      RowSeq(jInterval.start, jInterval.end, jInterval.includesStart, jInterval.includesEnd),
       region,
     )
   }

--- a/hail/hail/src/is/hail/types/physical/PCanonicalNDArray.scala
+++ b/hail/hail/src/is/hail/types/physical/PCanonicalNDArray.scala
@@ -1,6 +1,6 @@
 package is.hail.types.physical
 
-import is.hail.annotations.{Annotation, NDArray, Region, UnsafeOrdering}
+import is.hail.annotations.{Annotation, NDArray, Region, RowSeq, UnsafeOrdering}
 import is.hail.asm4s.{Code, _}
 import is.hail.asm4s.implicits.valueToRichCodeRegion
 import is.hail.backend.HailStateManager
@@ -13,8 +13,6 @@ import is.hail.types.physical.stypes.SValue
 import is.hail.types.physical.stypes.concrete._
 import is.hail.types.physical.stypes.interfaces._
 import is.hail.types.virtual.{TNDArray, Type}
-
-import org.apache.spark.sql.Row
 
 final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boolean = false)
     extends PNDArray {
@@ -440,11 +438,11 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
       val srcShape = srcPType.asInstanceOf[PNDArray].unstagedLoadShapes(srcAddress)
       val srcStrides = srcPType.asInstanceOf[PNDArray].unstagedLoadStrides(srcAddress)
 
-      shapeType.unstagedStoreJavaObjectAtAddress(sm, destAddress, Row(srcShape: _*), region)
+      shapeType.unstagedStoreJavaObjectAtAddress(sm, destAddress, RowSeq(srcShape: _*), region)
       strideType.unstagedStoreJavaObjectAtAddress(
         sm,
         destAddress + shapeType.byteSize,
-        Row(srcStrides: _*),
+        RowSeq(srcStrides: _*),
         region,
       )
 
@@ -586,12 +584,12 @@ final case class PCanonicalNDArray(elementType: PType, nDims: Int, required: Boo
       elementType.unstagedStoreJavaObjectAtAddress(sm, curElementAddress, element, region)
       curElementAddress += elementType.byteSize
     }
-    val shapeRow = Row(aNDArray.shape: _*)
-    val stridesRow = Row(ArraySeq.unsafeWrapArray(stridesArray): _*)
+    val shapeRow = RowSeq(aNDArray.shape: _*)
+    val stridesRow = RowSeq(ArraySeq.unsafeWrapArray(stridesArray): _*)
     this.representation.unstagedStoreJavaObjectAtAddress(
       sm,
       addr,
-      Row(shapeRow, stridesRow, dataFirstElementAddress),
+      RowSeq(shapeRow, stridesRow, dataFirstElementAddress),
       region,
     )
   }

--- a/hail/hail/src/is/hail/types/virtual/TStruct.scala
+++ b/hail/hail/src/is/hail/types/virtual/TStruct.scala
@@ -146,7 +146,7 @@ final case class TStruct(fields: IndexedSeq[Field]) extends TBaseStruct {
         case _ =>
           val arr = new Array[Any](typ.size)
           arr.update(idx, f(missing, v))
-          Row.fromSeq(ArraySeq.unsafeWrapArray(arr))
+          RowSeq.fromSeq(ArraySeq.unsafeWrapArray(arr))
       }
 
     def addField(typ: TStruct)(f: Inserter)(a: Annotation, v: Any): Annotation = {
@@ -158,7 +158,7 @@ final case class TStruct(fields: IndexedSeq[Field]) extends TBaseStruct {
         case _ =>
       }
       arr(typ.size) = f(missing, v)
-      Row.fromSeq(ArraySeq.unsafeWrapArray(arr))
+      RowSeq.fromSeq(ArraySeq.unsafeWrapArray(arr))
     }
 
     val (newType, inserter) =
@@ -264,8 +264,8 @@ final case class TStruct(fields: IndexedSeq[Field]) extends TBaseStruct {
 
     val newStruct = TStruct(newFieldsBuilder.result(): _*)
     val fieldIdx = fieldIdxBuilder.result()
-    val leftNulls = Row.fromSeq(ArraySeq.fill[Any](size)(null))
-    val rightNulls = Row.fromSeq(ArraySeq.fill[Any](other.size)(null))
+    val leftNulls = RowSeq.fromSeq(ArraySeq.fill[Any](size)(null))
+    val rightNulls = RowSeq.fromSeq(ArraySeq.fill[Any](other.size)(null))
 
     val annotator = (a1: Annotation, a2: Annotation) => {
       if (a1 == null && a2 == null)
@@ -276,7 +276,7 @@ final case class TStruct(fields: IndexedSeq[Field]) extends TBaseStruct {
         val resultValues = fieldIdx.map { idx =>
           if (idx < 0) rightValues(~idx) else leftValues(idx)
         }
-        Row.fromSeq(resultValues)
+        RowSeq.fromSeq(resultValues)
       }
     }
     newStruct -> annotator
@@ -402,7 +402,7 @@ final case class TStruct(fields: IndexedSeq[Field]) extends TBaseStruct {
     val t = TStruct(keep.map(n => n -> field(n).typ): _*)
 
     val keepIdx = keep.map(fieldIdx)
-    val selectF: Row => Row = { r => Row.fromSeq(keepIdx.map(r.get)) }
+    val selectF: Row => Row = { r => RowSeq.fromSeq(keepIdx.map(r.get)) }
     (t, selectF)
   }
 
@@ -424,7 +424,7 @@ final case class TStruct(fields: IndexedSeq[Field]) extends TBaseStruct {
 
     { (a: Any) =>
       val r = a.asInstanceOf[Row]
-      Row.fromSeq(subsetFields.map { case (i, subset) => subset(r.get(i)) })
+      RowSeq.fromSeq(subsetFields.map { case (i, subset) => subset(r.get(i)) })
     }
   }
 

--- a/hail/hail/src/is/hail/types/virtual/TTuple.scala
+++ b/hail/hail/src/is/hail/types/virtual/TTuple.scala
@@ -1,6 +1,6 @@
 package is.hail.types.virtual
 
-import is.hail.annotations.ExtendedOrdering
+import is.hail.annotations.{ExtendedOrdering, RowSeq}
 import is.hail.backend.HailStateManager
 import is.hail.collection.compat.immutable.ArraySeq
 import is.hail.collection.implicits.toRichIterable
@@ -97,7 +97,7 @@ final case class TTuple(_types: IndexedSeq[TupleField]) extends TBaseStruct {
 
     { (a: Any) =>
       val r = a.asInstanceOf[Row]
-      Row.fromSeq(subsetFields.map { case (i, subset) => subset(r.get(i)) })
+      RowSeq.fromSeq(subsetFields.map { case (i, subset) => subset(r.get(i)) })
     }
   }
 }

--- a/hail/hail/src/is/hail/variant/Locus.scala
+++ b/hail/hail/src/is/hail/variant/Locus.scala
@@ -1,6 +1,6 @@
 package is.hail.variant
 
-import is.hail.annotations.Annotation
+import is.hail.annotations.{Annotation, RowSeq}
 import is.hail.expr.Parser
 import is.hail.utils._
 
@@ -73,7 +73,7 @@ object Locus {
 }
 
 case class Locus(contig: String, position: Int) {
-  def toRow: Row = Row(contig, position)
+  def toRow: Row = RowSeq(contig, position)
 
   def toJSON: JValue = JObject(
     ("contig", JString(contig)),

--- a/hail/hail/test/src/is/hail/TestUtils.scala
+++ b/hail/hail/test/src/is/hail/TestUtils.scala
@@ -1,7 +1,7 @@
 package is.hail
 
 import is.hail.ExecStrategy.ExecStrategy
-import is.hail.annotations.{Region, RegionPool, RegionValueBuilder, SafeRow}
+import is.hail.annotations.{Region, RegionPool, RegionValueBuilder, RowSeq, SafeRow}
 import is.hail.asm4s.{
   classInfo, AsmFunction2RegionLongLong, AsmFunction3RegionLongLongLong, LongInfo,
 }
@@ -398,7 +398,7 @@ object TestUtils extends Logging {
   ): Unit =
     assertEvalsTo(
       MakeTuple.ordered(xs.toFastSeq.map(_._1)),
-      Row.fromSeq(xs.map(_._2)),
+      RowSeq.fromSeq(xs.map(_._2)),
     )
 
   def assertThrows[E <: Throwable: ClassTag](x: IR, regex: String)(implicit ctx: ExecuteContext)

--- a/hail/hail/test/src/is/hail/annotations/StagedConstructorSuite.scala
+++ b/hail/hail/test/src/is/hail/annotations/StagedConstructorSuite.scala
@@ -568,8 +568,8 @@ class StagedConstructorSuite {
     val t2 = RequirednessSuite.deepInnerRequired(t1, false)
 
     val value = IndexedSeq(
-      Row(1, IndexedSeq(1, 2, 3), IndexedSeq(0, -1), Set(Row("asdasdasd"), Row(""))),
-      Row(1, IndexedSeq(), IndexedSeq(-1), Set(Row("aa"))),
+      RowSeq(1, IndexedSeq(1, 2, 3), IndexedSeq(0, -1), Set(RowSeq("asdasdasd"), RowSeq(""))),
+      RowSeq(1, IndexedSeq(), IndexedSeq(-1), Set(RowSeq("aa"))),
     )
 
     ctx.r.pool.scopedRegion { r =>
@@ -605,8 +605,8 @@ class StagedConstructorSuite {
     val t2 = RequirednessSuite.deepInnerRequired(t1, false).asInstanceOf[PCanonicalStruct]
 
     val value = IndexedSeq(
-      Row(1, IndexedSeq(1, 2, 3), IndexedSeq(0, -1), Set(Row("asdasdasd"), Row(""))),
-      Row(1, IndexedSeq(), IndexedSeq(-1), Set(Row("aa"))),
+      RowSeq(1, IndexedSeq(1, 2, 3), IndexedSeq(0, -1), Set(RowSeq("asdasdasd"), RowSeq(""))),
+      RowSeq(1, IndexedSeq(), IndexedSeq(-1), Set(RowSeq("aa"))),
     )
 
     val valueT2 = t2.types(0)
@@ -625,7 +625,7 @@ class StagedConstructorSuite {
         ).a
       }
       val cp1 = f1.resultWithIndex()(ctx.theHailClassLoader, ctx.fs, ctx.taskContext, r)()
-      assert(SafeRow.read(t2, cp1) == Row(value))
+      assert(SafeRow.read(t2, cp1) == RowSeq(value))
 
       val f2 = EmitFunctionBuilder[Long](ctx, "stagedCopy2")
       f2.emitWithBuilder { cb =>
@@ -638,7 +638,7 @@ class StagedConstructorSuite {
         ).a
       }
       val cp2 = f2.resultWithIndex()(ctx.theHailClassLoader, ctx.fs, ctx.taskContext, r)()
-      assert(SafeRow.read(t1, cp2) == Row(value))
+      assert(SafeRow.read(t1, cp2) == RowSeq(value))
     }
   }
 }

--- a/hail/hail/test/src/is/hail/annotations/UnsafeSuite.scala
+++ b/hail/hail/test/src/is/hail/annotations/UnsafeSuite.scala
@@ -48,7 +48,7 @@ class UnsafeSuite {
           null
         else {
           val a2 = a.asInstanceOf[Row]
-          Row.fromSeq(requestedType2.fields.map { rf =>
+          RowSeq.fromSeq(requestedType2.fields.map { rf =>
             val f = t2.field(rf.name)
             subset(f.typ, rf.typ, a2.get(f.index))
           })
@@ -253,7 +253,7 @@ class UnsafeSuite {
           region2.clear()
           region2.allocate(1, n.toLong): Unit // preallocate
           val offset4 =
-            ps.unstagedStoreJavaObject(sm, Row.fromSeq(a.asInstanceOf[Row].toSeq), region2)
+            ps.unstagedStoreJavaObject(sm, RowSeq.fromSeq(a.asInstanceOf[Row].toSeq), region2)
           val ur4 = new UnsafeRow(ps, region2, offset4)
           assert(t.valuesSimilar(a, ur4))
           ()
@@ -272,7 +272,7 @@ class UnsafeSuite {
         case t: TStruct =>
           val ps = pt.asInstanceOf[PStruct]
           val offset6 =
-            ps.unstagedStoreJavaObject(sm, Row.fromSeq(a.asInstanceOf[Row].toSeq), region)
+            ps.unstagedStoreJavaObject(sm, RowSeq.fromSeq(a.asInstanceOf[Row].toSeq), region)
           val ur6 = new UnsafeRow(ps, region, offset6)
           assert(t.valuesSimilar(a, ur6)): Unit
         case _ =>

--- a/hail/hail/test/src/is/hail/asm4s/CodeSuite.scala
+++ b/hail/hail/test/src/is/hail/asm4s/CodeSuite.scala
@@ -1,7 +1,7 @@
 package is.hail.asm4s
 
 import is.hail.TestUtils._
-import is.hail.annotations.Region
+import is.hail.annotations.{Region, RowSeq}
 import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.{EmitCodeBuilder, EmitFunctionBuilder, EmitValue, IEmitCode}
 import is.hail.types.physical._
@@ -146,12 +146,12 @@ class CodeSuite {
     )
     assert(hashTestArrayHelper(IndexedSeq(1, 2)) != hashTestArrayHelper(IndexedSeq(3, 4, 5, 6, 7)))
     assertEq(
-      hashTestStructHelper(Row("wolf", 8, .009f), fields),
-      hashTestStructHelper(Row("wolf", 8, .009f), fields),
+      hashTestStructHelper(RowSeq("wolf", 8, .009f), fields),
+      hashTestStructHelper(RowSeq("wolf", 8, .009f), fields),
     )
     assert(
-      hashTestStructHelper(Row("w", 8, .009f), fields) != hashTestStructHelper(
-        Row("opaque", 8, .009f),
+      hashTestStructHelper(RowSeq("w", 8, .009f), fields) != hashTestStructHelper(
+        RowSeq("opaque", 8, .009f),
         fields,
       )
     )

--- a/hail/hail/test/src/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/Aggregators2Suite.scala
@@ -37,7 +37,7 @@ class Aggregators2Suite {
     val argT = PType.canonical(
       TStruct(args.map { case (Ref(n, typ), _) => n.str -> typ }: _*)
     ).setRequired(true).asInstanceOf[PStruct]
-    val argVs = Row.fromSeq(args.map { case (_, v) => v })
+    val argVs = RowSeq.fromSeq(args.map { case (_, v) => v })
     val argRef = Ref(freshName(), argT.virtualType)
     val spec = BufferSpec.wireSpec
 
@@ -200,7 +200,16 @@ class Aggregators2Suite {
     )
 
   val t = TStruct("a" -> TString, "b" -> TInt64)
-  val rows = FastSeq(Row("abcd", 5L), null, Row(null, -2L), Row("abcd", 7L), null, Row("foo", null))
+
+  val rows = FastSeq(
+    RowSeq("abcd", 5L),
+    null,
+    RowSeq(null, -2L),
+    RowSeq("abcd", 7L),
+    null,
+    RowSeq("foo", null),
+  )
+
   val arrayType = TArray(t)
 
   val pnnAggSig = PhysicalAggSig(PrevNonnull(), TypedStateSig(VirtualTypeWithReq.fullyOptional(t)))
@@ -293,23 +302,23 @@ class Aggregators2Suite {
     val t = TStruct("x" -> TCall)
 
     val calls = FastSeq(
-      Row(Call0()),
-      Row(Call1(0)),
-      Row(Call1(1)),
-      Row(Call1(2)),
-      Row(Call1(0)),
+      RowSeq(Call0()),
+      RowSeq(Call1(0)),
+      RowSeq(Call1(1)),
+      RowSeq(Call1(2)),
+      RowSeq(Call1(0)),
       null,
       null,
-      Row(Call2(0, 0)),
-      Row(Call2(0, 0, phased = true)),
-      Row(Call2(0, 0)),
-      Row(Call2(0, 1)),
-      Row(Call2(1, 0, phased = true)),
-      Row(Call2(1, 1)),
-      Row(Call2(1, 3)),
+      RowSeq(Call2(0, 0)),
+      RowSeq(Call2(0, 0, phased = true)),
+      RowSeq(Call2(0, 0)),
+      RowSeq(Call2(0, 1)),
+      RowSeq(Call2(1, 0, phased = true)),
+      RowSeq(Call2(1, 1)),
+      RowSeq(Call2(1, 3)),
       null,
       null,
-      Row(null),
+      RowSeq(null),
     )
 
     val aggSig = PhysicalAggSig(CallStats(), CallStatsStateSig())
@@ -327,7 +336,7 @@ class Aggregators2Suite {
       aggSig,
       FastSeq(I32(5)),
       seqOpArgs(calls),
-      expected = Row(ac, af, an, homCount),
+      expected = RowSeq(ac, af, an, homCount),
       args = FastSeq((a, calls)),
     )
 
@@ -336,7 +345,7 @@ class Aggregators2Suite {
       aggSig,
       FastSeq(I32(5)),
       seqOpArgs(allMissing),
-      expected = Row(FastSeq(0, 0, 0, 0, 0), null, 0, FastSeq(0, 0, 0, 0, 0)),
+      expected = RowSeq(FastSeq(0, 0, 0, 0, 0), null, 0, FastSeq(0, 0, 0, 0, 0)),
       args = FastSeq((a, allMissing)),
     )
   }
@@ -354,20 +363,20 @@ class Aggregators2Suite {
     )
 
     val rows = FastSeq(
-      Row(Row(11, 11L), 1, 1L, 1f, 1d, true, "1", FastSeq(1, 1)),
-      Row(Row(22, 22L), 2, 2L, 2f, 2d, false, "11", null),
-      Row(Row(33, 33L), 3, 3L, 3f, 3d, null, "111", FastSeq(3, null)),
-      Row(Row(44, null), 4, 4L, 4f, 4d, true, "1111", null),
-      Row(Row(55, null), 5, 5L, 5f, 5d, true, "11111", null),
-      Row(Row(66, 66L), 6, 6L, 6f, 6d, false, "111111", FastSeq(6, 6, 6, 6)),
-      Row(Row(77, 77L), 7, 7L, 7f, 7d, false, "1111111", FastSeq()),
-      Row(Row(88, 88L), 8, 8L, 8f, 8d, null, "11111111", null),
-      Row(Row(99, 99L), 9, 9L, 9f, 9d, null, "111111111", FastSeq(null)),
-      Row(Row(1010, 1010L), 10, 10L, 10f, 10d, false, "1111111111", FastSeq()),
-      Row(Row(1010, 1011L), 11, 11L, 11f, 11d, true, "11111111111", FastSeq()),
-      Row(null, null, null, null, null, null, null, null),
-      Row(null, null, null, null, null, null, null, null),
-      Row(null, null, null, null, null, null, null, null),
+      RowSeq(RowSeq(11, 11L), 1, 1L, 1f, 1d, true, "1", FastSeq(1, 1)),
+      RowSeq(RowSeq(22, 22L), 2, 2L, 2f, 2d, false, "11", null),
+      RowSeq(RowSeq(33, 33L), 3, 3L, 3f, 3d, null, "111", FastSeq(3, null)),
+      RowSeq(RowSeq(44, null), 4, 4L, 4f, 4d, true, "1111", null),
+      RowSeq(RowSeq(55, null), 5, 5L, 5f, 5d, true, "11111", null),
+      RowSeq(RowSeq(66, 66L), 6, 6L, 6f, 6d, false, "111111", FastSeq(6, 6, 6, 6)),
+      RowSeq(RowSeq(77, 77L), 7, 7L, 7f, 7d, false, "1111111", FastSeq()),
+      RowSeq(RowSeq(88, 88L), 8, 8L, 8f, 8d, null, "11111111", null),
+      RowSeq(RowSeq(99, 99L), 9, 9L, 9f, 9d, null, "111111111", FastSeq(null)),
+      RowSeq(RowSeq(1010, 1010L), 10, 10L, 10f, 10d, false, "1111111111", FastSeq()),
+      RowSeq(RowSeq(1010, 1011L), 11, 11L, 11f, 11d, true, "11111111111", FastSeq()),
+      RowSeq(null, null, null, null, null, null, null, null),
+      RowSeq(null, null, null, null, null, null, null, null),
+      RowSeq(null, null, null, null, null, null, null, null),
     )
 
     val rowsReversed = rows.take(rows.length - 3).reverse ++ rows.takeRight(3)
@@ -452,7 +461,7 @@ class Aggregators2Suite {
     test(7, rows, t, identity[IR], identity[Row], TInt64, _ => I64(5L))
 
     // test GC behavior by passing a large collection
-    val rows2 = ArraySeq.tabulate(1200)(i => Row(i, i.toString))
+    val rows2 = ArraySeq.tabulate(1200)(i => RowSeq(i, i.toString))
     val t2 = TStruct("a" -> TInt32, "b" -> TString)
     val aggSig2 = PhysicalAggSig(
       TakeBy(),
@@ -508,24 +517,24 @@ class Aggregators2Suite {
     )
 
     val rows = FastSeq(
-      Row(Row(11, 11L), 1, 1L, 1f, 1d, true, "one", FastSeq(1, 1)),
-      Row(Row(22, 22L), 2, 2L, 2f, 2d, false, "two", null),
+      RowSeq(RowSeq(11, 11L), 1, 1L, 1f, 1d, true, "one", FastSeq(1, 1)),
+      RowSeq(RowSeq(22, 22L), 2, 2L, 2f, 2d, false, "two", null),
       null,
-      Row(Row(33, 33L), 3, 3L, 3f, 3d, null, "three", FastSeq(3, null)),
-      Row(null, null, null, null, null, null, null, FastSeq()),
-      Row(Row(null, 44L), 4, 4L, 4f, 4d, true, "four", null),
-      Row(Row(55, null), 5, 5L, 5f, 5d, true, null, null),
+      RowSeq(RowSeq(33, 33L), 3, 3L, 3f, 3d, null, "three", FastSeq(3, null)),
+      RowSeq(null, null, null, null, null, null, null, FastSeq()),
+      RowSeq(RowSeq(null, 44L), 4, 4L, 4f, 4d, true, "four", null),
+      RowSeq(RowSeq(55, null), 5, 5L, 5f, 5d, true, null, null),
       null,
-      Row(Row(66, 66L), 6, 6L, 6f, 6d, false, "six", FastSeq(6, 6, 6, 6)),
-      Row(null, null, null, null, null, null, null, null),
-      Row(Row(77, 77L), 7, 7L, 7f, 7d, false, "seven", FastSeq()),
+      RowSeq(RowSeq(66, 66L), 6, 6L, 6f, 6d, false, "six", FastSeq(6, 6, 6, 6)),
+      RowSeq(null, null, null, null, null, null, null, null),
+      RowSeq(RowSeq(77, 77L), 7, 7L, 7f, 7d, false, "seven", FastSeq()),
       null,
       null,
-      Row(null, null, null, null, null, null, null, null),
-      Row(Row(88, 88L), 8, 8L, 8f, 8d, null, "eight", null),
-      Row(Row(99, 99L), 9, 9L, 9f, 9d, null, "nine", FastSeq(null)),
-      Row(Row(1010, 1010L), 10, 10L, 10f, 10d, false, "ten", FastSeq()),
-      Row(Row(1111, 1111L), 11, 11L, 11f, 11d, true, "eleven", FastSeq()),
+      RowSeq(null, null, null, null, null, null, null, null),
+      RowSeq(RowSeq(88, 88L), 8, 8L, 8f, 8d, null, "eight", null),
+      RowSeq(RowSeq(99, 99L), 9, 9L, 9f, 9d, null, "nine", FastSeq(null)),
+      RowSeq(RowSeq(1010, 1010L), 10, 10L, 10f, 10d, false, "ten", FastSeq()),
+      RowSeq(RowSeq(1111, 1111L), 11, 11L, 11f, 11d, true, "eleven", FastSeq()),
     )
 
     val aggSig = PhysicalAggSig(Take(), TakeStateSig(VirtualTypeWithReq(PType.canonical(t))))
@@ -662,20 +671,20 @@ class Aggregators2Suite {
     val alState = ArrayLenAggSig(knownLength = false, FastSeq(pnnAggSig, countAggSig, sumAggSig))
 
     val value = FastSeq(
-      FastSeq(Row("a", 0L), Row("b", 0L), Row("c", 0L), Row("f", 0L)),
-      FastSeq(Row("a", 1L), null, Row("c", 1L), null),
-      FastSeq(Row("a", 2L), Row("b", 2L), null, Row("f", 2L)),
-      FastSeq(Row("a", 3L), Row("b", 3L), Row("c", 3L), Row("f", 3L)),
-      FastSeq(Row("a", 4L), Row("b", 4L), Row("c", 4L), null),
-      FastSeq(null, null, null, Row("f", 5L)),
+      FastSeq(RowSeq("a", 0L), RowSeq("b", 0L), RowSeq("c", 0L), RowSeq("f", 0L)),
+      FastSeq(RowSeq("a", 1L), null, RowSeq("c", 1L), null),
+      FastSeq(RowSeq("a", 2L), RowSeq("b", 2L), null, RowSeq("f", 2L)),
+      FastSeq(RowSeq("a", 3L), RowSeq("b", 3L), RowSeq("c", 3L), RowSeq("f", 3L)),
+      FastSeq(RowSeq("a", 4L), RowSeq("b", 4L), RowSeq("c", 4L), null),
+      FastSeq(null, null, null, RowSeq("f", 5L)),
     )
 
     val expected =
       FastSeq(
-        Row(Row("a", 4L), 6L, 10L),
-        Row(Row("b", 4L), 6L, 9L),
-        Row(Row("c", 4L), 6L, 8L),
-        Row(Row("f", 5L), 6L, 10L),
+        RowSeq(RowSeq("a", 4L), 6L, 10L),
+        RowSeq(RowSeq("b", 4L), 6L, 9L),
+        RowSeq(RowSeq("c", 4L), 6L, 8L),
+        RowSeq(RowSeq("f", 5L), 6L, 10L),
       )
 
     val init = InitOp(
@@ -742,7 +751,7 @@ class Aggregators2Suite {
       )
     }
 
-    val expected = ArraySeq(Row(ArraySeq(Row(45L))))
+    val expected = ArraySeq(RowSeq(ArraySeq(RowSeq(45L))))
 
     val args = ArraySeq.tabulate(10)(i => ArraySeq(ArraySeq(i.toLong)))
     assertAggEqualsProcessed(
@@ -758,12 +767,12 @@ class Aggregators2Suite {
 
   @Test def testArrayElementsAggTake(implicit ctx: ExecuteContext): Unit = {
     val value = FastSeq(
-      FastSeq(Row("a", 0L), Row("b", 0L), Row("c", 0L), Row("f", 0L)),
-      FastSeq(Row("a", 1L), null, Row("c", 1L), null),
-      FastSeq(Row("a", 2L), Row("b", 2L), null, Row("f", 2L)),
-      FastSeq(Row("a", 3L), Row("b", 3L), Row("c", 3L), Row("f", 3L)),
-      FastSeq(Row("a", 4L), Row("b", 4L), Row("c", 4L), null),
-      FastSeq(null, null, null, Row("f", 5L)),
+      FastSeq(RowSeq("a", 0L), RowSeq("b", 0L), RowSeq("c", 0L), RowSeq("f", 0L)),
+      FastSeq(RowSeq("a", 1L), null, RowSeq("c", 1L), null),
+      FastSeq(RowSeq("a", 2L), RowSeq("b", 2L), null, RowSeq("f", 2L)),
+      FastSeq(RowSeq("a", 3L), RowSeq("b", 3L), RowSeq("c", 3L), RowSeq("f", 3L)),
+      FastSeq(RowSeq("a", 4L), RowSeq("b", 4L), RowSeq("c", 4L), null),
+      FastSeq(null, null, null, RowSeq("f", 5L)),
     )
 
     val take = PhysicalAggSig(Take(), TakeStateSig(VirtualTypeWithReq(PType.canonical(t))))
@@ -783,7 +792,7 @@ class Aggregators2Suite {
     }
 
     val expected = ArraySeq.tabulate(value(0).length)(i =>
-      Row(ArraySeq.tabulate(3)(j => value(j)(i)))
+      RowSeq(ArraySeq.tabulate(3)(j => value(j)(i)))
     )
     assertAggEqualsProcessed(
       alstate,
@@ -809,7 +818,14 @@ class Aggregators2Suite {
     )))
 
     val rows =
-      FastSeq(Row("abcd", 5L), null, Row(null, -2L), Row("abcd", 7L), null, Row("foo", null))
+      FastSeq(
+        RowSeq("abcd", 5L),
+        null,
+        RowSeq(null, -2L),
+        RowSeq("abcd", 7L),
+        null,
+        RowSeq("foo", null),
+      )
     val rref = Ref(freshName(), TArray(t))
 
     val seqOpArgs = ArraySeq.tabulate(rows.length)(i =>
@@ -824,9 +840,9 @@ class Aggregators2Suite {
     )
 
     val expected = Map(
-      "abcd" -> Row(Row("abcd", 7L), 2L, 12L),
-      "foo" -> Row(Row("foo", null), 1L, 0L),
-      (null, Row(Row(null, -2L), 3L, -2L)),
+      "abcd" -> RowSeq(RowSeq("abcd", 7L), 2L, 12L),
+      "foo" -> RowSeq(RowSeq("foo", null), 1L, 0L),
+      (null, RowSeq(RowSeq(null, -2L), 3L, -2L)),
     )
 
     assertAggEquals(
@@ -862,7 +878,14 @@ class Aggregators2Suite {
     )
 
     val rows =
-      FastSeq(Row("abcd", 5L), null, Row(null, -2L), Row("abcd", 7L), null, Row("foo", null))
+      FastSeq(
+        RowSeq("abcd", 5L),
+        null,
+        RowSeq(null, -2L),
+        RowSeq("abcd", 7L),
+        null,
+        RowSeq("foo", null),
+      )
     val rref = Ref(freshName(), arrayType)
 
     val seqOpArgs = ArraySeq.tabulate(rows.length)(i =>
@@ -884,9 +907,9 @@ class Aggregators2Suite {
     )
 
     val expected = Map(
-      "abcd" -> Row(Map("abcd" -> Row(Row("abcd", 7L), 2L, 12L))),
-      "foo" -> Row(Map("foo" -> Row(Row("foo", null), 1L, 0L))),
-      (null, Row(Map((null, Row(Row(null, -2L), 3L, -2L))))),
+      "abcd" -> RowSeq(Map("abcd" -> RowSeq(RowSeq("abcd", 7L), 2L, 12L))),
+      "foo" -> RowSeq(Map("foo" -> RowSeq(RowSeq("foo", null), 1L, 0L))),
+      (null, RowSeq(Map((null, RowSeq(RowSeq(null, -2L), 3L, -2L))))),
     )
 
     assertAggEquals(
@@ -900,7 +923,14 @@ class Aggregators2Suite {
 
   @Test def testCollectAsSet(implicit ctx: ExecuteContext): Unit = {
     val rows =
-      FastSeq(Row("abcd", 5L), null, Row(null, -2L), Row("abcd", 7L), null, Row("foo", null))
+      FastSeq(
+        RowSeq("abcd", 5L),
+        null,
+        RowSeq(null, -2L),
+        RowSeq("abcd", 7L),
+        null,
+        RowSeq("foo", null),
+      )
     val rref = Ref(freshName(), arrayType)
     val elts = ArraySeq.tabulate(rows.length)(i => FastSeq(GetField(ArrayRef(rref, i), "a")))
     val eltsPrimitive =
@@ -937,23 +967,23 @@ class Aggregators2Suite {
       DownsampleStateSig(VirtualTypeWithReq(PCanonicalArray(PCanonicalString()))),
     )
     val rows = FastSeq(
-      Row(-1.23, 1.23, null),
-      Row(-10d, 10d, FastSeq("foo")),
-      Row(0d, 100d, FastSeq()),
-      Row(0d, 100d, FastSeq()),
-      Row(-10.1d, -100d, null),
-      Row(0d, 0d, null),
-      Row(0d, 0d, null),
-      Row(1d, 1.1d, null),
-      Row(1d, 1.1d, null),
-      Row(2d, 2.2d, null),
-      Row(3d, 3.3d, null),
-      Row(3d, 3.3d, null),
-      Row(3d, 3.3d, null),
-      Row(4d, 4.4d, null),
-      Row(3d, 3.3d, null),
-      Row(3d, 3.3d, null),
-      Row(3d, 3.3d, null),
+      RowSeq(-1.23, 1.23, null),
+      RowSeq(-10d, 10d, FastSeq("foo")),
+      RowSeq(0d, 100d, FastSeq()),
+      RowSeq(0d, 100d, FastSeq()),
+      RowSeq(-10.1d, -100d, null),
+      RowSeq(0d, 0d, null),
+      RowSeq(0d, 0d, null),
+      RowSeq(1d, 1.1d, null),
+      RowSeq(1d, 1.1d, null),
+      RowSeq(2d, 2.2d, null),
+      RowSeq(3d, 3.3d, null),
+      RowSeq(3d, 3.3d, null),
+      RowSeq(3d, 3.3d, null),
+      RowSeq(4d, 4.4d, null),
+      RowSeq(3d, 3.3d, null),
+      RowSeq(3d, 3.3d, null),
+      RowSeq(3d, 3.3d, null),
     )
 
     val arrayType = TArray(TStruct("x" -> TFloat64, "y" -> TFloat64, "label" -> TArray(TString)))
@@ -1015,7 +1045,7 @@ class Aggregators2Suite {
       )
     )
 
-    assertEvalsTo(ir, Row((0 until 10).map(i => Row(i, 2L * i + 12L)), Row()))(
+    assertEvalsTo(ir, Row((0 until 10).map(i => RowSeq(i, 2L * i + 12L)), RowSeq()))(
       ctx,
       ExecStrategy.interpretOnly,
     )
@@ -1080,7 +1110,7 @@ class Aggregators2Suite {
       ResultOp.makeTuple(FastSeq(sig)),
       FastSeq(sig.state),
     )
-    assertEvalsTo(x, Row(-4.0))
+    assertEvalsTo(x, RowSeq(-4.0))
   }
 
   @Test def testRunAggNested(implicit ctx: ExecuteContext): Unit = {

--- a/hail/hail/test/src/is/hail/expr/ir/AggregatorsSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/AggregatorsSuite.scala
@@ -3,6 +3,7 @@ package is.hail.expr.ir
 import is.hail.ExecStrategy
 import is.hail.ExecStrategy.ExecStrategy
 import is.hail.TestUtils._
+import is.hail.annotations.RowSeq
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
 import is.hail.collection.compat.immutable.ArraySeq
@@ -48,7 +49,7 @@ class AggregatorsSuite {
     runAggregator(
       op,
       TStruct("x" -> t),
-      a.map(i => Row(i)),
+      a.map(i => RowSeq(i)),
       expected,
       initOpArgs,
       seqOpArgs = FastSeq(Ref(Name("x"), t)),
@@ -59,7 +60,7 @@ class AggregatorsSuite {
     val agg = ToArray(mapIR(StreamRange(0, 10, 1))(_ => ApplyAggOp(Count())()))
     assertEvalsTo(
       agg,
-      (FastSeq(1, 2).map(i => Row(i)), TStruct("x" -> TInt32)),
+      (FastSeq(1, 2).map(i => RowSeq(i)), TStruct("x" -> TInt32)),
       IndexedSeq.fill(10)(2L),
     )
   }
@@ -112,8 +113,8 @@ class AggregatorsSuite {
     runAggregator(
       Collect(),
       TStruct("a" -> TInt32, "b" -> TBoolean),
-      FastSeq(Row(5, true), Row(3, false), null, Row(0, false), null),
-      FastSeq(Row(5, true), Row(3, false), null, Row(0, false), null),
+      FastSeq(RowSeq(5, true), RowSeq(3, false), null, RowSeq(0, false), null),
+      FastSeq(RowSeq(5, true), RowSeq(3, false), null, RowSeq(0, false), null),
     )
   }
 
@@ -121,7 +122,15 @@ class AggregatorsSuite {
     runAggregator(
       Count(),
       TStruct("x" -> TString),
-      FastSeq(Row("hello"), Row("foo"), Row("a"), Row(null), Row("b"), Row(null), Row("c")),
+      FastSeq(
+        RowSeq("hello"),
+        RowSeq("foo"),
+        RowSeq("a"),
+        RowSeq(null),
+        RowSeq("b"),
+        RowSeq(null),
+        RowSeq("c"),
+      ),
       7L,
       initOpArgs = FastSeq(),
       seqOpArgs = FastSeq(),
@@ -164,8 +173,8 @@ class AggregatorsSuite {
     runAggregator(
       CollectAsSet(),
       TStruct("a" -> TInt32, "b" -> TBoolean),
-      FastSeq(Row(5, true), Row(3, false), null, Row(0, false), null, Row(5, true)),
-      Set(Row(5, true), Row(3, false), null, Row(0, false)),
+      FastSeq(RowSeq(5, true), RowSeq(3, false), null, RowSeq(0, false), null, RowSeq(5, true)),
+      Set(RowSeq(5, true), RowSeq(3, false), null, RowSeq(0, false)),
     )
 
   @Test def callStats(implicit ctx: ExecuteContext): Unit = {
@@ -173,7 +182,7 @@ class AggregatorsSuite {
       CallStats(),
       TCall,
       FastSeq(Call2(0, 0), Call2(0, 1), null, Call2(0, 2)),
-      Row(FastSeq(4, 1, 1), FastSeq(4.0 / 6.0, 1.0 / 6.0, 1.0 / 6.0), 6, FastSeq(1, 0, 0)),
+      RowSeq(FastSeq(4, 1, 1), FastSeq(4.0 / 6.0, 1.0 / 6.0, 1.0 / 6.0), 6, FastSeq(1, 0, 0)),
       initOpArgs = FastSeq(I32(3)),
     )
   }
@@ -264,7 +273,7 @@ class AggregatorsSuite {
         Sum(),
       ),
       (
-        FastSeq(Row(1.0, 10.0), Row(10.0, 10.0), Row(null, 10.0)),
+        FastSeq(RowSeq(1.0, 10.0), RowSeq(10.0, 10.0), RowSeq(null, 10.0)),
         TStruct("a" -> TFloat64, "b" -> TFloat64),
       ),
       110.0,
@@ -277,7 +286,7 @@ class AggregatorsSuite {
     expected: Seq[T],
   )(implicit ctx: ExecuteContext
   ): Unit = {
-    val aggregable = a.map(Row(_))
+    val aggregable = a.map(RowSeq(_))
     val structType = TStruct("foo" -> TArray(eltType))
 
     assertEvalsTo(
@@ -392,14 +401,14 @@ class AggregatorsSuite {
   }
 
   @Test def takeByNGreater(implicit ctx: ExecuteContext): Unit =
-    assertTakeByEvalsTo(TInt32, TInt32, 5, FastSeq(Row(3, 4)), FastSeq(3))
+    assertTakeByEvalsTo(TInt32, TInt32, 5, FastSeq(RowSeq(3, 4)), FastSeq(3))
 
   @Test def takeByBooleanBoolean(implicit ctx: ExecuteContext): Unit = {
     assertTakeByEvalsTo(
       TBoolean,
       TBoolean,
       3,
-      FastSeq(Row(false, true), Row(null, null), Row(true, false)),
+      FastSeq(RowSeq(false, true), RowSeq(null, null), RowSeq(true, false)),
       FastSeq(true, false, null),
     )
   }
@@ -410,12 +419,12 @@ class AggregatorsSuite {
       TInt32,
       3,
       FastSeq(
-        Row(false, 0),
-        Row(null, null),
-        Row(true, 1),
-        Row(false, 3),
-        Row(true, null),
-        Row(null, 2),
+        RowSeq(false, 0),
+        RowSeq(null, null),
+        RowSeq(true, 1),
+        RowSeq(false, 3),
+        RowSeq(true, null),
+        RowSeq(null, 2),
       ),
       FastSeq(false, true, null),
     )
@@ -427,12 +436,12 @@ class AggregatorsSuite {
       TInt64,
       3,
       FastSeq(
-        Row(false, 0L),
-        Row(null, null),
-        Row(true, 1L),
-        Row(false, 3L),
-        Row(true, null),
-        Row(null, 2L),
+        RowSeq(false, 0L),
+        RowSeq(null, null),
+        RowSeq(true, 1L),
+        RowSeq(false, 3L),
+        RowSeq(true, null),
+        RowSeq(null, 2L),
       ),
       FastSeq(false, true, null),
     )
@@ -444,12 +453,12 @@ class AggregatorsSuite {
       TFloat32,
       3,
       FastSeq(
-        Row(false, 0f),
-        Row(null, null),
-        Row(true, 1f),
-        Row(false, 3f),
-        Row(true, null),
-        Row(null, 2f),
+        RowSeq(false, 0f),
+        RowSeq(null, null),
+        RowSeq(true, 1f),
+        RowSeq(false, 3f),
+        RowSeq(true, null),
+        RowSeq(null, 2f),
       ),
       FastSeq(false, true, null),
     )
@@ -461,12 +470,12 @@ class AggregatorsSuite {
       TFloat64,
       3,
       FastSeq(
-        Row(false, 0d),
-        Row(null, null),
-        Row(true, 1d),
-        Row(false, 3d),
-        Row(true, null),
-        Row(null, 2d),
+        RowSeq(false, 0d),
+        RowSeq(null, null),
+        RowSeq(true, 1d),
+        RowSeq(false, 3d),
+        RowSeq(true, null),
+        RowSeq(null, 2d),
       ),
       FastSeq(false, true, null),
     )
@@ -478,12 +487,12 @@ class AggregatorsSuite {
       TString,
       3,
       FastSeq(
-        Row(false, "a"),
-        Row(null, null),
-        Row(true, "b"),
-        Row(false, "d"),
-        Row(true, null),
-        Row(null, "c"),
+        RowSeq(false, "a"),
+        RowSeq(null, null),
+        RowSeq(true, "b"),
+        RowSeq(false, "d"),
+        RowSeq(true, null),
+        RowSeq(null, "c"),
       ),
       FastSeq(false, true, null),
     )
@@ -494,7 +503,7 @@ class AggregatorsSuite {
       TInt32,
       TBoolean,
       2,
-      FastSeq(Row(3, true), Row(null, null), Row(null, false)),
+      FastSeq(RowSeq(3, true), RowSeq(null, null), RowSeq(null, false)),
       FastSeq(null, 3),
     )
   }
@@ -504,7 +513,14 @@ class AggregatorsSuite {
       TInt32,
       TInt32,
       3,
-      FastSeq(Row(3, 4), Row(null, null), Row(null, 2), Row(11, 0), Row(45, 1), Row(3, null)),
+      FastSeq(
+        RowSeq(3, 4),
+        RowSeq(null, null),
+        RowSeq(null, 2),
+        RowSeq(11, 0),
+        RowSeq(45, 1),
+        RowSeq(3, null),
+      ),
       FastSeq(11, 45, null),
     )
   }
@@ -514,7 +530,14 @@ class AggregatorsSuite {
       TInt32,
       TInt64,
       3,
-      FastSeq(Row(3, 4L), Row(null, null), Row(null, 2L), Row(11, 0L), Row(45, 1L), Row(3, null)),
+      FastSeq(
+        RowSeq(3, 4L),
+        RowSeq(null, null),
+        RowSeq(null, 2L),
+        RowSeq(11, 0L),
+        RowSeq(45, 1L),
+        RowSeq(3, null),
+      ),
       FastSeq(11, 45, null),
     )
   }
@@ -524,7 +547,14 @@ class AggregatorsSuite {
       TInt32,
       TFloat32,
       3,
-      FastSeq(Row(3, 4f), Row(null, null), Row(null, 2f), Row(11, 0f), Row(45, 1f), Row(3, null)),
+      FastSeq(
+        RowSeq(3, 4f),
+        RowSeq(null, null),
+        RowSeq(null, 2f),
+        RowSeq(11, 0f),
+        RowSeq(45, 1f),
+        RowSeq(3, null),
+      ),
       FastSeq(11, 45, null),
     )
   }
@@ -534,7 +564,14 @@ class AggregatorsSuite {
       TInt32,
       TFloat64,
       3,
-      FastSeq(Row(3, 4d), Row(null, null), Row(null, 2d), Row(11, 0d), Row(45, 1d), Row(3, null)),
+      FastSeq(
+        RowSeq(3, 4d),
+        RowSeq(null, null),
+        RowSeq(null, 2d),
+        RowSeq(11, 0d),
+        RowSeq(45, 1d),
+        RowSeq(3, null),
+      ),
       FastSeq(11, 45, null),
     )
   }
@@ -545,12 +582,12 @@ class AggregatorsSuite {
       TString,
       3,
       FastSeq(
-        Row(3, "d"),
-        Row(null, null),
-        Row(null, "c"),
-        Row(11, "a"),
-        Row(45, "b"),
-        Row(3, null),
+        RowSeq(3, "d"),
+        RowSeq(null, null),
+        RowSeq(null, "c"),
+        RowSeq(11, "a"),
+        RowSeq(45, "b"),
+        RowSeq(3, null),
       ),
       FastSeq(11, 45, null),
     )
@@ -561,7 +598,7 @@ class AggregatorsSuite {
       TInt64,
       TBoolean,
       2,
-      FastSeq(Row(3L, true), Row(null, null), Row(null, false)),
+      FastSeq(RowSeq(3L, true), RowSeq(null, null), RowSeq(null, false)),
       FastSeq(null, 3L),
     )
   }
@@ -571,7 +608,14 @@ class AggregatorsSuite {
       TInt64,
       TInt32,
       3,
-      FastSeq(Row(3L, 4), Row(null, null), Row(null, 2), Row(11L, 0), Row(45L, 1), Row(3L, null)),
+      FastSeq(
+        RowSeq(3L, 4),
+        RowSeq(null, null),
+        RowSeq(null, 2),
+        RowSeq(11L, 0),
+        RowSeq(45L, 1),
+        RowSeq(3L, null),
+      ),
       FastSeq(11L, 45L, null),
     )
   }
@@ -582,12 +626,12 @@ class AggregatorsSuite {
       TInt64,
       3,
       FastSeq(
-        Row(3L, 4L),
-        Row(null, null),
-        Row(null, 2L),
-        Row(11L, 0L),
-        Row(45L, 1L),
-        Row(3L, null),
+        RowSeq(3L, 4L),
+        RowSeq(null, null),
+        RowSeq(null, 2L),
+        RowSeq(11L, 0L),
+        RowSeq(45L, 1L),
+        RowSeq(3L, null),
       ),
       FastSeq(11L, 45L, null),
     )
@@ -599,12 +643,12 @@ class AggregatorsSuite {
       TFloat32,
       3,
       FastSeq(
-        Row(3L, 4f),
-        Row(null, null),
-        Row(null, 2f),
-        Row(11L, 0f),
-        Row(45L, 1f),
-        Row(3L, null),
+        RowSeq(3L, 4f),
+        RowSeq(null, null),
+        RowSeq(null, 2f),
+        RowSeq(11L, 0f),
+        RowSeq(45L, 1f),
+        RowSeq(3L, null),
       ),
       FastSeq(11L, 45L, null),
     )
@@ -616,12 +660,12 @@ class AggregatorsSuite {
       TFloat64,
       3,
       FastSeq(
-        Row(3L, 4d),
-        Row(null, null),
-        Row(null, 2d),
-        Row(11L, 0d),
-        Row(45L, 1d),
-        Row(3L, null),
+        RowSeq(3L, 4d),
+        RowSeq(null, null),
+        RowSeq(null, 2d),
+        RowSeq(11L, 0d),
+        RowSeq(45L, 1d),
+        RowSeq(3L, null),
       ),
       FastSeq(11L, 45L, null),
     )
@@ -633,12 +677,12 @@ class AggregatorsSuite {
       TString,
       3,
       FastSeq(
-        Row(3L, "d"),
-        Row(null, null),
-        Row(null, "c"),
-        Row(11L, "a"),
-        Row(45L, "b"),
-        Row(3L, null),
+        RowSeq(3L, "d"),
+        RowSeq(null, null),
+        RowSeq(null, "c"),
+        RowSeq(11L, "a"),
+        RowSeq(45L, "b"),
+        RowSeq(3L, null),
       ),
       FastSeq(11L, 45L, null),
     )
@@ -649,7 +693,7 @@ class AggregatorsSuite {
       TFloat32,
       TBoolean,
       2,
-      FastSeq(Row(3f, true), Row(null, null), Row(null, false)),
+      FastSeq(RowSeq(3f, true), RowSeq(null, null), RowSeq(null, false)),
       FastSeq(null, 3f),
     )
   }
@@ -659,7 +703,14 @@ class AggregatorsSuite {
       TFloat32,
       TInt32,
       3,
-      FastSeq(Row(3f, 4), Row(null, null), Row(null, 2), Row(11f, 0), Row(45f, 1), Row(3f, null)),
+      FastSeq(
+        RowSeq(3f, 4),
+        RowSeq(null, null),
+        RowSeq(null, 2),
+        RowSeq(11f, 0),
+        RowSeq(45f, 1),
+        RowSeq(3f, null),
+      ),
       FastSeq(11f, 45f, null),
     )
   }
@@ -670,12 +721,12 @@ class AggregatorsSuite {
       TInt64,
       3,
       FastSeq(
-        Row(3f, 4L),
-        Row(null, null),
-        Row(null, 2L),
-        Row(11f, 0L),
-        Row(45f, 1L),
-        Row(3f, null),
+        RowSeq(3f, 4L),
+        RowSeq(null, null),
+        RowSeq(null, 2L),
+        RowSeq(11f, 0L),
+        RowSeq(45f, 1L),
+        RowSeq(3f, null),
       ),
       FastSeq(11f, 45f, null),
     )
@@ -687,12 +738,12 @@ class AggregatorsSuite {
       TFloat32,
       3,
       FastSeq(
-        Row(3f, 4f),
-        Row(null, null),
-        Row(null, 2f),
-        Row(11f, 0f),
-        Row(45f, 1f),
-        Row(3f, null),
+        RowSeq(3f, 4f),
+        RowSeq(null, null),
+        RowSeq(null, 2f),
+        RowSeq(11f, 0f),
+        RowSeq(45f, 1f),
+        RowSeq(3f, null),
       ),
       FastSeq(11f, 45f, null),
     )
@@ -704,12 +755,12 @@ class AggregatorsSuite {
       TFloat64,
       3,
       FastSeq(
-        Row(3f, 4d),
-        Row(null, null),
-        Row(null, 2d),
-        Row(11f, 0d),
-        Row(45f, 1d),
-        Row(3f, null),
+        RowSeq(3f, 4d),
+        RowSeq(null, null),
+        RowSeq(null, 2d),
+        RowSeq(11f, 0d),
+        RowSeq(45f, 1d),
+        RowSeq(3f, null),
       ),
       FastSeq(11f, 45f, null),
     )
@@ -721,12 +772,12 @@ class AggregatorsSuite {
       TString,
       3,
       FastSeq(
-        Row(3f, "d"),
-        Row(null, null),
-        Row(null, "c"),
-        Row(11f, "a"),
-        Row(45f, "b"),
-        Row(3f, null),
+        RowSeq(3f, "d"),
+        RowSeq(null, null),
+        RowSeq(null, "c"),
+        RowSeq(11f, "a"),
+        RowSeq(45f, "b"),
+        RowSeq(3f, null),
       ),
       FastSeq(11f, 45f, null),
     )
@@ -737,7 +788,7 @@ class AggregatorsSuite {
       TFloat64,
       TBoolean,
       2,
-      FastSeq(Row(3d, true), Row(null, null), Row(null, false)),
+      FastSeq(RowSeq(3d, true), RowSeq(null, null), RowSeq(null, false)),
       FastSeq(null, 3d),
     )
   }
@@ -747,7 +798,14 @@ class AggregatorsSuite {
       TFloat64,
       TInt32,
       3,
-      FastSeq(Row(3d, 4), Row(null, null), Row(null, 2), Row(11d, 0), Row(45d, 1), Row(3d, null)),
+      FastSeq(
+        RowSeq(3d, 4),
+        RowSeq(null, null),
+        RowSeq(null, 2),
+        RowSeq(11d, 0),
+        RowSeq(45d, 1),
+        RowSeq(3d, null),
+      ),
       FastSeq(11d, 45d, null),
     )
   }
@@ -758,12 +816,12 @@ class AggregatorsSuite {
       TInt64,
       3,
       FastSeq(
-        Row(3d, 4L),
-        Row(null, null),
-        Row(null, 2L),
-        Row(11d, 0L),
-        Row(45d, 1L),
-        Row(3d, null),
+        RowSeq(3d, 4L),
+        RowSeq(null, null),
+        RowSeq(null, 2L),
+        RowSeq(11d, 0L),
+        RowSeq(45d, 1L),
+        RowSeq(3d, null),
       ),
       FastSeq(11d, 45d, null),
     )
@@ -775,12 +833,12 @@ class AggregatorsSuite {
       TFloat32,
       3,
       FastSeq(
-        Row(3d, 4f),
-        Row(null, null),
-        Row(null, 2f),
-        Row(11d, 0f),
-        Row(45d, 1f),
-        Row(3d, null),
+        RowSeq(3d, 4f),
+        RowSeq(null, null),
+        RowSeq(null, 2f),
+        RowSeq(11d, 0f),
+        RowSeq(45d, 1f),
+        RowSeq(3d, null),
       ),
       FastSeq(11d, 45d, null),
     )
@@ -792,12 +850,12 @@ class AggregatorsSuite {
       TFloat64,
       3,
       FastSeq(
-        Row(3d, 4d),
-        Row(null, null),
-        Row(null, 2d),
-        Row(11d, 0d),
-        Row(45d, 1d),
-        Row(3d, null),
+        RowSeq(3d, 4d),
+        RowSeq(null, null),
+        RowSeq(null, 2d),
+        RowSeq(11d, 0d),
+        RowSeq(45d, 1d),
+        RowSeq(3d, null),
       ),
       FastSeq(11d, 45d, null),
     )
@@ -809,12 +867,12 @@ class AggregatorsSuite {
       TString,
       3,
       FastSeq(
-        Row(3d, "d"),
-        Row(null, null),
-        Row(null, "c"),
-        Row(11d, "a"),
-        Row(45d, "b"),
-        Row(3d, null),
+        RowSeq(3d, "d"),
+        RowSeq(null, null),
+        RowSeq(null, "c"),
+        RowSeq(11d, "a"),
+        RowSeq(45d, "b"),
+        RowSeq(3d, null),
       ),
       FastSeq(11d, 45d, null),
     )
@@ -825,7 +883,7 @@ class AggregatorsSuite {
       TString,
       TBoolean,
       2,
-      FastSeq(Row("hello", true), Row(null, null), Row(null, false)),
+      FastSeq(RowSeq("hello", true), RowSeq(null, null), RowSeq(null, false)),
       FastSeq(null, "hello"),
     )
   }
@@ -835,7 +893,14 @@ class AggregatorsSuite {
       TString,
       TInt32,
       3,
-      FastSeq(Row("a", 4), Row(null, null), Row(null, 2), Row("b", 0), Row("c", 1), Row("d", null)),
+      FastSeq(
+        RowSeq("a", 4),
+        RowSeq(null, null),
+        RowSeq(null, 2),
+        RowSeq("b", 0),
+        RowSeq("c", 1),
+        RowSeq("d", null),
+      ),
       FastSeq("b", "c", null),
     )
   }
@@ -846,12 +911,12 @@ class AggregatorsSuite {
       TInt64,
       3,
       FastSeq(
-        Row("a", 4L),
-        Row(null, null),
-        Row(null, 2L),
-        Row("b", 0L),
-        Row("c", 1L),
-        Row("d", null),
+        RowSeq("a", 4L),
+        RowSeq(null, null),
+        RowSeq(null, 2L),
+        RowSeq("b", 0L),
+        RowSeq("c", 1L),
+        RowSeq("d", null),
       ),
       FastSeq("b", "c", null),
     )
@@ -863,12 +928,12 @@ class AggregatorsSuite {
       TFloat32,
       3,
       FastSeq(
-        Row("a", 4f),
-        Row(null, null),
-        Row(null, 2f),
-        Row("b", 0f),
-        Row("c", 1f),
-        Row("d", null),
+        RowSeq("a", 4f),
+        RowSeq(null, null),
+        RowSeq(null, 2f),
+        RowSeq("b", 0f),
+        RowSeq("c", 1f),
+        RowSeq("d", null),
       ),
       FastSeq("b", "c", null),
     )
@@ -880,12 +945,12 @@ class AggregatorsSuite {
       TFloat64,
       3,
       FastSeq(
-        Row("a", 4d),
-        Row(null, null),
-        Row(null, 2d),
-        Row("b", 0d),
-        Row("c", 1d),
-        Row("d", null),
+        RowSeq("a", 4d),
+        RowSeq(null, null),
+        RowSeq(null, 2d),
+        RowSeq("b", 0d),
+        RowSeq("c", 1d),
+        RowSeq("d", null),
       ),
       FastSeq("b", "c", null),
     )
@@ -897,12 +962,12 @@ class AggregatorsSuite {
       TString,
       3,
       FastSeq(
-        Row("a", "d"),
-        Row(null, null),
-        Row(null, "c"),
-        Row("b", "a"),
-        Row("c", "b"),
-        Row("d", null),
+        RowSeq("a", "d"),
+        RowSeq(null, null),
+        RowSeq(null, "c"),
+        RowSeq("b", "a"),
+        RowSeq("c", "b"),
+        RowSeq("d", null),
       ),
       FastSeq("b", "c", null),
     )
@@ -914,12 +979,12 @@ class AggregatorsSuite {
       TInt64,
       3,
       FastSeq(
-        Row(Call2(0, 0), 4L),
-        Row(null, null),
-        Row(null, 2L),
-        Row(Call2(0, 1), 0L),
-        Row(Call2(1, 1), 1L),
-        Row(Call2(0, 2), null),
+        RowSeq(Call2(0, 0), 4L),
+        RowSeq(null, null),
+        RowSeq(null, 2L),
+        RowSeq(Call2(0, 1), 0L),
+        RowSeq(Call2(1, 1), 1L),
+        RowSeq(Call2(0, 2), null),
       ),
       FastSeq(Call2(0, 1), Call2(1, 1), null),
     )
@@ -952,7 +1017,7 @@ class AggregatorsSuite {
       Count(),
       Ref(Name("k"), TInt32),
       TStruct("k" -> TInt32),
-      FastSeq(Row(1), Row(2), Row(3), Row(1), Row(1), Row(null), Row(null)),
+      FastSeq(RowSeq(1), RowSeq(2), RowSeq(3), RowSeq(1), RowSeq(1), RowSeq(null), RowSeq(null)),
       Map(1 -> 3L, 2 -> 1L, 3 -> 1L, (null, 2L)),
       initOpArgs = FastSeq(),
       seqOpArgs = FastSeq(),
@@ -962,7 +1027,15 @@ class AggregatorsSuite {
       Count(),
       Ref(Name("k"), TBoolean),
       TStruct("k" -> TBoolean),
-      FastSeq(Row(true), Row(true), Row(true), Row(false), Row(false), Row(null), Row(null)),
+      FastSeq(
+        RowSeq(true),
+        RowSeq(true),
+        RowSeq(true),
+        RowSeq(false),
+        RowSeq(false),
+        RowSeq(null),
+        RowSeq(null),
+      ),
       Map(true -> 3L, false -> 2L, (null, 2L)),
       initOpArgs = FastSeq(),
       seqOpArgs = FastSeq(),
@@ -974,15 +1047,15 @@ class AggregatorsSuite {
       Ref(Name("k"), TStruct("a" -> TBoolean)),
       TStruct("k" -> TStruct("a" -> TBoolean)),
       FastSeq(
-        Row(Row(true)),
-        Row(Row(true)),
-        Row(Row(true)),
-        Row(Row(false)),
-        Row(Row(false)),
-        Row(Row(null)),
-        Row(Row(null)),
+        RowSeq(RowSeq(true)),
+        RowSeq(RowSeq(true)),
+        RowSeq(RowSeq(true)),
+        RowSeq(RowSeq(false)),
+        RowSeq(RowSeq(false)),
+        RowSeq(RowSeq(null)),
+        RowSeq(RowSeq(null)),
       ),
-      Map(Row(true) -> 3L, Row(false) -> 2L, (Row(null), 2L)),
+      Map(RowSeq(true) -> 3L, RowSeq(false) -> 2L, (RowSeq(null), 2L)),
       initOpArgs = FastSeq(),
       seqOpArgs = FastSeq(),
     )
@@ -995,13 +1068,13 @@ class AggregatorsSuite {
       Ref(Name("k"), TBoolean),
       TStruct("k" -> TBoolean, "v" -> TInt32),
       FastSeq(
-        Row(true, 5),
-        Row(true, 3),
-        Row(true, null),
-        Row(false, 0),
-        Row(false, null),
-        Row(null, null),
-        Row(null, 2),
+        RowSeq(true, 5),
+        RowSeq(true, 3),
+        RowSeq(true, null),
+        RowSeq(false, 0),
+        RowSeq(false, null),
+        RowSeq(null, null),
+        RowSeq(null, 2),
       ),
       Map(true -> FastSeq(5, 3, null), false -> FastSeq(0, null), (null, FastSeq(null, 2))),
       FastSeq(),
@@ -1016,16 +1089,16 @@ class AggregatorsSuite {
       Ref(Name("k"), TBoolean),
       TStruct("k" -> TBoolean, "v" -> TCall),
       FastSeq(
-        Row(true, null),
-        Row(true, Call2(0, 1)),
-        Row(true, Call2(0, 1)),
-        Row(false, null),
-        Row(false, Call2(0, 0)),
-        Row(false, Call2(1, 1)),
+        RowSeq(true, null),
+        RowSeq(true, Call2(0, 1)),
+        RowSeq(true, Call2(0, 1)),
+        RowSeq(false, null),
+        RowSeq(false, Call2(0, 0)),
+        RowSeq(false, Call2(1, 1)),
       ),
       Map(
-        true -> Row(FastSeq(2, 2), FastSeq(0.5, 0.5), 4, FastSeq(0, 0)),
-        false -> Row(FastSeq(2, 2), FastSeq(0.5, 0.5), 4, FastSeq(1, 1)),
+        true -> RowSeq(FastSeq(2, 2), FastSeq(0.5, 0.5), 4, FastSeq(0, 0)),
+        false -> RowSeq(FastSeq(2, 2), FastSeq(0.5, 0.5), 4, FastSeq(1, 1)),
       ),
       FastSeq(I32(2)),
       FastSeq(Ref(Name("v"), TCall)),
@@ -1039,12 +1112,12 @@ class AggregatorsSuite {
       Ref(Name("k"), TString),
       TStruct("k" -> TString, "x" -> TFloat64, "y" -> TInt32),
       FastSeq(
-        Row("case", 0.2, 5),
-        Row("control", 0.4, 0),
-        Row(null, 1.0, 3),
-        Row("control", 0.0, 2),
-        Row("case", 0.3, 6),
-        Row("control", 0.5, 1),
+        RowSeq("case", 0.2, 5),
+        RowSeq("control", 0.4, 0),
+        RowSeq(null, 1.0, 3),
+        RowSeq("control", 0.0, 2),
+        RowSeq("case", 0.3, 6),
+        RowSeq("control", 0.5, 1),
       ),
       Map("case" -> FastSeq(0.2, 0.3), "control" -> FastSeq(0.4, 0.5), (null, FastSeq(1.0))),
       FastSeq(I32(2)),
@@ -1055,7 +1128,12 @@ class AggregatorsSuite {
   @Test
   def keyedKeyedCollect(implicit ctx: ExecuteContext): Unit = {
     val agg =
-      FastSeq(Row("EUR", true, 1), Row("EUR", false, 2), Row("AFR", true, 3), Row("AFR", null, 4))
+      FastSeq(
+        RowSeq("EUR", true, 1),
+        RowSeq("EUR", false, 2),
+        RowSeq("AFR", true, 3),
+        RowSeq("AFR", null, 4),
+      )
     val aggType = TStruct("k1" -> TString, "k2" -> TBoolean, "x" -> TInt32)
     val expected: Map[String, Map[Any, Seq[Int]]] = Map(
       "EUR" -> Map(true -> FastSeq(1), false -> FastSeq(2)),
@@ -1079,20 +1157,20 @@ class AggregatorsSuite {
   @Test
   def keyedKeyedCallStats(implicit ctx: ExecuteContext): Unit = {
     val agg = FastSeq(
-      Row("EUR", "CASE", null),
-      Row("EUR", "CONTROL", Call2(0, 1)),
-      Row("AFR", "CASE", Call2(1, 1)),
-      Row("AFR", "CONTROL", null),
+      RowSeq("EUR", "CASE", null),
+      RowSeq("EUR", "CONTROL", Call2(0, 1)),
+      RowSeq("AFR", "CASE", Call2(1, 1)),
+      RowSeq("AFR", "CONTROL", null),
     )
     val aggType = TStruct("k1" -> TString, "k2" -> TString, "g" -> TCall)
     val expected = Map(
       "EUR" -> Map(
-        "CONTROL" -> Row(FastSeq(1, 1), FastSeq(0.5, 0.5), 2, FastSeq(0, 0)),
-        "CASE" -> Row(FastSeq(0, 0), null, 0, FastSeq(0, 0)),
+        "CONTROL" -> RowSeq(FastSeq(1, 1), FastSeq(0.5, 0.5), 2, FastSeq(0, 0)),
+        "CASE" -> RowSeq(FastSeq(0, 0), null, 0, FastSeq(0, 0)),
       ),
       "AFR" -> Map(
-        "CASE" -> Row(FastSeq(0, 2), FastSeq(0.0, 1.0), 2, FastSeq(0, 1)),
-        "CONTROL" -> Row(FastSeq(0, 0), null, 0, FastSeq(0, 0)),
+        "CASE" -> RowSeq(FastSeq(0, 2), FastSeq(0.0, 1.0), 2, FastSeq(0, 1)),
+        "CONTROL" -> RowSeq(FastSeq(0, 0), null, 0, FastSeq(0, 0)),
       ),
     )
     assertEvalsTo(
@@ -1113,12 +1191,12 @@ class AggregatorsSuite {
   @Test
   def keyedKeyedTakeBy(implicit ctx: ExecuteContext): Unit = {
     val agg = FastSeq(
-      Row("case", "a", 0.2, 5),
-      Row("control", "b", 0.4, 0),
-      Row(null, "c", 1.0, 3),
-      Row("control", "b", 0.0, 2),
-      Row("case", "a", 0.3, 6),
-      Row("control", "b", 0.5, 1),
+      RowSeq("case", "a", 0.2, 5),
+      RowSeq("control", "b", 0.4, 0),
+      RowSeq(null, "c", 1.0, 3),
+      RowSeq("control", "b", 0.0, 2),
+      RowSeq("case", "a", 0.3, 6),
+      RowSeq("control", "b", 0.5, 1),
     )
     val aggType = TStruct("k1" -> TString, "k2" -> TString, "x" -> TFloat64, "y" -> TInt32)
     val expected = Map(
@@ -1148,10 +1226,10 @@ class AggregatorsSuite {
   @Test
   def keyedKeyedKeyedCollect(implicit ctx: ExecuteContext): Unit = {
     val agg = FastSeq(
-      Row("EUR", "CASE", true, 1),
-      Row("EUR", "CONTROL", true, 2),
-      Row("AFR", "CASE", false, 3),
-      Row("AFR", "CONTROL", false, 4),
+      RowSeq("EUR", "CASE", true, 1),
+      RowSeq("EUR", "CONTROL", true, 2),
+      RowSeq("AFR", "CASE", false, 3),
+      RowSeq("AFR", "CONTROL", false, 4),
     )
     val aggType = TStruct("k1" -> TString, "k2" -> TString, "k3" -> TBoolean, "x" -> TInt32)
     val expected = Map(
@@ -1194,7 +1272,7 @@ class AggregatorsSuite {
 
   @Test def testAggFilter(implicit ctx: ExecuteContext): Unit = {
     val aggType = TStruct("x" -> TBoolean, "y" -> TInt64)
-    val agg = FastSeq(Row(true, -1L), Row(true, 1L), Row(false, 3L), Row(true, 5L))
+    val agg = FastSeq(RowSeq(true, -1L), RowSeq(true, 1L), RowSeq(false, 3L), RowSeq(true, 5L))
 
     assertEvalsTo(
       AggFilter(
@@ -1210,10 +1288,10 @@ class AggregatorsSuite {
   @Test def testAggExplode(implicit ctx: ExecuteContext): Unit = {
     val aggType = TStruct("x" -> TArray(TInt64))
     val agg = FastSeq(
-      Row(FastSeq[Long](1, 4)),
-      Row(FastSeq[Long]()),
-      Row(FastSeq[Long](-1, 3)),
-      Row(FastSeq[Long](4, 5, 6, -7)),
+      RowSeq(FastSeq[Long](1, 4)),
+      RowSeq(FastSeq[Long]()),
+      RowSeq(FastSeq[Long](-1, 3)),
+      RowSeq(FastSeq[Long](4, 5, 6, -7)),
     )
 
     assertEvalsTo(
@@ -1259,24 +1337,29 @@ class AggregatorsSuite {
   }
 
   @Test def testImputeTypeSimple(implicit ctx: ExecuteContext): Unit = {
-    runAggregator(ImputeType(), TString, FastSeq(null), Row(false, false, true, true, true, true))
+    runAggregator(
+      ImputeType(),
+      TString,
+      FastSeq(null),
+      RowSeq(false, false, true, true, true, true),
+    )
     runAggregator(
       ImputeType(),
       TString,
       FastSeq("1231", "1234.5", null),
-      Row(true, false, false, false, false, true),
+      RowSeq(true, false, false, false, false, true),
     )
     runAggregator(
       ImputeType(),
       TString,
       FastSeq("1231", "123"),
-      Row(true, true, false, true, true, true),
+      RowSeq(true, true, false, true, true, true),
     )
     runAggregator(
       ImputeType(),
       TString,
       FastSeq("true", "false"),
-      Row(true, true, true, false, false, false),
+      RowSeq(true, true, true, false, false, false),
     )
   }
 
@@ -1349,7 +1432,7 @@ class AggregatorsSuite {
 
     assertEvalsTo(
       x,
-      Row(
+      RowSeq(
         5,
         0 until 5,
       ),

--- a/hail/hail/test/src/is/hail/expr/ir/ArrayDeforestationSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/ArrayDeforestationSuite.scala
@@ -2,13 +2,13 @@ package is.hail.expr.ir
 
 import is.hail.ExecStrategy
 import is.hail.TestUtils._
+import is.hail.annotations.RowSeq
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
 import is.hail.expr.ir.defs.{
   GetField, GetTupleElement, If, MakeStruct, MakeTuple, StreamRange, ToArray, ToStream,
 }
 
-import org.apache.spark.sql.Row
 import org.junit.jupiter.api.Test
 
 class ArrayDeforestationSuite {
@@ -54,8 +54,8 @@ class ArrayDeforestationSuite {
 
   @Test def testArrayFold(implicit ctx: ExecuteContext): Unit = {
     implicit val execStrats: ExecStrategy.ValueSet = ExecStrategy.values
-    assertEvalsTo(arrayFoldWithStructWithPrimitiveValues(5, -5, -6), Row(5, 4))
-    assertEvalsTo(arrayFoldWithStruct(5, -5, -6), Row(Row(4, 0), Row(5, 0)))
+    assertEvalsTo(arrayFoldWithStructWithPrimitiveValues(5, -5, -6), RowSeq(5, 4))
+    assertEvalsTo(arrayFoldWithStruct(5, -5, -6), RowSeq(RowSeq(4, 0), RowSeq(5, 0)))
   }
 
 }

--- a/hail/hail/test/src/is/hail/expr/ir/DictFunctionsSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/DictFunctionsSuite.scala
@@ -3,6 +3,7 @@ package is.hail.expr.ir
 import is.hail.{ExecStrategy, ParameterizedTest}
 import is.hail.ExecStrategy.ExecStrategy
 import is.hail.TestUtils._
+import is.hail.annotations.RowSeq
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
 import is.hail.collection.compat.immutable.ArraySeq
@@ -48,10 +49,10 @@ class DictFunctionsSuite {
     )
 
   def dictToArray() = ArraySeq[(IndexedSeq[(Integer, Integer)], IndexedSeq[Row])](
-    (FastSeq[(Integer, Integer)]((1, 3), (2, 7)), FastSeq(Row(1, 3), Row(2, 7))),
+    (FastSeq[(Integer, Integer)]((1, 3), (2, 7)), FastSeq(RowSeq(1, 3), RowSeq(2, 7))),
     (
       FastSeq[(Integer, Integer)]((1, 3), (2, null), null, (null, 1), (3, 7)),
-      FastSeq(Row(1, 3), Row(2, null), Row(3, 7), Row(null, 1)),
+      FastSeq(RowSeq(1, 3), RowSeq(2, null), RowSeq(3, 7), RowSeq(null, 1)),
     ),
     (FastSeq(), FastSeq()),
     (FastSeq(null), FastSeq()),

--- a/hail/hail/test/src/is/hail/expr/ir/EmitStreamSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/EmitStreamSuite.scala
@@ -3,7 +3,7 @@ package is.hail.expr.ir
 import is.hail.{ExecStrategy, ParameterizedTest}
 import is.hail.ExecStrategy.ExecStrategy
 import is.hail.TestUtils._
-import is.hail.annotations.{Region, SafeRow, ScalaToRegionValue}
+import is.hail.annotations.{Region, RowSeq, SafeRow, ScalaToRegionValue}
 import is.hail.asm4s._
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
@@ -24,7 +24,6 @@ import is.hail.types.virtual._
 import is.hail.utils._
 import is.hail.variant.Call2
 
-import org.apache.spark.sql.Row
 import org.junit.jupiter.api.Test
 
 class EmitStreamSuite {
@@ -209,7 +208,7 @@ class EmitStreamSuite {
         IndexedSeq[IR](MakeTuple.ordered(IndexedSeq(4, 5))),
         TStream(TTuple(TInt32, TInt32)),
       ) ->
-        IndexedSeq(Row(4, 5)),
+        IndexedSeq(RowSeq(4, 5)),
       MakeStream(IndexedSeq[IR](Str("hi"), Str("world")), TStream(TString)) ->
         IndexedSeq("hi", "world"),
     )
@@ -245,12 +244,12 @@ class EmitStreamSuite {
       step <- 1 to 3
     }
       assert(
-        range(Row(start, stop, step)) == ArraySeq.range(start, stop, step),
+        range(RowSeq(start, stop, step)) == ArraySeq.range(start, stop, step),
         s"($start, $stop, $step)",
       )
-    assert(range(Row(null, 10, 1)) == null)
-    assert(range(Row(0, null, 1)) == null)
-    assert(range(Row(0, 10, null)) == null)
+    assert(range(RowSeq(null, 10, 1)) == null)
+    assert(range(RowSeq(0, null, 1)) == null)
+    assert(range(RowSeq(0, 10, null)) == null)
     assert(range(null) == null)
   }
 
@@ -368,7 +367,7 @@ class EmitStreamSuite {
   }
 
   @Test def testStreamBufferedAggregator(implicit ctx: ExecuteContext): Unit = {
-    val resultArrayToCompare = (0 until 12).map(i => Row(Row(i, i + 1), 1))
+    val resultArrayToCompare = (0 until 12).map(i => RowSeq(RowSeq(i, i + 1), 1))
     val streamType = TStream(TStruct("a" -> TInt64, "b" -> TInt64))
     val numSeq = (0L until 12).map(i => IndexedSeq(I64(i), I64(i + 1)))
     val numTupleSeq = numSeq.map(_ => IndexedSeq("a", "b")).zip(numSeq)
@@ -414,7 +413,7 @@ class EmitStreamSuite {
   }
 
   @Test def testStreamBufferedAggregatorCombine(implicit ctx: ExecuteContext): Unit = {
-    val resultArrayToCompare = IndexedSeq(Row(Row(1), 2))
+    val resultArrayToCompare = IndexedSeq(RowSeq(RowSeq(1), 2))
     val streamType = TStream(TStruct("a" -> TInt64))
     val elemOne = MakeStruct(IndexedSeq(("a", I64(1))))
     val elemTwo = MakeStruct(IndexedSeq(("a", I64(1))))
@@ -459,7 +458,7 @@ class EmitStreamSuite {
 
   @Test def testStreamBufferedAggregatorCollectAggregator(implicit ctx: ExecuteContext): Unit = {
     val resultArrayToCompare =
-      IndexedSeq(Row(Row(1), IndexedSeq(1, 3)), Row(Row(2), IndexedSeq(2, 4)))
+      IndexedSeq(RowSeq(RowSeq(1), IndexedSeq(1, 3)), RowSeq(RowSeq(2), IndexedSeq(2, 4)))
     val streamType = TStream(TStruct("a" -> TInt64, "b" -> TInt64))
     val elemOne = MakeStruct(IndexedSeq(("a", I64(1)), ("b", I64(1))))
     val elemTwo = MakeStruct(IndexedSeq(("a", I64(2)), ("b", I64(2))))
@@ -505,17 +504,17 @@ class EmitStreamSuite {
 
   @Test def testStreamBufferedAggregatorMultipleAggregators(implicit ctx: ExecuteContext): Unit = {
     val resultArrayToCompare = IndexedSeq(
-      Row(Row(1), Row(3, IndexedSeq(1L, 3L, 2L))),
-      Row(Row(2), Row(2, IndexedSeq(2L, 4L))),
-      Row(Row(3), Row(3, IndexedSeq(1L, 2L, 3L))),
-      Row(Row(4), Row(1, IndexedSeq(4L))),
-      Row(Row(5), Row(1, IndexedSeq(1L))),
-      Row(Row(6), Row(1, IndexedSeq(3L))),
-      Row(Row(7), Row(1, IndexedSeq(4L))),
-      Row(Row(8), Row(1, IndexedSeq(1L))),
-      Row(Row(8), Row(1, IndexedSeq(2L))),
-      Row(Row(9), Row(1, IndexedSeq(3L))),
-      Row(Row(10), Row(2, IndexedSeq(4L, 4L))),
+      RowSeq(RowSeq(1), RowSeq(3, IndexedSeq(1L, 3L, 2L))),
+      RowSeq(RowSeq(2), RowSeq(2, IndexedSeq(2L, 4L))),
+      RowSeq(RowSeq(3), RowSeq(3, IndexedSeq(1L, 2L, 3L))),
+      RowSeq(RowSeq(4), RowSeq(1, IndexedSeq(4L))),
+      RowSeq(RowSeq(5), RowSeq(1, IndexedSeq(1L))),
+      RowSeq(RowSeq(6), RowSeq(1, IndexedSeq(3L))),
+      RowSeq(RowSeq(7), RowSeq(1, IndexedSeq(4L))),
+      RowSeq(RowSeq(8), RowSeq(1, IndexedSeq(1L))),
+      RowSeq(RowSeq(8), RowSeq(1, IndexedSeq(2L))),
+      RowSeq(RowSeq(9), RowSeq(1, IndexedSeq(3L))),
+      RowSeq(RowSeq(10), RowSeq(2, IndexedSeq(4L, 4L))),
     )
     val streamType = TStream(TStruct("a" -> TInt64, "b" -> TInt64))
     val elemOne = MakeStruct(IndexedSeq(("a", I64(1)), ("b", I64(1))))
@@ -617,27 +616,38 @@ class EmitStreamSuite {
       (
         pairs(IndexedSeq(3 -> "A")),
         pairs(IndexedSeq()),
-        IndexedSeq(Row("A", null)),
-        IndexedSeq(Row("A", null)),
+        IndexedSeq(RowSeq("A", null)),
+        IndexedSeq(RowSeq("A", null)),
       ),
-      (pairs(IndexedSeq()), pairs(IndexedSeq(3 -> "B")), IndexedSeq(), IndexedSeq(Row(null, "B"))),
+      (
+        pairs(IndexedSeq()),
+        pairs(IndexedSeq(3 -> "B")),
+        IndexedSeq(),
+        IndexedSeq(RowSeq(null, "B")),
+      ),
       (
         pairs(IndexedSeq(0 -> "A")),
         pairs(IndexedSeq(0 -> "B")),
-        IndexedSeq(Row("A", "B")),
-        IndexedSeq(Row("A", "B")),
+        IndexedSeq(RowSeq("A", "B")),
+        IndexedSeq(RowSeq("A", "B")),
       ),
       (
         pairs(IndexedSeq(0 -> "A", 2 -> "B", 3 -> "C")),
         pairs(IndexedSeq(0 -> "a", 1 -> ".", 2 -> "b", 4 -> "..")),
-        IndexedSeq(Row("A", "a"), Row("B", "b"), Row("C", null)),
-        IndexedSeq(Row("A", "a"), Row(null, "."), Row("B", "b"), Row("C", null), Row(null, "..")),
+        IndexedSeq(RowSeq("A", "a"), RowSeq("B", "b"), RowSeq("C", null)),
+        IndexedSeq(
+          RowSeq("A", "a"),
+          RowSeq(null, "."),
+          RowSeq("B", "b"),
+          RowSeq("C", null),
+          RowSeq(null, ".."),
+        ),
       ),
       (
         pairs(IndexedSeq(0 -> "A", 1 -> "B1", 1 -> "B2")),
         pairs(IndexedSeq(0 -> "a", 1 -> "b", 2 -> "c")),
-        IndexedSeq(Row("A", "a"), Row("B1", "b"), Row("B2", "b")),
-        IndexedSeq(Row("A", "a"), Row("B1", "b"), Row("B2", "b"), Row(null, "c")),
+        IndexedSeq(RowSeq("A", "a"), RowSeq("B1", "b"), RowSeq("B2", "b")),
+        IndexedSeq(RowSeq("A", "a"), RowSeq("B1", "b"), RowSeq("B2", "b"), RowSeq(null, "c")),
       ),
     )
     tests.foreach { case (lstream, rstream, expectedLeft, expectedOuter) =>
@@ -691,15 +701,20 @@ class EmitStreamSuite {
 
     val tests: Array[(IR, IR, IndexedSeq[Any], IndexedSeq[Any])] = Array(
       (lElts(), rElts(), IndexedSeq(), IndexedSeq()),
-      (lElts(3 -> "A"), rElts(), IndexedSeq(Row("A", null)), IndexedSeq()),
+      (lElts(3 -> "A"), rElts(), IndexedSeq(RowSeq("A", null)), IndexedSeq()),
       (lElts(), rElts(('[', 1, 2, ']') -> "B"), IndexedSeq(), IndexedSeq()),
       (
         lElts(0 -> "A"),
         rElts(('[', 0, 1, ')') -> "B"),
-        IndexedSeq(Row("A", "B")),
-        IndexedSeq(Row("A", "B")),
+        IndexedSeq(RowSeq("A", "B")),
+        IndexedSeq(RowSeq("A", "B")),
       ),
-      (lElts(0 -> "A"), rElts(('(', 0, 1, ')') -> "B"), IndexedSeq(Row("A", null)), IndexedSeq()),
+      (
+        lElts(0 -> "A"),
+        rElts(('(', 0, 1, ')') -> "B"),
+        IndexedSeq(RowSeq("A", null)),
+        IndexedSeq(),
+      ),
       (
         lElts(0 -> "A", 2 -> "B", 3 -> "C", 4 -> "D"),
         rElts(
@@ -708,8 +723,8 @@ class EmitStreamSuite {
           ('[', 1, 4, ')') -> "b",
           ('[', 2, 4, ')') -> "..",
         ),
-        IndexedSeq(Row("A", "a"), Row("B", "b"), Row("C", "b"), Row("D", null)),
-        IndexedSeq(Row("A", "a"), Row("B", "b"), Row("C", "b")),
+        IndexedSeq(RowSeq("A", "a"), RowSeq("B", "b"), RowSeq("C", "b"), RowSeq("D", null)),
+        IndexedSeq(RowSeq("A", "a"), RowSeq("B", "b"), RowSeq("C", "b")),
       ),
       (
         lElts(1 -> "A", 2 -> "B", 3 -> "C", 4 -> "D"),
@@ -719,8 +734,8 @@ class EmitStreamSuite {
           ('[', 1, 4, ')') -> "b",
           ('[', 2, 4, ')') -> "..",
         ),
-        IndexedSeq(Row("A", "a"), Row("B", "b"), Row("C", "b"), Row("D", null)),
-        IndexedSeq(Row("A", "a"), Row("B", "b"), Row("C", "b")),
+        IndexedSeq(RowSeq("A", "a"), RowSeq("B", "b"), RowSeq("C", "b"), RowSeq("D", null)),
+        IndexedSeq(RowSeq("A", "a"), RowSeq("B", "b"), RowSeq("C", "b")),
       ),
     )
 
@@ -737,19 +752,19 @@ class EmitStreamSuite {
   @Test def testStreamJoinOuterWithKeyRepeats(implicit ctx: ExecuteContext): Unit = {
     val lEltType = TStruct("k" -> TInt32, "idx_left" -> TInt32)
     val lRows = FastSeq(
-      Row(1, 1),
-      Row(1, 2),
-      Row(1, 3),
-      Row(3, 4),
+      RowSeq(1, 1),
+      RowSeq(1, 2),
+      RowSeq(1, 3),
+      RowSeq(3, 4),
     )
 
     val a = ToStream(Literal(TArray(lEltType), lRows))
 
     val rEltType = TStruct("k" -> TInt32, "idx_right" -> TInt32)
     val rRows = FastSeq(
-      Row(1, 1),
-      Row(2, 2),
-      Row(4, 3),
+      RowSeq(1, 1),
+      RowSeq(2, 2),
+      RowSeq(4, 3),
     )
     val b = ToStream(Literal(TArray(rEltType), rRows))
 
@@ -759,12 +774,12 @@ class EmitStreamSuite {
 
     val compiled = evalStream(ir)
     val expected = FastSeq(
-      Row(Row(1, 1), Row(1, 1)),
-      Row(Row(1, 2), Row(1, 1)),
-      Row(Row(1, 3), Row(1, 1)),
-      Row(null, Row(2, 2)),
-      Row(Row(3, 4), null),
-      Row(null, Row(4, 3)),
+      RowSeq(RowSeq(1, 1), RowSeq(1, 1)),
+      RowSeq(RowSeq(1, 2), RowSeq(1, 1)),
+      RowSeq(RowSeq(1, 3), RowSeq(1, 1)),
+      RowSeq(null, RowSeq(2, 2)),
+      RowSeq(RowSeq(3, 4), null),
+      RowSeq(null, RowSeq(4, 3)),
     )
     assert(compiled == expected)
   }
@@ -811,12 +826,12 @@ class EmitStreamSuite {
       },
       TArray(pairType),
       FastSeq(
-        Row(null, 1),
-        Row(Call2(0, 0), 2),
-        Row(Call2(0, 1), 3),
-        Row(Call2(1, 1), 4),
+        RowSeq(null, 1),
+        RowSeq(Call2(0, 0), 2),
+        RowSeq(Call2(0, 1), 3),
+        RowSeq(Call2(1, 1), 4),
         null,
-        Row(null, 5),
+        RowSeq(null, 5),
       ) -> FastSeq(1 + 0, 2 + 0, 3 + 2, 4 + 4, null, 5 + 6),
     )
 
@@ -925,12 +940,12 @@ class EmitStreamSuite {
     ctx.r.pool.scopedSmallRegion { r =>
       val input = t.unstagedStoreJavaObject(
         ctx.stateManager,
-        Row(null, IndexedSeq(1d, 2d), IndexedSeq(3d, 4d)),
+        RowSeq(null, IndexedSeq(1d, 2d), IndexedSeq(3d, 4d)),
         r,
       )
 
       assert(
-        SafeRow.read(pt, f(ctx.theHailClassLoader, ctx.fs, ctx.taskContext, r)(r, input)) == Row(
+        SafeRow.read(pt, f(ctx.theHailClassLoader, ctx.fs, ctx.taskContext, r)(r, input)) == RowSeq(
           null
         )
       )
@@ -1274,7 +1289,7 @@ class EmitStreamSuite {
         StreamLeftIntervalJoin(
           keyStream,
           ToStream(
-            Literal(TArray(rightElemType), intervals.map(Row(_))),
+            Literal(TArray(rightElemType), intervals.map(RowSeq(_))),
             requiresMemoryManagementPerElement = true,
           ),
           kType.fieldNames.head,
@@ -1295,15 +1310,15 @@ class EmitStreamSuite {
     assertEvalsTo(
       join,
       FastSeq(
-        Row(0, FastSeq()),
-        Row(1, FastSeq(intervals(0))),
-        Row(2, FastSeq(intervals(0))),
-        Row(3, FastSeq(intervals(2), intervals(0))),
-        Row(4, FastSeq(intervals(2), intervals(0), intervals(3))),
-        Row(5, FastSeq(intervals(2), intervals(0), intervals(3))),
-        Row(6, FastSeq(intervals(3))),
-        Row(7, FastSeq(intervals(4))),
-        Row(8, FastSeq()),
+        RowSeq(0, FastSeq()),
+        RowSeq(1, FastSeq(intervals(0))),
+        RowSeq(2, FastSeq(intervals(0))),
+        RowSeq(3, FastSeq(intervals(2), intervals(0))),
+        RowSeq(4, FastSeq(intervals(2), intervals(0), intervals(3))),
+        RowSeq(5, FastSeq(intervals(2), intervals(0), intervals(3))),
+        RowSeq(6, FastSeq(intervals(3))),
+        RowSeq(7, FastSeq(intervals(4))),
+        RowSeq(8, FastSeq()),
       ),
     )
   }

--- a/hail/hail/test/src/is/hail/expr/ir/ExtractIntervalFiltersSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/ExtractIntervalFiltersSuite.scala
@@ -2,6 +2,7 @@ package is.hail.expr.ir
 
 import is.hail.ExecStrategy
 import is.hail.TestUtils._
+import is.hail.annotations.RowSeq
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
 import is.hail.expr.ir.defs._
@@ -37,7 +38,7 @@ class ExtractIntervalFiltersSuite {
     MakeStruct(FastSeq("y" -> GetField(structRef, "y"))),
   )
 
-  def wrappedIntervalEndpoint(x: Any, sign: Int) = IntervalEndpoint(Row(x), sign)
+  def wrappedIntervalEndpoint(x: Any, sign: Int) = IntervalEndpoint(RowSeq(x), sign)
 
   def grch38(implicit ctx: ExecuteContext): ReferenceGenome = ctx.references(ReferenceGenome.GRCh38)
 
@@ -69,7 +70,7 @@ class ExtractIntervalFiltersSuite {
       key.typ.asInstanceOf[TStruct].fieldNames,
     )
     if (result.isEmpty) {
-      assert(trueIntervals == FastSeq(Interval(Row(), Row(), true, true)))
+      assert(trueIntervals == FastSeq(Interval(RowSeq(), RowSeq(), true, true)))
       return
     }
     val (rw, intervals) = result.get
@@ -123,16 +124,16 @@ class ExtractIntervalFiltersSuite {
 
   @Test def testIsNA(implicit ctx: ExecuteContext): Unit = {
     val testRows = FastSeq(
-      Row(0, 0, true),
-      Row(0, null, true),
+      RowSeq(0, 0, true),
+      RowSeq(0, null, true),
     )
     checkAll(
       IsNA(k1),
       ref1,
       k1Full,
       testRows,
-      FastSeq(Interval(Row(null), Row(), true, true)),
-      FastSeq(Interval(Row(), Row(null), true, false)),
+      FastSeq(Interval(RowSeq(null), RowSeq(), true, true)),
+      FastSeq(Interval(RowSeq(), RowSeq(null), true, false)),
       FastSeq(),
     )
   }
@@ -146,10 +147,10 @@ class ExtractIntervalFiltersSuite {
       naIntervals: IndexedSeq[Interval],
     ): Unit = {
       val testRows = FastSeq(
-        Row(0, -1, true),
-        Row(0, 0, true),
-        Row(0, 1, true),
-        Row(0, null, true),
+        RowSeq(0, -1, true),
+        RowSeq(0, 0, true),
+        RowSeq(0, 1, true),
+        RowSeq(0, null, true),
       )
 
       checkAll(
@@ -193,48 +194,48 @@ class ExtractIntervalFiltersSuite {
     check(
       LT,
       I32(0),
-      FastSeq(Interval(Row(), Row(0), true, false)),
-      FastSeq(Interval(Row(0), Row(null), true, false)),
-      FastSeq(Interval(Row(null), Row(), true, true)),
+      FastSeq(Interval(RowSeq(), RowSeq(0), true, false)),
+      FastSeq(Interval(RowSeq(0), RowSeq(null), true, false)),
+      FastSeq(Interval(RowSeq(null), RowSeq(), true, true)),
     )
     check(
       GT,
       I32(0),
-      FastSeq(Interval(Row(0), Row(null), false, false)),
-      FastSeq(Interval(Row(), Row(0), true, true)),
-      FastSeq(Interval(Row(null), Row(), true, true)),
+      FastSeq(Interval(RowSeq(0), RowSeq(null), false, false)),
+      FastSeq(Interval(RowSeq(), RowSeq(0), true, true)),
+      FastSeq(Interval(RowSeq(null), RowSeq(), true, true)),
     )
     check(
       EQ,
       I32(0),
-      FastSeq(Interval(Row(0), Row(0), true, true)),
+      FastSeq(Interval(RowSeq(0), RowSeq(0), true, true)),
       FastSeq(
-        Interval(Row(), Row(0), true, false),
-        Interval(Row(0), Row(null), false, false),
+        Interval(RowSeq(), RowSeq(0), true, false),
+        Interval(RowSeq(0), RowSeq(null), false, false),
       ),
-      FastSeq(Interval(Row(null), Row(), true, true)),
+      FastSeq(Interval(RowSeq(null), RowSeq(), true, true)),
     )
 
     // These are never true (always missing), extracts the empty set of intervals
-    check(LT, NA(TInt32), FastSeq(), FastSeq(), FastSeq(Interval(Row(), Row(), true, true)))
-    check(GT, NA(TInt32), FastSeq(), FastSeq(), FastSeq(Interval(Row(), Row(), true, true)))
-    check(EQ, NA(TInt32), FastSeq(), FastSeq(), FastSeq(Interval(Row(), Row(), true, true)))
+    check(LT, NA(TInt32), FastSeq(), FastSeq(), FastSeq(Interval(RowSeq(), RowSeq(), true, true)))
+    check(GT, NA(TInt32), FastSeq(), FastSeq(), FastSeq(Interval(RowSeq(), RowSeq(), true, true)))
+    check(EQ, NA(TInt32), FastSeq(), FastSeq(), FastSeq(Interval(RowSeq(), RowSeq(), true, true)))
 
     check(
       EQWithNA,
       I32(0),
-      FastSeq(Interval(Row(0), Row(0), true, true)),
+      FastSeq(Interval(RowSeq(0), RowSeq(0), true, true)),
       FastSeq(
-        Interval(Row(), Row(0), true, false),
-        Interval(Row(0), Row(), false, true),
+        Interval(RowSeq(), RowSeq(0), true, false),
+        Interval(RowSeq(0), RowSeq(), false, true),
       ),
       FastSeq(),
     )
     check(
       EQWithNA,
       NA(TInt32),
-      FastSeq(Interval(Row(null), Row(), true, true)),
-      FastSeq(Interval(Row(), Row(null), true, false)),
+      FastSeq(Interval(RowSeq(null), RowSeq(), true, true)),
+      FastSeq(Interval(RowSeq(), RowSeq(null), true, false)),
       FastSeq(),
     )
 
@@ -254,10 +255,10 @@ class ExtractIntervalFiltersSuite {
       naIntervals: IndexedSeq[Interval],
     ): Unit = {
       val testRows = FastSeq(
-        Row(0, 1, true),
-        Row(0, 5, true),
-        Row(0, 10, true),
-        Row(0, null, true),
+        RowSeq(0, 1, true),
+        RowSeq(0, 5, true),
+        RowSeq(0, 10, true),
+        RowSeq(0, null, true),
       )
       checkAll(node, ref1, k1Full, testRows, trueIntervals, falseIntervals, naIntervals)
     }
@@ -270,14 +271,14 @@ class ExtractIntervalFiltersSuite {
       check(
         invoke("contains", TBoolean, lit, k1),
         FastSeq(
-          Interval(Row(1), Row(1), true, true),
-          Interval(Row(10), Row(10), true, true),
-          Interval(Row(null), Row(), true, true),
+          Interval(RowSeq(1), RowSeq(1), true, true),
+          Interval(RowSeq(10), RowSeq(10), true, true),
+          Interval(RowSeq(null), RowSeq(), true, true),
         ),
         FastSeq(
-          Interval(Row(), Row(1), true, false),
-          Interval(Row(1), Row(10), false, false),
-          Interval(Row(10), Row(null), false, false),
+          Interval(RowSeq(), RowSeq(1), true, false),
+          Interval(RowSeq(1), RowSeq(10), false, false),
+          Interval(RowSeq(10), RowSeq(null), false, false),
         ),
         FastSeq(),
       )
@@ -291,13 +292,13 @@ class ExtractIntervalFiltersSuite {
       check(
         invoke("contains", TBoolean, lit, k1),
         FastSeq(
-          Interval(Row(1), Row(1), true, true),
-          Interval(Row(10), Row(10), true, true),
+          Interval(RowSeq(1), RowSeq(1), true, true),
+          Interval(RowSeq(10), RowSeq(10), true, true),
         ),
         FastSeq(
-          Interval(Row(), Row(1), true, false),
-          Interval(Row(1), Row(10), false, false),
-          Interval(Row(10), Row(), false, true),
+          Interval(RowSeq(), RowSeq(1), true, false),
+          Interval(RowSeq(1), RowSeq(10), false, false),
+          Interval(RowSeq(10), RowSeq(), false, true),
         ),
         FastSeq(),
       )
@@ -312,13 +313,13 @@ class ExtractIntervalFiltersSuite {
       naIntervals: IndexedSeq[Interval],
     ): Unit = {
       val testRows = FastSeq(
-        Row(0, 1, 2),
-        Row(0, 3, 4),
-        Row(0, 3, null),
-        Row(0, 5, null),
-        Row(0, 5, 5),
-        Row(0, null, 1),
-        Row(0, null, null),
+        RowSeq(0, 1, 2),
+        RowSeq(0, 3, 4),
+        RowSeq(0, 3, null),
+        RowSeq(0, 5, null),
+        RowSeq(0, 5, 5),
+        RowSeq(0, null, 1),
+        RowSeq(0, null, null),
       )
       checkAll(
         node,
@@ -332,26 +333,26 @@ class ExtractIntervalFiltersSuite {
     }
 
     Array(
-      Literal(TSet(structT1), Set(Row(1, 2), Row(3, 4), Row(3, null))),
-      Literal(TArray(structT1), FastSeq(Row(3, 4), Row(1, 2), Row(3, null))),
+      Literal(TSet(structT1), Set(RowSeq(1, 2), RowSeq(3, 4), RowSeq(3, null))),
+      Literal(TArray(structT1), FastSeq(RowSeq(3, 4), RowSeq(1, 2), RowSeq(3, null))),
       Literal(
         TDict(structT1, TString),
-        Map(Row(1, 2) -> "foo", Row(3, 4) -> "bar", Row(3, null) -> "baz"),
+        Map(RowSeq(1, 2) -> "foo", RowSeq(3, 4) -> "bar", RowSeq(3, null) -> "baz"),
       ),
     ).foreach { lit =>
       fullKeyRefs.foreach { k =>
         check(
           invoke("contains", TBoolean, lit, k),
           IndexedSeq(
-            Interval(Row(1, 2), Row(1, 2), true, true),
-            Interval(Row(3, 4), Row(3, 4), true, true),
-            Interval(Row(3, null), Row(3, null), true, true),
+            Interval(RowSeq(1, 2), RowSeq(1, 2), true, true),
+            Interval(RowSeq(3, 4), RowSeq(3, 4), true, true),
+            Interval(RowSeq(3, null), RowSeq(3, null), true, true),
           ),
           IndexedSeq(
-            Interval(Row(), Row(1, 2), true, false),
-            Interval(Row(1, 2), Row(3, 4), false, false),
-            Interval(Row(3, 4), Row(3, null), false, false),
-            Interval(Row(3, null), Row(), false, true),
+            Interval(RowSeq(), RowSeq(1, 2), true, false),
+            Interval(RowSeq(1, 2), RowSeq(3, 4), false, false),
+            Interval(RowSeq(3, 4), RowSeq(3, null), false, false),
+            Interval(RowSeq(3, null), RowSeq(), false, true),
           ),
           IndexedSeq(),
         )
@@ -359,22 +360,25 @@ class ExtractIntervalFiltersSuite {
     }
 
     Array(
-      Literal(TSet(structT2), Set(Row(1), Row(3), Row(null))),
-      Literal(TArray(structT2), FastSeq(Row(3), Row(null), Row(1))),
-      Literal(TDict(structT2, TString), Map(Row(1) -> "foo", Row(null) -> "baz", Row(3) -> "bar")),
+      Literal(TSet(structT2), Set(RowSeq(1), RowSeq(3), RowSeq(null))),
+      Literal(TArray(structT2), FastSeq(RowSeq(3), RowSeq(null), RowSeq(1))),
+      Literal(
+        TDict(structT2, TString),
+        Map(RowSeq(1) -> "foo", RowSeq(null) -> "baz", RowSeq(3) -> "bar"),
+      ),
     ).foreach { lit =>
       prefixKeyRefs.foreach { k =>
         check(
           invoke("contains", TBoolean, lit, k),
           IndexedSeq(
-            Interval(Row(1), Row(1), true, true),
-            Interval(Row(3), Row(3), true, true),
-            Interval(Row(null), Row(), true, true),
+            Interval(RowSeq(1), RowSeq(1), true, true),
+            Interval(RowSeq(3), RowSeq(3), true, true),
+            Interval(RowSeq(null), RowSeq(), true, true),
           ),
           IndexedSeq(
-            Interval(Row(), Row(1), true, false),
-            Interval(Row(1), Row(3), false, false),
-            Interval(Row(3), Row(null), false, false),
+            Interval(RowSeq(), RowSeq(1), true, false),
+            Interval(RowSeq(1), RowSeq(3), false, false),
+            Interval(RowSeq(3), RowSeq(null), false, false),
           ),
           IndexedSeq(),
         )
@@ -385,11 +389,11 @@ class ExtractIntervalFiltersSuite {
   @Test def testIntervalContains(implicit ctx: ExecuteContext): Unit = {
     val interval = Interval(1, 5, false, true)
     val testRows = FastSeq(
-      Row(0, 0, true),
-      Row(0, 1, true),
-      Row(0, 5, true),
-      Row(0, 10, true),
-      Row(0, null, true),
+      RowSeq(0, 0, true),
+      RowSeq(0, 1, true),
+      RowSeq(0, 5, true),
+      RowSeq(0, 10, true),
+      RowSeq(0, null, true),
     )
 
     val ir = invoke("contains", TBoolean, Literal(TInterval(TInt32), interval), k1)
@@ -398,18 +402,18 @@ class ExtractIntervalFiltersSuite {
       ref1,
       k1Full,
       testRows,
-      FastSeq(Interval(Row(1), Row(5), false, true)),
+      FastSeq(Interval(RowSeq(1), RowSeq(5), false, true)),
       FastSeq(
-        Interval(Row(), Row(1), true, true),
-        Interval(Row(5), Row(null), false, false),
+        Interval(RowSeq(), RowSeq(1), true, true),
+        Interval(RowSeq(5), RowSeq(null), false, false),
       ),
-      FastSeq(Interval(Row(null), Row(), true, true)),
+      FastSeq(Interval(RowSeq(null), RowSeq(), true, true)),
     )
   }
 
   @Test def testIntervalContainsStruct(implicit ctx: ExecuteContext): Unit = {
-    val fullInterval = Interval(Row(1, 1), Row(2, 2), false, true)
-    val prefixInterval = Interval(Row(1), Row(2), false, true)
+    val fullInterval = Interval(RowSeq(1, 1), RowSeq(2, 2), false, true)
+    val prefixInterval = Interval(RowSeq(1), RowSeq(2), false, true)
 
     def check(
       node: IR,
@@ -418,17 +422,17 @@ class ExtractIntervalFiltersSuite {
       naIntervals: IndexedSeq[Interval],
     ): Unit = {
       val testRows = FastSeq(
-        Row(0, null, 0),
-        Row(0, 0, 0),
-        Row(0, 0, null),
-        Row(0, 1, 0),
-        Row(0, 1, 1),
-        Row(0, 1, null),
-        Row(0, 2, 1),
-        Row(0, 2, 2),
-        Row(0, 2, null),
-        Row(0, 3, 0),
-        Row(0, null, null),
+        RowSeq(0, null, 0),
+        RowSeq(0, 0, 0),
+        RowSeq(0, 0, null),
+        RowSeq(0, 1, 0),
+        RowSeq(0, 1, 1),
+        RowSeq(0, 1, null),
+        RowSeq(0, 2, 1),
+        RowSeq(0, 2, 2),
+        RowSeq(0, 2, null),
+        RowSeq(0, 3, 0),
+        RowSeq(0, null, null),
       )
       checkAll(
         node,
@@ -446,8 +450,8 @@ class ExtractIntervalFiltersSuite {
         invoke("contains", TBoolean, Literal(TInterval(structT1), fullInterval), k),
         FastSeq(fullInterval),
         FastSeq(
-          Interval(Row(), Row(1, 1), true, true),
-          Interval(Row(2, 2), Row(), false, true),
+          Interval(RowSeq(), RowSeq(1, 1), true, true),
+          Interval(RowSeq(2, 2), RowSeq(), false, true),
         ),
         FastSeq(),
       )
@@ -458,8 +462,8 @@ class ExtractIntervalFiltersSuite {
         invoke("contains", TBoolean, Literal(TInterval(structT2), prefixInterval), k),
         FastSeq(prefixInterval),
         FastSeq(
-          Interval(Row(), Row(1), true, true),
-          Interval(Row(2), Row(), false, true),
+          Interval(RowSeq(), RowSeq(1), true, true),
+          Interval(RowSeq(2), RowSeq(), false, true),
         ),
         FastSeq(),
       )
@@ -474,21 +478,26 @@ class ExtractIntervalFiltersSuite {
     val ir2 = eq(invoke("contig", TString, k), Str("chr2"))
 
     val testRows = FastSeq(
-      Row(Locus("chr1", 5)),
-      Row(Locus("chr2", 1)),
-      Row(Locus("chr2", 1000)),
-      Row(Locus("chr3", 5)),
-      Row(null),
+      RowSeq(Locus("chr1", 5)),
+      RowSeq(Locus("chr2", 1)),
+      RowSeq(Locus("chr2", 1000)),
+      RowSeq(Locus("chr3", 5)),
+      RowSeq(null),
     )
 
     val trueIntervals = FastSeq(
-      Interval(Row(Locus("chr2", 1)), Row(Locus("chr2", grch38.contigLength("chr2"))), true, false)
+      Interval(
+        RowSeq(Locus("chr2", 1)),
+        RowSeq(Locus("chr2", grch38.contigLength("chr2"))),
+        true,
+        false,
+      )
     )
     val falseIntervals = FastSeq(
-      Interval(Row(), Row(Locus("chr2", 1)), true, false),
-      Interval(Row(Locus("chr2", grch38.contigLength("chr2"))), Row(null), true, false),
+      Interval(RowSeq(), RowSeq(Locus("chr2", 1)), true, false),
+      Interval(RowSeq(Locus("chr2", grch38.contigLength("chr2"))), RowSeq(null), true, false),
     )
-    val naIntervals = FastSeq(Interval(Row(null), Row(), true, true))
+    val naIntervals = FastSeq(Interval(RowSeq(null), RowSeq(), true, true))
 
     checkAll(ir1, ref, ref, testRows, trueIntervals, falseIntervals, naIntervals)
     checkAll(ir2, ref, ref, testRows, trueIntervals, falseIntervals, naIntervals)
@@ -517,15 +526,15 @@ class ExtractIntervalFiltersSuite {
       val naIntervals = ExtractIntervalFilters.liftPosIntervalsToLocus(naPosIntervals, grch38, ctx)
 
       val testRows = FastSeq(
-        Row(Locus("chr1", 1)),
-        Row(Locus("chr1", 5)),
-        Row(Locus("chr1", 100)),
-        Row(Locus("chr1", 105)),
-        Row(Locus("chr2", 1)),
-        Row(Locus("chr2", 5)),
-        Row(Locus("chr2", 100)),
-        Row(Locus("chr3", 105)),
-        Row(null),
+        RowSeq(Locus("chr1", 1)),
+        RowSeq(Locus("chr1", 5)),
+        RowSeq(Locus("chr1", 100)),
+        RowSeq(Locus("chr1", 105)),
+        RowSeq(Locus("chr2", 1)),
+        RowSeq(Locus("chr2", 5)),
+        RowSeq(Locus("chr2", 100)),
+        RowSeq(Locus("chr3", 105)),
+        RowSeq(null),
       )
 
       checkAll(
@@ -569,58 +578,58 @@ class ExtractIntervalFiltersSuite {
     check(
       GT,
       100,
-      FastSeq(Interval(Row(100), Row(null), false, false)),
-      FastSeq(Interval(Row(), Row(100), true, true)),
-      FastSeq(Interval(Row(null), Row(), true, true)),
+      FastSeq(Interval(RowSeq(100), RowSeq(null), false, false)),
+      FastSeq(Interval(RowSeq(), RowSeq(100), true, true)),
+      FastSeq(Interval(RowSeq(null), RowSeq(), true, true)),
     )
     check(
       GT,
       -1000,
-      FastSeq(Interval(Row(1), Row(null), true, false)),
+      FastSeq(Interval(RowSeq(1), RowSeq(null), true, false)),
       FastSeq(),
-      FastSeq(Interval(Row(null), Row(), true, true)),
+      FastSeq(Interval(RowSeq(null), RowSeq(), true, true)),
     )
 
     check(
       LT,
       100,
-      FastSeq(Interval(Row(), Row(100), true, false)),
-      FastSeq(Interval(Row(100), Row(null), true, false)),
-      FastSeq(Interval(Row(null), Row(), true, true)),
+      FastSeq(Interval(RowSeq(), RowSeq(100), true, false)),
+      FastSeq(Interval(RowSeq(100), RowSeq(null), true, false)),
+      FastSeq(Interval(RowSeq(null), RowSeq(), true, true)),
     )
     check(
       LT,
       -1000,
       FastSeq(),
-      FastSeq(Interval(Row(), Row(null), true, false)),
-      FastSeq(Interval(Row(null), Row(), true, true)),
+      FastSeq(Interval(RowSeq(), RowSeq(null), true, false)),
+      FastSeq(Interval(RowSeq(null), RowSeq(), true, true)),
     )
 
     check(
       EQ,
       100,
-      FastSeq(Interval(Row(100), Row(100), true, true)),
+      FastSeq(Interval(RowSeq(100), RowSeq(100), true, true)),
       FastSeq(
-        Interval(Row(), Row(100), true, false),
-        Interval(Row(100), Row(null), false, false),
+        Interval(RowSeq(), RowSeq(100), true, false),
+        Interval(RowSeq(100), RowSeq(null), false, false),
       ),
-      FastSeq(Interval(Row(null), Row(), true, true)),
+      FastSeq(Interval(RowSeq(null), RowSeq(), true, true)),
     )
     check(
       EQ,
       -1000,
       FastSeq(),
-      FastSeq(Interval(Row(), Row(null), true, false)),
-      FastSeq(Interval(Row(null), Row(), true, true)),
+      FastSeq(Interval(RowSeq(), RowSeq(null), true, false)),
+      FastSeq(Interval(RowSeq(null), RowSeq(), true, true)),
     )
 
     check(
       EQWithNA,
       100,
-      FastSeq(Interval(Row(100), Row(100), true, true)),
+      FastSeq(Interval(RowSeq(100), RowSeq(100), true, true)),
       FastSeq(
-        Interval(Row(), Row(100), true, false),
-        Interval(Row(100), Row(), false, true),
+        Interval(RowSeq(), RowSeq(100), true, false),
+        Interval(RowSeq(100), RowSeq(), false, true),
       ),
       FastSeq(),
     )
@@ -628,7 +637,7 @@ class ExtractIntervalFiltersSuite {
       EQWithNA,
       -1000,
       FastSeq(),
-      FastSeq(Interval(Row(), Row(), true, true)),
+      FastSeq(Interval(RowSeq(), RowSeq(), true, true)),
       FastSeq(),
     )
 
@@ -652,10 +661,10 @@ class ExtractIntervalFiltersSuite {
       naIntervals: IndexedSeq[Interval],
     ): Unit = {
       val testRows = FastSeq(
-        Row(Locus("chr1", 5)),
-        Row(Locus("chr2", 1)),
-        Row(Locus("chr10", 5)),
-        Row(null),
+        RowSeq(Locus("chr1", 5)),
+        RowSeq(Locus("chr2", 1)),
+        RowSeq(Locus("chr10", 5)),
+        RowSeq(null),
       )
       checkAll(node, ref, ref, testRows, trueIntervals, falseIntervals, naIntervals)
     }
@@ -672,35 +681,35 @@ class ExtractIntervalFiltersSuite {
         invoke("contains", TBoolean, lit, contig),
         FastSeq(
           Interval(
-            Row(Locus("chr1", 1)),
-            Row(Locus("chr1", grch38.contigLength("chr1"))),
+            RowSeq(Locus("chr1", 1)),
+            RowSeq(Locus("chr1", grch38.contigLength("chr1"))),
             true,
             false,
           ),
           Interval(
-            Row(Locus("chr10", 1)),
-            Row(Locus("chr10", grch38.contigLength("chr10"))),
+            RowSeq(Locus("chr10", 1)),
+            RowSeq(Locus("chr10", grch38.contigLength("chr10"))),
             true,
             false,
           ),
-          Interval(Row(null), Row(), true, true),
+          Interval(RowSeq(null), RowSeq(), true, true),
         ),
         FastSeq(
           Interval(
-            Row(),
-            Row(Locus("chr1", 1)),
+            RowSeq(),
+            RowSeq(Locus("chr1", 1)),
             true,
             false,
           ),
           Interval(
-            Row(Locus("chr1", grch38.contigLength("chr1"))),
-            Row(Locus("chr10", 1)),
+            RowSeq(Locus("chr1", grch38.contigLength("chr1"))),
+            RowSeq(Locus("chr10", 1)),
             true,
             false,
           ),
           Interval(
-            Row(Locus("chr10", grch38.contigLength("chr10"))),
-            Row(null),
+            RowSeq(Locus("chr10", grch38.contigLength("chr10"))),
+            RowSeq(null),
             true,
             false,
           ),
@@ -718,34 +727,34 @@ class ExtractIntervalFiltersSuite {
         invoke("contains", TBoolean, lit, contig),
         FastSeq(
           Interval(
-            Row(Locus("chr1", 1)),
-            Row(Locus("chr1", grch38.contigLength("chr1"))),
+            RowSeq(Locus("chr1", 1)),
+            RowSeq(Locus("chr1", grch38.contigLength("chr1"))),
             true,
             false,
           ),
           Interval(
-            Row(Locus("chr10", 1)),
-            Row(Locus("chr10", grch38.contigLength("chr10"))),
+            RowSeq(Locus("chr10", 1)),
+            RowSeq(Locus("chr10", grch38.contigLength("chr10"))),
             true,
             false,
           ),
         ),
         FastSeq(
           Interval(
-            Row(),
-            Row(Locus("chr1", 1)),
+            RowSeq(),
+            RowSeq(Locus("chr1", 1)),
             true,
             false,
           ),
           Interval(
-            Row(Locus("chr1", grch38.contigLength("chr1"))),
-            Row(Locus("chr10", 1)),
+            RowSeq(Locus("chr1", grch38.contigLength("chr1"))),
+            RowSeq(Locus("chr10", 1)),
             true,
             false,
           ),
           Interval(
-            Row(Locus("chr10", grch38.contigLength("chr10"))),
-            Row(),
+            RowSeq(Locus("chr10", grch38.contigLength("chr10"))),
+            RowSeq(),
             true,
             true,
           ),
@@ -775,18 +784,18 @@ class ExtractIntervalFiltersSuite {
       naIntervals: IndexedSeq[Interval],
     ): Unit = {
       val testRows = FastSeq(
-        Row(0, -15, true),
-        Row(0, -10, true),
-        Row(0, -5, true),
-        Row(0, 0, true),
-        Row(0, 5, true),
-        Row(0, 10, true),
-        Row(0, 15, true),
-        Row(0, 20, true),
-        Row(0, 22, true),
-        Row(0, 25, true),
-        Row(0, 30, true),
-        Row(0, null, true),
+        RowSeq(0, -15, true),
+        RowSeq(0, -10, true),
+        RowSeq(0, -5, true),
+        RowSeq(0, 0, true),
+        RowSeq(0, 5, true),
+        RowSeq(0, 10, true),
+        RowSeq(0, 15, true),
+        RowSeq(0, 20, true),
+        RowSeq(0, 22, true),
+        RowSeq(0, 25, true),
+        RowSeq(0, 30, true),
+        RowSeq(0, null, true),
       )
       checkAll(node, ref1, k1Full, testRows, trueIntervals, falseIntervals, naIntervals)
     }
@@ -799,15 +808,15 @@ class ExtractIntervalFiltersSuite {
     check(
       containsKey(inIntervals),
       FastSeq(
-        Interval(Row(-10), Row(10), true, false),
-        Interval(Row(20), Row(25), true, false),
+        Interval(RowSeq(-10), RowSeq(10), true, false),
+        Interval(RowSeq(20), RowSeq(25), true, false),
       ),
       FastSeq(
-        Interval(Row(), Row(-10), true, false),
-        Interval(Row(10), Row(20), true, false),
-        Interval(Row(25), Row(null), true, false),
+        Interval(RowSeq(), RowSeq(-10), true, false),
+        Interval(RowSeq(10), RowSeq(20), true, false),
+        Interval(RowSeq(25), RowSeq(null), true, false),
       ),
-      FastSeq(Interval(Row(null), Row(), true, true)),
+      FastSeq(Interval(RowSeq(null), RowSeq(), true, true)),
     )
 
     // Whenever the previous would be false, this is instead missing, because of the null
@@ -815,14 +824,14 @@ class ExtractIntervalFiltersSuite {
     check(
       containsKey(inIntervalsWithNull),
       FastSeq(
-        Interval(Row(-10), Row(10), true, false),
-        Interval(Row(20), Row(25), true, false),
+        Interval(RowSeq(-10), RowSeq(10), true, false),
+        Interval(RowSeq(20), RowSeq(25), true, false),
       ),
       FastSeq(),
       FastSeq(
-        Interval(Row(), Row(-10), true, false),
-        Interval(Row(10), Row(20), true, false),
-        Interval(Row(25), Row(), true, true),
+        Interval(RowSeq(), RowSeq(-10), true, false),
+        Interval(RowSeq(10), RowSeq(20), true, false),
+        Interval(RowSeq(25), RowSeq(), true, true),
       ),
     )
   }
@@ -838,18 +847,18 @@ class ExtractIntervalFiltersSuite {
       naResidual: IR = True(),
     ): Unit = {
       val testRows = FastSeq(
-        Row(0, 0, true),
-        Row(0, 0, false),
-        Row(0, 5, true),
-        Row(0, 5, false),
-        Row(0, 7, true),
-        Row(0, 7, false),
-        Row(0, 10, true),
-        Row(0, 10, false),
-        Row(0, 15, true),
-        Row(0, 15, false),
-        Row(0, null, true),
-        Row(0, null, false),
+        RowSeq(0, 0, true),
+        RowSeq(0, 0, false),
+        RowSeq(0, 5, true),
+        RowSeq(0, 5, false),
+        RowSeq(0, 7, true),
+        RowSeq(0, 7, false),
+        RowSeq(0, 10, true),
+        RowSeq(0, 10, false),
+        RowSeq(0, 15, true),
+        RowSeq(0, 15, false),
+        RowSeq(0, null, true),
+        RowSeq(0, null, false),
       )
       checkAll(node, ref1, k1Full, testRows, trueIntervals, falseIntervals, naIntervals,
         trueResidual, falseResidual, naResidual)
@@ -861,22 +870,22 @@ class ExtractIntervalFiltersSuite {
     check(
       or(lt5, gt10),
       FastSeq(
-        Interval(Row(), Row(5), true, false),
-        Interval(Row(10), Row(null), false, false),
+        Interval(RowSeq(), RowSeq(5), true, false),
+        Interval(RowSeq(10), RowSeq(null), false, false),
       ),
-      FastSeq(Interval(Row(5), Row(10), true, true)),
-      FastSeq(Interval(Row(null), Row(), true, true)),
+      FastSeq(Interval(RowSeq(5), RowSeq(10), true, true)),
+      FastSeq(Interval(RowSeq(null), RowSeq(), true, true)),
     )
 
     check(
       or(lt5, unknownBool),
       // could be true anywhere, since unknownBool might be true
-      FastSeq(Interval(Row(), Row(), true, true)),
+      FastSeq(Interval(RowSeq(), RowSeq(), true, true)),
       // can only be false if lt5 is false
-      FastSeq(Interval(Row(5), Row(null), true, false)),
+      FastSeq(Interval(RowSeq(5), RowSeq(null), true, false)),
       // can only be missing if lt5 is missing (and unknown is false or missing),
       // or if lt5 is false (and unknown is missing)
-      FastSeq(Interval(Row(5), Row(), true, true)),
+      FastSeq(Interval(RowSeq(5), RowSeq(), true, true)),
       // we've filtered to the rows where lt5 is false
       falseResidual = not(or(False(), unknownBool)),
       // we've filtered to where lt5 is false or missing, so can't simplify
@@ -885,9 +894,12 @@ class ExtractIntervalFiltersSuite {
 
     check(
       and(not(or(lt5, unknownBool)), not(or(gt10, unknownBool))),
-      FastSeq(Interval(Row(5), Row(10), true, true)),
-      FastSeq(Interval(Row(), Row(), true, true)),
-      FastSeq(Interval(Row(5), Row(10), true, true), Interval(Row(null), Row(), true, true)),
+      FastSeq(Interval(RowSeq(5), RowSeq(10), true, true)),
+      FastSeq(Interval(RowSeq(), RowSeq(), true, true)),
+      FastSeq(
+        Interval(RowSeq(5), RowSeq(10), true, true),
+        Interval(RowSeq(null), RowSeq(), true, true),
+      ),
       trueResidual = and(
         not(or(False(), unknownBool)),
         not(or(False(), unknownBool)),
@@ -910,18 +922,18 @@ class ExtractIntervalFiltersSuite {
       naResidual: IR = True(),
     ): Unit = {
       val testRows = FastSeq(
-        Row(0, 0, true),
-        Row(0, 0, false),
-        Row(0, 5, true),
-        Row(0, 5, false),
-        Row(0, 7, true),
-        Row(0, 7, false),
-        Row(0, 10, true),
-        Row(0, 10, false),
-        Row(0, 15, true),
-        Row(0, 15, false),
-        Row(0, null, true),
-        Row(0, null, false),
+        RowSeq(0, 0, true),
+        RowSeq(0, 0, false),
+        RowSeq(0, 5, true),
+        RowSeq(0, 5, false),
+        RowSeq(0, 7, true),
+        RowSeq(0, 7, false),
+        RowSeq(0, 10, true),
+        RowSeq(0, 10, false),
+        RowSeq(0, 15, true),
+        RowSeq(0, 15, false),
+        RowSeq(0, null, true),
+        RowSeq(0, null, false),
       )
       checkAll(node, ref1, k1Full, testRows, trueIntervals, falseIntervals, naIntervals,
         trueResidual, falseResidual, naResidual)
@@ -932,23 +944,23 @@ class ExtractIntervalFiltersSuite {
 
     check(
       and(gt5, lt10),
-      FastSeq(Interval(Row(5), Row(10), false, false)),
+      FastSeq(Interval(RowSeq(5), RowSeq(10), false, false)),
       FastSeq(
-        Interval(Row(), Row(5), true, true),
-        Interval(Row(10), Row(null), true, false),
+        Interval(RowSeq(), RowSeq(5), true, true),
+        Interval(RowSeq(10), RowSeq(null), true, false),
       ),
-      FastSeq(Interval(Row(null), Row(), true, true)),
+      FastSeq(Interval(RowSeq(null), RowSeq(), true, true)),
     )
 
     check(
       and(gt5, unknownBool),
       // can only be true if gt5 is true
-      FastSeq(Interval(Row(5), Row(null), false, false)),
+      FastSeq(Interval(RowSeq(5), RowSeq(null), false, false)),
       // could be false anywhere, since unknownBool might be false
-      FastSeq(Interval(Row(), Row(), true, true)),
+      FastSeq(Interval(RowSeq(), RowSeq(), true, true)),
       // can only be missing if gt5 is missing (and unknown is true or missing),
       // or if gt5 is true (and unknown is missing)
-      FastSeq(Interval(Row(5), Row(), false, true)),
+      FastSeq(Interval(RowSeq(5), RowSeq(), false, true)),
       // we've filtered to the rows where gt5 is true
       trueResidual = and(True(), unknownBool),
       // we've filtered to where gt5 is false or missing, so can't simplify
@@ -967,12 +979,12 @@ class ExtractIntervalFiltersSuite {
       naResidual: IR = True(),
     ): Unit = {
       val testRows = FastSeq(
-        Row(0, 0, true),
-        Row(0, 5, true),
-        Row(0, 7, true),
-        Row(0, 10, true),
-        Row(0, 15, true),
-        Row(0, null, true),
+        RowSeq(0, 0, true),
+        RowSeq(0, 5, true),
+        RowSeq(0, 7, true),
+        RowSeq(0, 10, true),
+        RowSeq(0, 15, true),
+        RowSeq(0, null, true),
       )
       checkAll(node, ref1, k1Full, testRows, trueIntervals, falseIntervals, naIntervals,
         trueResidual, falseResidual, naResidual)
@@ -983,10 +995,10 @@ class ExtractIntervalFiltersSuite {
 
     check(
       Coalesce(FastSeq(gt5, lt10, False())),
-      FastSeq(Interval(Row(5), Row(null), false, false)),
+      FastSeq(Interval(RowSeq(5), RowSeq(null), false, false)),
       FastSeq(
-        Interval(Row(), Row(5), true, true),
-        Interval(Row(null), Row(), true, true),
+        Interval(RowSeq(), RowSeq(5), true, true),
+        Interval(RowSeq(null), RowSeq(), true, true),
       ),
       FastSeq(),
     )
@@ -1003,12 +1015,12 @@ class ExtractIntervalFiltersSuite {
       naResidual: IR = True(),
     ): Unit = {
       val testRows = FastSeq(
-        Row(0, 0, true),
-        Row(0, 5, true),
-        Row(0, 7, true),
-        Row(0, 10, true),
-        Row(0, 15, true),
-        Row(0, null, true),
+        RowSeq(0, 0, true),
+        RowSeq(0, 5, true),
+        RowSeq(0, 7, true),
+        RowSeq(0, 10, true),
+        RowSeq(0, 15, true),
+        RowSeq(0, null, true),
       )
       checkAll(node, ref1, k1Full, testRows, trueIntervals, falseIntervals, naIntervals,
         trueResidual, falseResidual, naResidual)
@@ -1016,12 +1028,12 @@ class ExtractIntervalFiltersSuite {
 
     check(
       If(gt(k1, I32(0)), lt(k1, I32(5)), gt(k1, I32(-5))),
-      FastSeq(Interval(Row(-5), Row(5), false, false)),
+      FastSeq(Interval(RowSeq(-5), RowSeq(5), false, false)),
       FastSeq(
-        Interval(Row(), Row(-5), true, true),
-        Interval(Row(5), Row(null), true, false),
+        Interval(RowSeq(), RowSeq(-5), true, true),
+        Interval(RowSeq(5), RowSeq(null), true, false),
       ),
-      FastSeq(Interval(Row(null), Row(), true, true)),
+      FastSeq(Interval(RowSeq(null), RowSeq(), true, true)),
     )
   }
 
@@ -1036,15 +1048,15 @@ class ExtractIntervalFiltersSuite {
       naResidual: IR = True(),
     ): Unit = {
       val testRows = FastSeq(
-        Row(0, 0, true),
-        Row(0, 5, true),
-        Row(0, -5, true),
-        Row(0, null, true),
-        Row(1, 0, true),
-        Row(1, 5, true),
-        Row(1, -5, true),
-        Row(1, null, true),
-        Row(null, null, true),
+        RowSeq(0, 0, true),
+        RowSeq(0, 5, true),
+        RowSeq(0, -5, true),
+        RowSeq(0, null, true),
+        RowSeq(1, 0, true),
+        RowSeq(1, 5, true),
+        RowSeq(1, -5, true),
+        RowSeq(1, null, true),
+        RowSeq(null, null, true),
       )
       checkAll(node, ref1, k1Full, testRows, trueIntervals, falseIntervals, naIntervals,
         trueResidual, falseResidual, naResidual)
@@ -1052,24 +1064,27 @@ class ExtractIntervalFiltersSuite {
 
     check(
       Switch(I32(0), gt(k1, I32(-5)), FastSeq(lt(k1, I32(5)))),
-      FastSeq(Interval(Row(), Row(5), true, false)),
-      FastSeq(Interval(Row(5), Row(null), true, false)),
-      FastSeq(Interval(Row(null), Row(), true, true)),
+      FastSeq(Interval(RowSeq(), RowSeq(5), true, false)),
+      FastSeq(Interval(RowSeq(5), RowSeq(null), true, false)),
+      FastSeq(Interval(RowSeq(null), RowSeq(), true, true)),
     )
 
     check(
       Switch(I32(-1), gt(k1, I32(-5)), FastSeq(lt(k1, I32(5)))),
-      FastSeq(Interval(Row(-5), Row(null), false, false)),
-      FastSeq(Interval(Row(), Row(-5), true, true)),
-      FastSeq(Interval(Row(null), Row(), true, true)),
+      FastSeq(Interval(RowSeq(-5), RowSeq(null), false, false)),
+      FastSeq(Interval(RowSeq(), RowSeq(-5), true, true)),
+      FastSeq(Interval(RowSeq(null), RowSeq(), true, true)),
     )
 
     val filter = Switch(GetField(ref1, "w"), gt(k1, I32(-5)), FastSeq(lt(k1, I32(5))))
     check(
       filter,
-      FastSeq(Interval(Row(), Row(null), true, false)),
-      FastSeq(Interval(Row(), Row(-5), true, true), Interval(Row(5), Row(null), true, false)),
-      FastSeq(Interval(Row(), Row(), true, true)),
+      FastSeq(Interval(RowSeq(), RowSeq(null), true, false)),
+      FastSeq(
+        Interval(RowSeq(), RowSeq(-5), true, true),
+        Interval(RowSeq(5), RowSeq(null), true, false),
+      ),
+      FastSeq(Interval(RowSeq(), RowSeq(), true, true)),
       trueResidual = filter,
       falseResidual = ApplyUnaryPrimOp(Bang, filter),
       naResidual = IsNA(filter),
@@ -1078,10 +1093,10 @@ class ExtractIntervalFiltersSuite {
 
   @Test def testRelationalChildren(implicit ctx: ExecuteContext): Unit = {
     val testRows = FastSeq(
-      Row(0, 0, true),
-      Row(0, 10, true),
-      Row(0, 20, true),
-      Row(0, null, true),
+      RowSeq(0, 0, true),
+      RowSeq(0, 10, true),
+      RowSeq(0, 20, true),
+      RowSeq(0, null, true),
     )
 
     val count = TableAggregate(
@@ -1090,7 +1105,7 @@ class ExtractIntervalFiltersSuite {
     )
     print(count.typ)
     val filter = gt(count, Cast(k1, TInt64))
-    check(filter, ref1, k1Full, testRows, filter, FastSeq(Interval(Row(), Row(), true, true)))
+    check(filter, ref1, k1Full, testRows, filter, FastSeq(Interval(RowSeq(), RowSeq(), true, true)))
   }
 
   @Test def testIntegration(implicit ctx: ExecuteContext): Unit = {

--- a/hail/hail/test/src/is/hail/expr/ir/IRSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/IRSuite.scala
@@ -3,7 +3,7 @@ package is.hail.expr.ir
 import is.hail.{ExecStrategy, ParameterizedTest}
 import is.hail.ExecStrategy.ExecStrategy
 import is.hail.TestUtils._
-import is.hail.annotations.{BroadcastRow, ExtendedOrdering, SafeNDArray}
+import is.hail.annotations.{BroadcastRow, ExtendedOrdering, RowSeq, SafeNDArray}
 import is.hail.backend.ExecuteContext
 import is.hail.collection.{FastSeq, IntArrayBuilder}
 import is.hail.collection.compat.immutable.ArraySeq
@@ -106,13 +106,16 @@ class IRSuite {
   }
 
   @Test def testCastRename(implicit ctx: ExecuteContext): Unit = {
-    assertEvalsTo(CastRename(MakeStruct(FastSeq(("x", I32(1)))), TStruct("foo" -> TInt32)), Row(1))
+    assertEvalsTo(
+      CastRename(MakeStruct(FastSeq(("x", I32(1)))), TStruct("foo" -> TInt32)),
+      RowSeq(1),
+    )
     assertEvalsTo(
       CastRename(
         MakeArray(FastSeq(MakeStruct(FastSeq(("x", I32(1))))), TArray(TStruct("x" -> TInt32))),
         TArray(TStruct("foo" -> TInt32)),
       ),
-      FastSeq(Row(1)),
+      FastSeq(RowSeq(1)),
     )
   }
 
@@ -1280,8 +1283,11 @@ class IRSuite {
   }
 
   @Test def testMakeStruct(implicit ctx: ExecuteContext): Unit = {
-    assertEvalsTo(MakeStruct(FastSeq()), Row())
-    assertEvalsTo(MakeStruct(FastSeq("a" -> NA(TInt32), "b" -> 4, "c" -> 0.5)), Row(null, 4, 0.5))
+    assertEvalsTo(MakeStruct(FastSeq()), RowSeq())
+    assertEvalsTo(
+      MakeStruct(FastSeq("a" -> NA(TInt32), "b" -> 4, "c" -> 0.5)),
+      RowSeq(null, 4, 0.5),
+    )
     // making sure wide structs get emitted without failure
     assertEvalsTo(GetField(MakeStruct((0 until 20000).map(i => s"foo$i" -> I32(1))), "foo1"), 1)
   }
@@ -1294,7 +1300,7 @@ class IRSuite {
       "b" -> PCanonicalArray(PInt32(), true),
     ))
 
-    val value = Row(2, FastSeq(1))
+    val value = RowSeq(2, FastSeq(1))
     assertEvalsTo(
       MakeArray(
         In(0, SingleCodeEmitParamType(true, PTypeReferenceSingleCodeType(pt1.elementType))),
@@ -1306,8 +1312,8 @@ class IRSuite {
   }
 
   @Test def testMakeTuple(implicit ctx: ExecuteContext): Unit = {
-    assertEvalsTo(MakeTuple.ordered(FastSeq()), Row())
-    assertEvalsTo(MakeTuple.ordered(FastSeq(NA(TInt32), 4, 0.5)), Row(null, 4, 0.5))
+    assertEvalsTo(MakeTuple.ordered(FastSeq()), RowSeq())
+    assertEvalsTo(MakeTuple.ordered(FastSeq(NA(TInt32), 4, 0.5)), RowSeq(null, 4, 0.5))
     // making sure wide structs get emitted without failure
     assertEvalsTo(GetTupleElement(MakeTuple.ordered((0 until 20000).map(I32)), 1), 1)
   }
@@ -1465,7 +1471,7 @@ class IRSuite {
       CastToArray(In(0, t)),
       // wtf you can't do null -> ...
       FastSeq((d, t)),
-      FastSeq(Row(1, "a"), Row(2, null), Row(null, "c")),
+      FastSeq(RowSeq(1, "a"), RowSeq(2, null), RowSeq(null, "c")),
     )
   }
 
@@ -1718,11 +1724,11 @@ class IRSuite {
     assertEvalsTo(
       toNestedArray(group(a)),
       FastSeq(
-        FastSeq(Row(3, 1), Row(3, 3)),
-        FastSeq(Row(null, -1)),
-        FastSeq(Row(null, -2)),
-        FastSeq(Row(1, 2), Row(1, 4), Row(1, 6)),
-        FastSeq(Row(4, null)),
+        FastSeq(RowSeq(3, 1), RowSeq(3, 3)),
+        FastSeq(RowSeq(null, -1)),
+        FastSeq(RowSeq(null, -2)),
+        FastSeq(RowSeq(1, 2), RowSeq(1, 4), RowSeq(1, 6)),
+        FastSeq(RowSeq(4, null)),
       ),
     )
     assertEvalsTo(toNestedArray(group(MakeStream(IndexedSeq(), TStream(structType)))), FastSeq())
@@ -1736,21 +1742,21 @@ class IRSuite {
     assertEvalsTo(
       toNestedArray(takeFromEach(a, I32(1))),
       FastSeq(
-        FastSeq(Row(3, 1)),
-        FastSeq(Row(null, -1)),
-        FastSeq(Row(null, -2)),
-        FastSeq(Row(1, 2)),
-        FastSeq(Row(4, null)),
+        FastSeq(RowSeq(3, 1)),
+        FastSeq(RowSeq(null, -1)),
+        FastSeq(RowSeq(null, -2)),
+        FastSeq(RowSeq(1, 2)),
+        FastSeq(RowSeq(4, null)),
       ),
     )
     assertEvalsTo(
       toNestedArray(takeFromEach(a, I32(2))),
       FastSeq(
-        FastSeq(Row(3, 1), Row(3, 3)),
-        FastSeq(Row(null, -1)),
-        FastSeq(Row(null, -2)),
-        FastSeq(Row(1, 2), Row(1, 4)),
-        FastSeq(Row(4, null)),
+        FastSeq(RowSeq(3, 1), RowSeq(3, 3)),
+        FastSeq(RowSeq(null, -1)),
+        FastSeq(RowSeq(null, -2)),
+        FastSeq(RowSeq(1, 2), RowSeq(1, 4)),
+        FastSeq(RowSeq(4, null)),
       ),
     )
   }
@@ -1840,7 +1846,7 @@ class IRSuite {
       { case (elt, Seq(_, y)) => Coalesce(FastSeq(y, elt)) },
     ) { case Seq(x, y) => makestruct("x" -> x, "y" -> y) }
 
-    assertEvalsTo(af, FastSeq((FastSeq(1, 2, 3), TArray(TInt32))), Row(6, 1))
+    assertEvalsTo(af, FastSeq((FastSeq(1, 2, 3), TArray(TInt32))), RowSeq(6, 1))
   }
 
   @Test def testArrayScan(implicit ctx: ExecuteContext): Unit = {
@@ -1900,9 +1906,9 @@ class IRSuite {
   @Test def testNDArrayShape(implicit ctx: ExecuteContext): Unit = {
     implicit val execStrats = ExecStrategy.compileOnly
 
-    assertEvalsTo(NDArrayShape(scalarRowMajor), Row())
-    assertEvalsTo(NDArrayShape(vectorRowMajor), Row(2L))
-    assertEvalsTo(NDArrayShape(cubeRowMajor), Row(3L, 3L, 3L))
+    assertEvalsTo(NDArrayShape(scalarRowMajor), RowSeq())
+    assertEvalsTo(NDArrayShape(vectorRowMajor), RowSeq(2L))
+    assertEvalsTo(NDArrayShape(cubeRowMajor), RowSeq(3L, 3L, 3L))
   }
 
   @Test def testNDArrayRef(implicit ctx: ExecuteContext): Unit = {
@@ -1955,7 +1961,7 @@ class IRSuite {
           else
             MakeNDArray(
               Literal(TArray(TInt32), values),
-              Literal(TTuple(TInt64, TInt64), Row(nRows, nCols)),
+              Literal(TTuple(TInt64, TInt64), RowSeq(nRows, nCols)),
               True(),
               ErrorIDs.NO_ERROR,
             )
@@ -2132,10 +2138,10 @@ class IRSuite {
       NDArrayReindex(vectorRowMajor, FastSeq(1, 0)),
       makeNDArray(FastSeq(), FastSeq(0, 2), True()),
     )
-    assertEvalsTo(NDArrayShape(vectorWithEmpty), Row(0L, 2L))
+    assertEvalsTo(NDArrayShape(vectorWithEmpty), RowSeq(0L, 2L))
 
     val colVectorWithEmpty = sum(colVector, makeNDArray(FastSeq(), FastSeq(2, 0), True()))
-    assertEvalsTo(NDArrayShape(colVectorWithEmpty), Row(2L, 0L))
+    assertEvalsTo(NDArrayShape(colVectorWithEmpty), RowSeq(2L, 0L))
   }
 
   @Test def testNDArrayAgg(implicit ctx: ExecuteContext): Unit = {
@@ -2205,7 +2211,7 @@ class IRSuite {
       matrixRowMajor,
       MakeTuple.ordered(IndexedSeq(MakeTuple.ordered(IndexedSeq(I64(0), I64(2), I64(1))), I64(1))),
     )
-    assertEvalsTo(NDArrayShape(rightCol), Row(2L))
+    assertEvalsTo(NDArrayShape(rightCol), RowSeq(2L))
     assertEvalsTo(makeNDArrayRef(rightCol, FastSeq(0)), 2.0)
     assertEvalsTo(makeNDArrayRef(rightCol, FastSeq(1)), 4.0)
 
@@ -2237,26 +2243,26 @@ class IRSuite {
       vectorRowMajor,
       MakeTuple.ordered(FastSeq(sliceTuple(0, 0, 1))),
     )
-    assertEvalsTo(NDArrayShape(emptyVec), Row(0L))
+    assertEvalsTo(NDArrayShape(emptyVec), RowSeq(0L))
 
     val emptyRows = NDArraySlice(
       mat4x5,
       MakeTuple.ordered(FastSeq(sliceTuple(2, 2, 1), sliceTuple(0, 5, 1))),
     )
-    assertEvalsTo(NDArrayShape(emptyRows), Row(0L, 5L))
+    assertEvalsTo(NDArrayShape(emptyRows), RowSeq(0L, 5L))
 
     val emptyCols = NDArraySlice(
       mat4x5,
       MakeTuple.ordered(FastSeq(sliceTuple(0, 4, 1), sliceTuple(3, 3, 1))),
     )
-    assertEvalsTo(NDArrayShape(emptyCols), Row(4L, 0L))
+    assertEvalsTo(NDArrayShape(emptyCols), RowSeq(4L, 0L))
 
     // empty slice with step > 1
     val emptyStride = NDArraySlice(
       mat4x5,
       MakeTuple.ordered(FastSeq(sliceTuple(1, 1, 3), sliceTuple(0, 5, 1))),
     )
-    assertEvalsTo(NDArrayShape(emptyStride), Row(0L, 5L))
+    assertEvalsTo(NDArrayShape(emptyStride), RowSeq(0L, 5L))
 
     // step=2 on rows: select rows 0, 2
     assertNDEvals(
@@ -2465,29 +2471,29 @@ class IRSuite {
     assertEvalsTo(
       zipJoin(ArraySeq(ArraySeq(0, 1, null), ArraySeq(1, 2, null)), 1),
       FastSeq(
-        Row(0, FastSeq(Row(0, "x", 0), null)),
-        Row(1, FastSeq(Row(1, "x", 1), Row(1, "x", 0))),
-        Row(2, FastSeq(null, Row(2, "x", 1))),
-        Row(null, FastSeq(Row(null, "x", 2), null)),
-        Row(null, FastSeq(null, Row(null, "x", 2))),
+        RowSeq(0, FastSeq(RowSeq(0, "x", 0), null)),
+        RowSeq(1, FastSeq(RowSeq(1, "x", 1), RowSeq(1, "x", 0))),
+        RowSeq(2, FastSeq(null, RowSeq(2, "x", 1))),
+        RowSeq(null, FastSeq(RowSeq(null, "x", 2), null)),
+        RowSeq(null, FastSeq(null, RowSeq(null, "x", 2))),
       ),
     )
 
     assertEvalsTo(
       zipJoin(ArraySeq(ArraySeq(0, 1), ArraySeq(1, 2), ArraySeq(0, 2)), 1),
       FastSeq(
-        Row(0, FastSeq(Row(0, "x", 0), null, Row(0, "x", 0))),
-        Row(1, FastSeq(Row(1, "x", 1), Row(1, "x", 0), null)),
-        Row(2, FastSeq(null, Row(2, "x", 1), Row(2, "x", 1))),
+        RowSeq(0, FastSeq(RowSeq(0, "x", 0), null, RowSeq(0, "x", 0))),
+        RowSeq(1, FastSeq(RowSeq(1, "x", 1), RowSeq(1, "x", 0), null)),
+        RowSeq(2, FastSeq(null, RowSeq(2, "x", 1), RowSeq(2, "x", 1))),
       ),
     )
 
     assertEvalsTo(
       zipJoin(ArraySeq(ArraySeq(0, 1), ArraySeq(), ArraySeq(0, 2)), 1),
       FastSeq(
-        Row(0, FastSeq(Row(0, "x", 0), null, Row(0, "x", 0))),
-        Row(1, FastSeq(Row(1, "x", 1), null, null)),
-        Row(2, FastSeq(null, null, Row(2, "x", 1))),
+        RowSeq(0, FastSeq(RowSeq(0, "x", 0), null, RowSeq(0, "x", 0))),
+        RowSeq(1, FastSeq(RowSeq(1, "x", 1), null, null)),
+        RowSeq(2, FastSeq(null, null, RowSeq(2, "x", 1))),
       ),
     )
 
@@ -2499,8 +2505,8 @@ class IRSuite {
     assertEvalsTo(
       zipJoin(ArraySeq(ArraySeq(0, 1)), 1),
       FastSeq(
-        Row(0, FastSeq(Row(0, "x", 0))),
-        Row(1, FastSeq(Row(1, "x", 1))),
+        RowSeq(0, FastSeq(RowSeq(0, "x", 0))),
+        RowSeq(1, FastSeq(RowSeq(1, "x", 1))),
       ),
     )
   }
@@ -2536,36 +2542,36 @@ class IRSuite {
     assertEvalsTo(
       merge(ArraySeq(ArraySeq(0, 1, null, null), ArraySeq(1, 2, null, null)), 1),
       FastSeq(
-        Row(0, "x", 0),
-        Row(1, "x", 1),
-        Row(1, "x", 0),
-        Row(2, "x", 1),
-        Row(null, "x", 2),
-        Row(null, "x", 3),
-        Row(null, "x", 2),
-        Row(null, "x", 3),
+        RowSeq(0, "x", 0),
+        RowSeq(1, "x", 1),
+        RowSeq(1, "x", 0),
+        RowSeq(2, "x", 1),
+        RowSeq(null, "x", 2),
+        RowSeq(null, "x", 3),
+        RowSeq(null, "x", 2),
+        RowSeq(null, "x", 3),
       ),
     )
 
     assertEvalsTo(
       merge(ArraySeq(ArraySeq(0, 1), ArraySeq(1, 2), ArraySeq(0, 2)), 1),
       FastSeq(
-        Row(0, "x", 0),
-        Row(0, "x", 0),
-        Row(1, "x", 1),
-        Row(1, "x", 0),
-        Row(2, "x", 1),
-        Row(2, "x", 1),
+        RowSeq(0, "x", 0),
+        RowSeq(0, "x", 0),
+        RowSeq(1, "x", 1),
+        RowSeq(1, "x", 0),
+        RowSeq(2, "x", 1),
+        RowSeq(2, "x", 1),
       ),
     )
 
     assertEvalsTo(
       merge(ArraySeq(ArraySeq(0, 1), ArraySeq(), ArraySeq(0, 2)), 1),
       FastSeq(
-        Row(0, "x", 0),
-        Row(0, "x", 0),
-        Row(1, "x", 1),
-        Row(2, "x", 1),
+        RowSeq(0, "x", 0),
+        RowSeq(0, "x", 0),
+        RowSeq(1, "x", 1),
+        RowSeq(2, "x", 1),
       ),
     )
 
@@ -2577,8 +2583,8 @@ class IRSuite {
     assertEvalsTo(
       merge(ArraySeq(ArraySeq(0, 1)), 1),
       FastSeq(
-        Row(0, "x", 0),
-        Row(1, "x", 1),
+        RowSeq(0, "x", 0),
+        RowSeq(1, "x", 1),
       ),
     )
   }
@@ -2658,46 +2664,46 @@ class IRSuite {
     assertEvalsTo(
       leftJoinRows(ArraySeq(0, null), ArraySeq(1, null)),
       FastSeq(
-        Row(0, "x", 0L, null, null),
-        Row(null, "x", 1L, null, null),
+        RowSeq(0, "x", 0L, null, null),
+        RowSeq(null, "x", 1L, null, null),
       ),
     )
 
     assertEvalsTo(
       outerJoinRows(ArraySeq(0, null), ArraySeq(1, null)),
       FastSeq(
-        Row(0, "x", 0L, null, null),
-        Row(1, "x", null, 0, "foo"),
-        Row(null, "x", 1L, null, null),
-        Row(null, "x", null, 1, "foo"),
+        RowSeq(0, "x", 0L, null, null),
+        RowSeq(1, "x", null, 0, "foo"),
+        RowSeq(null, "x", 1L, null, null),
+        RowSeq(null, "x", null, 1, "foo"),
       ),
     )
 
     assertEvalsTo(
       leftJoinRows(ArraySeq(0, 1, 2), ArraySeq(1)),
       FastSeq(
-        Row(0, "x", 0L, null, null),
-        Row(1, "x", 1L, 0, "foo"),
-        Row(2, "x", 2L, null, null),
+        RowSeq(0, "x", 0L, null, null),
+        RowSeq(1, "x", 1L, 0, "foo"),
+        RowSeq(2, "x", 2L, null, null),
       ),
     )
 
     assertEvalsTo(
       leftJoinRows(ArraySeq(0, 1, 2), ArraySeq(-1, 0, 0, 1, 1, 2, 2, 3)),
       FastSeq(
-        Row(0, "x", 0L, 1, "foo"),
-        Row(1, "x", 1L, 3, "foo"),
-        Row(2, "x", 2L, 5, "foo"),
+        RowSeq(0, "x", 0L, 1, "foo"),
+        RowSeq(1, "x", 1L, 3, "foo"),
+        RowSeq(2, "x", 2L, 5, "foo"),
       ),
     )
 
     assertEvalsTo(
       leftJoinRows(ArraySeq(0, 1, 1, 2), ArraySeq(-1, 0, 0, 1, 1, 2, 2, 3)),
       FastSeq(
-        Row(0, "x", 0L, 1, "foo"),
-        Row(1, "x", 1L, 3, "foo"),
-        Row(1, "x", 2L, 3, "foo"),
-        Row(2, "x", 3L, 5, "foo"),
+        RowSeq(0, "x", 0L, 1, "foo"),
+        RowSeq(1, "x", 1L, 3, "foo"),
+        RowSeq(1, "x", 2L, 3, "foo"),
+        RowSeq(2, "x", 3L, 5, "foo"),
       ),
     )
   }
@@ -2740,14 +2746,14 @@ class IRSuite {
         ArraySeq(0, 0, 1, 1, 3, 3, null, null),
       ),
       FastSeq(
-        Row(1, 0, 2),
-        Row(1, 0, 3),
-        Row(1, 1, 2),
-        Row(1, 1, 3),
-        Row(2, 2, null),
-        Row(2, 3, null),
-        Row(null, 4, null),
-        Row(null, 5, null),
+        RowSeq(1, 0, 2),
+        RowSeq(1, 0, 3),
+        RowSeq(1, 1, 2),
+        RowSeq(1, 1, 3),
+        RowSeq(2, 2, null),
+        RowSeq(2, 3, null),
+        RowSeq(null, 4, null),
+        RowSeq(null, 5, null),
       ),
     )
 
@@ -2757,20 +2763,20 @@ class IRSuite {
         ArraySeq(0, 0, 1, 1, 3, 3, null, null),
       ),
       FastSeq(
-        Row(0, null, 0),
-        Row(0, null, 1),
-        Row(1, 0, 2),
-        Row(1, 0, 3),
-        Row(1, 1, 2),
-        Row(1, 1, 3),
-        Row(2, 2, null),
-        Row(2, 3, null),
-        Row(3, null, 4),
-        Row(3, null, 5),
-        Row(null, 4, null),
-        Row(null, 5, null),
-        Row(null, null, 6),
-        Row(null, null, 7),
+        RowSeq(0, null, 0),
+        RowSeq(0, null, 1),
+        RowSeq(1, 0, 2),
+        RowSeq(1, 0, 3),
+        RowSeq(1, 1, 2),
+        RowSeq(1, 1, 3),
+        RowSeq(2, 2, null),
+        RowSeq(2, 3, null),
+        RowSeq(3, null, 4),
+        RowSeq(3, null, 5),
+        RowSeq(null, 4, null),
+        RowSeq(null, 5, null),
+        RowSeq(null, null, 6),
+        RowSeq(null, null, 7),
       ),
     )
 
@@ -2780,10 +2786,10 @@ class IRSuite {
         ArraySeq(0, 0, 1, 1, 3, 3, null, null),
       ),
       FastSeq(
-        Row(1, 0, 2),
-        Row(1, 0, 3),
-        Row(1, 1, 2),
-        Row(1, 1, 3),
+        RowSeq(1, 0, 2),
+        RowSeq(1, 0, 3),
+        RowSeq(1, 1, 2),
+        RowSeq(1, 1, 3),
       ),
     )
 
@@ -2793,16 +2799,16 @@ class IRSuite {
         ArraySeq(0, 0, 1, 1, 3, 3, null, null),
       ),
       FastSeq(
-        Row(0, null, 0),
-        Row(0, null, 1),
-        Row(1, 0, 2),
-        Row(1, 0, 3),
-        Row(1, 1, 2),
-        Row(1, 1, 3),
-        Row(3, null, 4),
-        Row(3, null, 5),
-        Row(null, null, 6),
-        Row(null, null, 7),
+        RowSeq(0, null, 0),
+        RowSeq(0, null, 1),
+        RowSeq(1, 0, 2),
+        RowSeq(1, 0, 3),
+        RowSeq(1, 1, 2),
+        RowSeq(1, 1, 3),
+        RowSeq(3, null, 4),
+        RowSeq(3, null, 5),
+        RowSeq(null, null, 6),
+        RowSeq(null, null, 7),
       ),
     )
   }
@@ -2852,20 +2858,20 @@ class IRSuite {
         1,
       ),
       FastSeq(
-        Row(0, -1, 0),
-        Row(0, -1, 1),
-        Row(1, 1, 0),
-        Row(1, 1, 1),
-        Row(1, -1, 2),
-        Row(1, -1, 3),
-        Row(2, 1, 2),
-        Row(2, 1, 3),
-        Row(3, -1, 4),
-        Row(3, -1, 5),
-        Row(null, 1, 4),
-        Row(null, 1, 5),
-        Row(null, -1, 6),
-        Row(null, -1, 7),
+        RowSeq(0, -1, 0),
+        RowSeq(0, -1, 1),
+        RowSeq(1, 1, 0),
+        RowSeq(1, 1, 1),
+        RowSeq(1, -1, 2),
+        RowSeq(1, -1, 3),
+        RowSeq(2, 1, 2),
+        RowSeq(2, 1, 3),
+        RowSeq(3, -1, 4),
+        RowSeq(3, -1, 5),
+        RowSeq(null, 1, 4),
+        RowSeq(null, 1, 5),
+        RowSeq(null, -1, 6),
+        RowSeq(null, -1, 7),
       ),
     )
 
@@ -2873,14 +2879,14 @@ class IRSuite {
     assertEvalsTo(
       mergeRows(ArraySeq(1, 1, 2, 2), ArraySeq(0, 0, 1, 1), 1),
       FastSeq(
-        Row(0, -1, 0),
-        Row(0, -1, 1),
-        Row(1, 1, 0),
-        Row(1, 1, 1),
-        Row(1, -1, 2),
-        Row(1, -1, 3),
-        Row(2, 1, 2),
-        Row(2, 1, 3),
+        RowSeq(0, -1, 0),
+        RowSeq(0, -1, 1),
+        RowSeq(1, 1, 0),
+        RowSeq(1, 1, 1),
+        RowSeq(1, -1, 2),
+        RowSeq(1, -1, 3),
+        RowSeq(2, 1, 2),
+        RowSeq(2, 1, 3),
       ),
     )
 
@@ -2892,20 +2898,20 @@ class IRSuite {
         2,
       ),
       FastSeq(
-        Row(0, -1, 0),
-        Row(0, -1, 1),
-        Row(1, -1, 2),
-        Row(1, -1, 3),
-        Row(1, 1, 0),
-        Row(1, 1, 1),
-        Row(2, 1, 2),
-        Row(2, 1, 3),
-        Row(3, -1, 4),
-        Row(3, -1, 5),
-        Row(null, 1, 4),
-        Row(null, 1, 5),
-        Row(null, -1, 6),
-        Row(null, -1, 7),
+        RowSeq(0, -1, 0),
+        RowSeq(0, -1, 1),
+        RowSeq(1, -1, 2),
+        RowSeq(1, -1, 3),
+        RowSeq(1, 1, 0),
+        RowSeq(1, 1, 1),
+        RowSeq(2, 1, 2),
+        RowSeq(2, 1, 3),
+        RowSeq(3, -1, 4),
+        RowSeq(3, -1, 5),
+        RowSeq(null, 1, 4),
+        RowSeq(null, 1, 5),
+        RowSeq(null, -1, 6),
+        RowSeq(null, -1, 7),
       ),
     )
 
@@ -2913,9 +2919,9 @@ class IRSuite {
     assertEvalsTo(
       mergeRows(ArraySeq(1, 2, null), ArraySeq(), 1),
       FastSeq(
-        Row(1, 1, 0),
-        Row(2, 1, 1),
-        Row(null, 1, 2),
+        RowSeq(1, 1, 0),
+        RowSeq(2, 1, 1),
+        RowSeq(null, 1, 2),
       ),
     )
 
@@ -2923,9 +2929,9 @@ class IRSuite {
     assertEvalsTo(
       mergeRows(ArraySeq(), ArraySeq(1, 2, null), 1),
       FastSeq(
-        Row(1, -1, 0),
-        Row(2, -1, 1),
-        Row(null, -1, 2),
+        RowSeq(1, -1, 0),
+        RowSeq(2, -1, 1),
+        RowSeq(null, -1, 2),
       ),
     )
 
@@ -3021,12 +3027,12 @@ class IRSuite {
     }
 
     val input = FastSeq(
-      Row(null, 1),
-      Row(Call2(0, 0), 2),
-      Row(Call2(0, 1), 3),
-      Row(Call2(1, 1), 4),
+      RowSeq(null, 1),
+      RowSeq(Call2(0, 0), 2),
+      RowSeq(Call2(0, 1), 3),
+      RowSeq(Call2(1, 1), 4),
       null,
-      Row(null, 5),
+      RowSeq(null, 5),
     ) -> TArray(eltType)
 
     assertEvalsTo(
@@ -3057,7 +3063,7 @@ class IRSuite {
         emptyStruct,
         IndexedSeq("a" -> I64(5)),
       ),
-      Row(5L, null),
+      RowSeq(5L, null),
     )
 
     assertEvalsTo(
@@ -3065,7 +3071,7 @@ class IRSuite {
         emptyStruct,
         IndexedSeq("c" -> F64(3.2)),
       ),
-      Row(null, null, 3.2),
+      RowSeq(null, null, 3.2),
     )
 
     assertEvalsTo(
@@ -3073,7 +3079,7 @@ class IRSuite {
         emptyStruct,
         IndexedSeq("c" -> NA(TFloat64)),
       ),
-      Row(null, null, null),
+      RowSeq(null, null, null),
     )
 
     assertEvalsTo(
@@ -3081,7 +3087,7 @@ class IRSuite {
         MakeStruct(IndexedSeq("a" -> NA(TInt64), "b" -> Str("abc"))),
         IndexedSeq(),
       ),
-      Row(null, "abc"),
+      RowSeq(null, "abc"),
     )
 
     assertEvalsTo(
@@ -3089,7 +3095,7 @@ class IRSuite {
         MakeStruct(IndexedSeq("a" -> NA(TInt64), "b" -> Str("abc"))),
         IndexedSeq("a" -> I64(5)),
       ),
-      Row(5L, "abc"),
+      RowSeq(5L, "abc"),
     )
 
     assertEvalsTo(
@@ -3097,7 +3103,7 @@ class IRSuite {
         MakeStruct(IndexedSeq("a" -> NA(TInt64), "b" -> Str("abc"))),
         IndexedSeq("c" -> F64(3.2)),
       ),
-      Row(null, "abc", 3.2),
+      RowSeq(null, "abc", 3.2),
     )
 
     assertEvalsTo(
@@ -3111,8 +3117,8 @@ class IRSuite {
         IndexedSeq("c" -> F64(3.2), "d" -> F64(5.5), "e" -> F64(6.6)),
         Some(FastSeq("c", "d", "e", "a", "b")),
       ),
-      FastSeq(Row(null, "abc") -> s),
-      Row(3.2, 5.5, 6.6, null, "abc"),
+      FastSeq(RowSeq(null, "abc") -> s),
+      RowSeq(3.2, 5.5, 6.6, null, "abc"),
     )
 
     assertEvalsTo(
@@ -3121,8 +3127,8 @@ class IRSuite {
         IndexedSeq("c" -> F64(3.2), "d" -> F64(5.5), "e" -> F64(6.6)),
         Some(FastSeq("a", "b", "c", "d", "e")),
       ),
-      FastSeq(Row(null, "abc") -> s),
-      Row(null, "abc", 3.2, 5.5, 6.6),
+      FastSeq(RowSeq(null, "abc") -> s),
+      RowSeq(null, "abc", 3.2, 5.5, 6.6),
     )
 
     assertEvalsTo(
@@ -3131,8 +3137,8 @@ class IRSuite {
         IndexedSeq("c" -> F64(3.2), "d" -> F64(5.5), "e" -> F64(6.6)),
         Some(FastSeq("c", "a", "d", "b", "e")),
       ),
-      FastSeq(Row(null, "abc") -> s),
-      Row(3.2, null, 5.5, "abc", 6.6),
+      FastSeq(RowSeq(null, "abc") -> s),
+      RowSeq(3.2, null, 5.5, "abc", 6.6),
     )
 
   }
@@ -3151,7 +3157,7 @@ class IRSuite {
         MakeStruct(FastSeq("foo" -> 6, "bar" -> 0.0)),
         FastSeq("foo"),
       ),
-      Row(6),
+      RowSeq(6),
     )
 
     assertEvalsTo(
@@ -3159,7 +3165,7 @@ class IRSuite {
         MakeStruct(FastSeq("a" -> 6, "b" -> 0.0, "c" -> 3L)),
         FastSeq("b", "a"),
       ),
-      Row(0.0, 6),
+      RowSeq(0.0, 6),
     )
   }
 
@@ -3184,7 +3190,7 @@ class IRSuite {
       TDict(TInt32, TString),
     )
     val values = ArraySeq(
-      Row(400, "foo" + poopEmoji, FastSeq(4, 6, 8)),
+      RowSeq(400, "foo" + poopEmoji, FastSeq(4, 6, 8)),
       FastSeq(poopEmoji, "", "foo"),
       Map[Int, String](1 -> "", 5 -> "foo", -4 -> poopEmoji),
     )
@@ -3192,7 +3198,7 @@ class IRSuite {
     assertEvalsTo(Literal(types(0), values(0)), values(0))
     assertEvalsTo(
       MakeTuple.ordered(types.zip(values).map { case (t, v) => Literal(t, v) }),
-      Row.fromSeq(values),
+      RowSeq.fromSeq(values),
     )
     assertEvalsTo(Str("hello" + poopEmoji), "hello" + poopEmoji)
   }
@@ -3219,8 +3225,11 @@ class IRSuite {
   @Test def testTableGetGlobals(implicit ctx: ExecuteContext): Unit = {
     implicit val execStrats = ExecStrategy.interpretOnly
     assertEvalsTo(
-      TableGetGlobals(TableMapGlobals(TableRange(0, 1), Literal(TStruct("a" -> TInt32), Row(1)))),
-      Row(1),
+      TableGetGlobals(TableMapGlobals(
+        TableRange(0, 1),
+        Literal(TStruct("a" -> TInt32), RowSeq(1)),
+      )),
+      RowSeq(1),
     )
   }
 
@@ -3229,7 +3238,7 @@ class IRSuite {
 
     val table = TableRange(3, 2)
     val count = ApplyAggOp(Count())()
-    assertEvalsTo(TableAggregate(table, MakeStruct(IndexedSeq("foo" -> count))), Row(3L))
+    assertEvalsTo(TableAggregate(table, MakeStruct(IndexedSeq("foo" -> count))), RowSeq(3L))
   }
 
   @Test def testMatrixAggregate(implicit ctx: ExecuteContext): Unit = {
@@ -3237,7 +3246,7 @@ class IRSuite {
 
     val matrix = MatrixIR.range(ctx, 5, 5, None)
     val count = ApplyAggOp(Count())()
-    assertEvalsTo(MatrixAggregate(matrix, MakeStruct(IndexedSeq("foo" -> count))), Row(25L))
+    assertEvalsTo(MatrixAggregate(matrix, MakeStruct(IndexedSeq("foo" -> count))), RowSeq(25L))
   }
 
   @Test def testGroupByKey(implicit ctx: ExecuteContext): Unit = {
@@ -3279,13 +3288,13 @@ class IRSuite {
       TInterval(TInt32),
     ),
     (
-      Row("foo", 0.0),
+      RowSeq("foo", 0.0),
       TStruct("a" -> TString, "b" -> TFloat64),
       TStruct("a" -> TString, "b" -> TFloat64),
     ),
-    (Row("foo", 0.0), TTuple(TString, TFloat64), TTuple(TString, TFloat64)),
+    (RowSeq("foo", 0.0), TTuple(TString, TFloat64), TTuple(TString, TFloat64)),
     (
-      Row(FastSeq("foo"), 0.0),
+      RowSeq(FastSeq("foo"), 0.0),
       TTuple(TArray(TString), TFloat64),
       TTuple(TArray(TString), TFloat64),
     ),
@@ -3514,7 +3523,7 @@ class IRSuite {
         val left = mapIR(rangeIR(2))(x => MakeStruct(FastSeq("x" -> x)))
         val right = ToStream(Literal(
           TArray(TStruct("a" -> TInterval(TInt32))),
-          FastSeq(Row(Interval(IntervalEndpoint(0, -1), IntervalEndpoint(1, 1)))),
+          FastSeq(RowSeq(Interval(IntervalEndpoint(0, -1), IntervalEndpoint(1, 1)))),
         ))
         val lref = Ref(freshName(), elementType(left.typ))
         val rref = Ref(freshName(), TArray(elementType(right.typ)))
@@ -3597,7 +3606,7 @@ class IRSuite {
       Die("mumblefoo", TFloat64),
       invoke("land", TBoolean, b, c) -> ArraySeq(c), // ApplySpecial
       invoke("toFloat64", TFloat64, i), // Apply
-      Literal(TStruct("x" -> TInt32), Row(1)),
+      Literal(TStruct("x" -> TInt32), RowSeq(1)),
       TableCount(table),
       MatrixCount(mt),
       TableGetGlobals(table),
@@ -3766,7 +3775,7 @@ class IRSuite {
         TableRename(read, Map("idx" -> "idx_foo"), Map("global_f32" -> "global_foo")),
         TableFilterIntervals(
           read,
-          FastSeq(Interval(IntervalEndpoint(Row(0), -1), IntervalEndpoint(Row(10), 1))),
+          FastSeq(Interval(IntervalEndpoint(RowSeq(0), -1), IntervalEndpoint(RowSeq(10), 1))),
           keep = false,
         ),
         RelationalLetTable(freshName(), I32(0), read), {
@@ -3909,7 +3918,7 @@ class IRSuite {
         ),
         MatrixFilterIntervals(
           read,
-          FastSeq(Interval(IntervalEndpoint(Row(0), -1), IntervalEndpoint(Row(10), 1))),
+          FastSeq(Interval(IntervalEndpoint(RowSeq(0), -1), IntervalEndpoint(RowSeq(10), 1))),
           keep = false,
         ),
         RelationalLetMatrixTable(freshName(), I32(0), read),
@@ -4034,7 +4043,7 @@ class IRSuite {
       TableValue(
         ctx,
         t1,
-        BroadcastRow(ctx, Row(1, 1.1), t1.globalType),
+        BroadcastRow(ctx, RowSeq(1, 1.1), t1.globalType),
         RVD.empty(ctx, t1.canonicalRVDType),
       ),
       ctx.theHailClassLoader,
@@ -4043,21 +4052,21 @@ class IRSuite {
       TableValue(
         ctx,
         t2,
-        BroadcastRow(ctx, Row(2, 2.2), t2.globalType),
+        BroadcastRow(ctx, RowSeq(2, 2.2), t2.globalType),
         RVD.empty(ctx, t2.canonicalRVDType),
       ),
       ctx.theHailClassLoader,
     )
 
-    assertEvalsTo(TableGetGlobals(TableJoin(tab1, tab2, "left")), Row(1, 1.1, 2, 2.2))
+    assertEvalsTo(TableGetGlobals(TableJoin(tab1, tab2, "left")), RowSeq(1, 1.1, 2, 2.2))
     assertEvalsTo(
       TableGetGlobals(TableMapGlobals(
         tab1,
         InsertFields(Ref(TableIR.globalName, t1.globalType), IndexedSeq("g1" -> I32(3))),
       )),
-      Row(3, 1.1),
+      RowSeq(3, 1.1),
     )
-    assertEvalsTo(TableGetGlobals(TableRename(tab1, Map.empty, Map("g2" -> "g3"))), Row(1, 1.1))
+    assertEvalsTo(TableGetGlobals(TableRename(tab1, Map.empty, Map("g2" -> "g3"))), RowSeq(1, 1.1))
   }
 
   @Test def testAggLet(implicit ctx: ExecuteContext): Unit = {
@@ -4090,7 +4099,7 @@ class IRSuite {
     val ir = TableAggregate(
       RelationalLetTable(
         x.name,
-        Literal(t, FastSeq(Row(1))),
+        Literal(t, FastSeq(RowSeq(1))),
         TableParallelize(MakeStruct(FastSeq(
           "rows" -> x,
           "global" -> MakeStruct(FastSeq()),
@@ -4125,7 +4134,7 @@ class IRSuite {
       FastSeq(),
     )
     val ir = MatrixAggregate(
-      RelationalLetMatrixTable(x.name, Literal(t, FastSeq(Row(1))), m),
+      RelationalLetMatrixTable(x.name, Literal(t, FastSeq(RowSeq(1))), m),
       ApplyAggOp(Count())(),
     )
     assertEvalsTo(ir, 1L)
@@ -4219,7 +4228,7 @@ class IRSuite {
 
   @Test def testNonCanonicalTypeParsing(implicit ctx: ExecuteContext): Unit = {
     val t = TTuple(FastSeq(TupleField(1, TInt64)))
-    val lit = Literal(t, Row(1L))
+    val lit = Literal(t, RowSeq(1L))
 
     assert(IRParser.parseType(t.parsableString()) == t)
     assert(IRParser.parse_value_ir(ctx, Pretty.sexprStyle(lit, elideLiterals = false)) == lit)
@@ -4243,8 +4252,8 @@ class IRSuite {
       ir.typ.ordering(ctx.stateManager).equiv(
         FastSeq(
           Interval(
-            Row(Locus("20", 10277621)),
-            Row(Locus("20", 11898992)),
+            RowSeq(Locus("20", 10277621)),
+            RowSeq(Locus("20", 11898992)),
             includesStart = true,
             includesEnd = false,
           )
@@ -4373,7 +4382,7 @@ class IRSuite {
         PCanonicalString(),
         PCanonicalStruct(),
       )),
-      Row(3, "bar", Row()): Any,
+      RowSeq(3, "bar", RowSeq()): Any,
     ),
   )
 
@@ -4455,7 +4464,7 @@ class IRSuite {
         behavior,
       )(_ => makestruct("x" -> Str("foo"), "y" -> Str("bar")))
 
-      assertEvalsTo(ToArray(zip), ArraySeq.fill(10)(Row("foo", "bar")))
+      assertEvalsTo(ToArray(zip), ArraySeq.fill(10)(RowSeq("foo", "bar")))
     }
 
   @Test def testStreamDistribute(implicit ctx: ExecuteContext): Unit = {

--- a/hail/hail/test/src/is/hail/expr/ir/IntervalSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/IntervalSuite.scala
@@ -3,6 +3,7 @@ package is.hail.expr.ir
 import is.hail.ExecStrategy
 import is.hail.ExecStrategy.ExecStrategy
 import is.hail.TestUtils._
+import is.hail.annotations.RowSeq
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
 import is.hail.collection.compat.immutable.ArraySeq
@@ -13,7 +14,6 @@ import is.hail.rvd.RVDPartitioner
 import is.hail.types.virtual._
 import is.hail.utils._
 
-import org.apache.spark.sql.Row
 import org.junit.jupiter.api.{BeforeEach, Test}
 
 class IntervalSuite {
@@ -44,16 +44,16 @@ class IntervalSuite {
   val i5 = interval(NA(tpoint1), point(2), true, null)
 
   @Test def constructor(implicit ctx: ExecuteContext): Unit = {
-    assertEvalsTo(i1, Interval(Row(1), Row(2), true, false))
-    assertEvalsTo(i2, Interval(Row(1), null, true, false))
-    assertEvalsTo(i3, Interval(null, Row(2), true, false))
+    assertEvalsTo(i1, Interval(RowSeq(1), RowSeq(2), true, false))
+    assertEvalsTo(i2, Interval(RowSeq(1), null, true, false))
+    assertEvalsTo(i3, Interval(null, RowSeq(2), true, false))
     assertEvalsTo(i4, null)
     assertEvalsTo(i5, null)
   }
 
   @Test def start(implicit ctx: ExecuteContext): Unit = {
-    assertEvalsTo(invoke("start", tpoint1, i1), Row(1))
-    assertEvalsTo(invoke("start", tpoint1, i2), Row(1))
+    assertEvalsTo(invoke("start", tpoint1, i1), RowSeq(1))
+    assertEvalsTo(invoke("start", tpoint1, i2), RowSeq(1))
     assertEvalsTo(invoke("start", tpoint1, i3), null)
     assertEvalsTo(invoke("start", tpoint1, na), null)
   }
@@ -64,9 +64,9 @@ class IntervalSuite {
   }
 
   @Test def end(implicit ctx: ExecuteContext): Unit = {
-    assertEvalsTo(invoke("end", tpoint1, i1), Row(2))
+    assertEvalsTo(invoke("end", tpoint1, i1), RowSeq(2))
     assertEvalsTo(invoke("end", tpoint1, i2), null)
-    assertEvalsTo(invoke("end", tpoint1, i3), Row(2))
+    assertEvalsTo(invoke("end", tpoint1, i3), RowSeq(2))
     assertEvalsTo(invoke("end", tpoint1, na), null)
   }
 
@@ -247,9 +247,9 @@ class IntervalSuite {
       ctx.stateManager,
       partitionerKType,
       ArraySeq(
-        Interval(Row(1, 0), Row(4, 3), true, false),
-        Interval(Row(4, 3), Row(7, 9), true, false),
-        Interval(Row(7, 11), Row(10, 0), true, true),
+        Interval(RowSeq(1, 0), RowSeq(4, 3), true, false),
+        Interval(RowSeq(4, 3), RowSeq(7, 9), true, false),
+        Interval(RowSeq(7, 11), RowSeq(10, 0), true, true),
       ),
     ).partitionBoundsIRRepresentation
   }
@@ -264,14 +264,14 @@ class IntervalSuite {
       )
       assertEvalsTo(
         invoke("partitionerFindIntervalRange", resultType, partitioner, irInterval),
-        Row(startIdx, endIdx),
+        RowSeq(startIdx, endIdx),
       )
     }
-    assertRange(Interval(Row(3, 4, 0), Row(7, 11), true, true), 0, 3)
-    assertRange(Interval(Row(3, 4), Row(7, 9), true, false), 0, 2)
-    assertRange(Interval(Row(4), Row(5), true, true), 0, 2)
-    assertRange(Interval(Row(4), Row(5), false, true), 1, 2)
-    assertRange(Interval(Row(-1, 7), Row(0, 9), true, false), 0, 0)
+    assertRange(Interval(RowSeq(3, 4, 0), RowSeq(7, 11), true, true), 0, 3)
+    assertRange(Interval(RowSeq(3, 4), RowSeq(7, 9), true, false), 0, 2)
+    assertRange(Interval(RowSeq(4), RowSeq(5), true, true), 0, 2)
+    assertRange(Interval(RowSeq(4), RowSeq(5), false, true), 1, 2)
+    assertRange(Interval(RowSeq(-1, 7), RowSeq(0, 9), true, false), 0, 0)
   }
 
   @Test def testPointPartitionIntervalEndpointComparison(implicit ctx: ExecuteContext): Unit = {

--- a/hail/hail/test/src/is/hail/expr/ir/LiftLiteralsSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/LiftLiteralsSuite.scala
@@ -3,12 +3,12 @@ package is.hail.expr.ir
 import is.hail.ExecStrategy
 import is.hail.ExecStrategy.ExecStrategy
 import is.hail.TestUtils._
+import is.hail.annotations.RowSeq
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
 import is.hail.expr.ir.defs.{ApplyBinaryPrimOp, I64, MakeStruct, TableCount, TableGetGlobals}
 import is.hail.expr.ir.lowering.ExecuteRelational
 
-import org.apache.spark.sql.Row
 import org.junit.jupiter.api.Test
 
 class LiftLiteralsSuite {
@@ -37,6 +37,6 @@ class LiftLiteralsSuite {
       )
     )
 
-    assertEvalsTo(ir, Row(11L))
+    assertEvalsTo(ir, RowSeq(11L))
   }
 }

--- a/hail/hail/test/src/is/hail/expr/ir/LocusFunctionsSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/LocusFunctionsSuite.scala
@@ -3,6 +3,7 @@ package is.hail.expr.ir
 import is.hail.ExecStrategy
 import is.hail.ExecStrategy.ExecStrategy
 import is.hail.TestUtils._
+import is.hail.annotations.RowSeq
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
 import is.hail.expr.ir.defs.{Apply, ErrorIDs, False, I32, I64, MakeArray, MakeTuple, NA, Str, True}
@@ -10,7 +11,6 @@ import is.hail.types.virtual._
 import is.hail.utils.Interval
 import is.hail.variant.{Locus, ReferenceGenome}
 
-import org.apache.spark.sql.Row
 import org.junit.jupiter.api.Test
 
 class LocusFunctionsSuite {
@@ -64,7 +64,7 @@ class LocusFunctionsSuite {
     val alleles = MakeArray(FastSeq(Str("AA"), Str("AT")), TArray(TString))
     assertEvalsTo(
       invoke("min_rep", tvariant, locusIR, alleles),
-      Row(Locus("chr22", 2), FastSeq("A", "T")),
+      RowSeq(Locus("chr22", 2), FastSeq("A", "T")),
     )
     assertEvalsTo(invoke("min_rep", tvariant, locusIR, NA(TArray(TString))), null)
   }
@@ -90,7 +90,7 @@ class LocusFunctionsSuite {
 
     assertEvalsTo(
       ir,
-      Row(
+      RowSeq(
         Locus("1", 1, ctx.references(ReferenceGenome.GRCh37)),
         Locus("chr1", 1, ctx.references(ReferenceGenome.GRCh38)),
       ),
@@ -184,7 +184,7 @@ class LocusFunctionsSuite {
 
     assertEvalsTo(
       ir,
-      Row(
+      RowSeq(
         null,
         null,
         null,

--- a/hail/hail/test/src/is/hail/expr/ir/MatrixIRSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/MatrixIRSuite.scala
@@ -3,7 +3,7 @@ package is.hail.expr.ir
 import is.hail.{ExecStrategy, ParameterizedTest}
 import is.hail.ExecStrategy.ExecStrategy
 import is.hail.TestUtils._
-import is.hail.annotations.BroadcastRow
+import is.hail.annotations.{BroadcastRow, RowSeq}
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
 import is.hail.collection.compat.immutable.ArraySeq
@@ -44,7 +44,7 @@ class MatrixIRSuite {
     val writer1 = MatrixNativeWriter(path, overwrite = true)
     val partType = TArray(TInterval(TStruct("row_idx" -> TInt32)))
     val parts = JsonMethods.compact(JSONAnnotationImpex.exportAnnotation(
-      FastSeq(Interval(Row(0), Row(10), true, false)),
+      FastSeq(Interval(RowSeq(0), RowSeq(10), true, false)),
       partType,
     ))
     val writer2 = MatrixNativeWriter(
@@ -60,30 +60,30 @@ class MatrixIRSuite {
       val read = MatrixIR.read(fs, path, dropCols = false, dropRows = false, None)
       val droppedRows = MatrixIR.read(fs, path, dropCols = false, dropRows = true, None)
 
-      val expectedCols = ArraySeq.tabulate(10)(i => Row(i, Row(0L, i.toLong)))
+      val expectedCols = ArraySeq.tabulate(10)(i => RowSeq(i, RowSeq(0L, i.toLong)))
       val expectedRows = if (writer eq writer1) {
         val uids = for {
           (partSize, partIndex) <- partition(10, 3).zipWithIndex
           i <- 0 until partSize
-        } yield Row(partIndex.toLong, i.toLong)
+        } yield RowSeq(partIndex.toLong, i.toLong)
         (0 until 10).lazyZip(uids).map { (i, uid) =>
-          Row(i, uid, expectedCols.map { case Row(j, _) => Row(i, j) })
+          RowSeq(i, uid, expectedCols.map { case Row(j, _) => RowSeq(i, j) })
         }
       } else
         ArraySeq.tabulate(10)(i =>
-          Row(i, Row(0L, i.toLong), expectedCols.map { case Row(j, _) => Row(i, j) })
+          RowSeq(i, RowSeq(0L, i.toLong), expectedCols.map { case Row(j, _) => RowSeq(i, j) })
         )
-      val expectedGlobals = Row(0, expectedCols);
+      val expectedGlobals = RowSeq(0, expectedCols);
       {
         implicit val execStrats: Set[ExecStrategy] =
           Set(ExecStrategy.Interpret, ExecStrategy.InterpretUnoptimized)
         assertEvalsTo(
           TableCollect(TableKeyBy(CastMatrixToTable(read, "entries", "cols"), FastSeq())),
-          Row(expectedRows, expectedGlobals),
+          RowSeq(expectedRows, expectedGlobals),
         )
         assertEvalsTo(
           TableCollect(TableKeyBy(CastMatrixToTable(droppedRows, "entries", "cols"), FastSeq())),
-          Row(FastSeq(), expectedGlobals),
+          RowSeq(FastSeq(), expectedGlobals),
         )
       }
     }
@@ -302,20 +302,20 @@ class MatrixIRSuite {
     var tv = TableValue(ctx, rowSig, keyNames, rowRdd)
     tv = tv.copy(
       typ = tv.typ.copy(globalType = globalType),
-      globals = BroadcastRow(ctx, Row(cdata), globalType),
+      globals = BroadcastRow(ctx, RowSeq(cdata), globalType),
     )
     TableLiteral(tv, ctx.theHailClassLoader)
   }
 
   @Test def testCastTableToMatrix(implicit ctx: ExecuteContext): Unit = {
     val rdata = ArraySeq(
-      Row(1, "fish", FastSeq(Row("a", 1.0), Row("x", 2.0))),
-      Row(2, "cat", FastSeq(Row("b", 0.0), Row("y", 0.1))),
-      Row(3, "dog", FastSeq(Row("c", -1.0), Row("z", 30.0))),
+      RowSeq(1, "fish", FastSeq(RowSeq("a", 1.0), RowSeq("x", 2.0))),
+      RowSeq(2, "cat", FastSeq(RowSeq("b", 0.0), RowSeq("y", 0.1))),
+      RowSeq(3, "dog", FastSeq(RowSeq("c", -1.0), RowSeq("z", 30.0))),
     )
     val cdata = ArraySeq(
-      Row(1, "atag"),
-      Row(2, "btag"),
+      RowSeq(1, "atag"),
+      RowSeq(2, "btag"),
     )
     val rowTab = makeLocalizedTable(rdata, cdata)
 
@@ -326,7 +326,7 @@ class MatrixIRSuite {
 
     // Rows are same
     val mtRows = Interpret(MatrixRowsTable(mir), ctx).rdd.collect()
-    assert(mtRows sameElements rdata.map(row => Row.fromSeq(row.toSeq.take(2))))
+    assert(mtRows sameElements rdata.map(row => RowSeq.fromSeq(row.toSeq.take(2))))
 
     // Round trip
     val roundTrip = Interpret(CastMatrixToTable(mir, "__entries", "__cols"), ctx)
@@ -338,13 +338,13 @@ class MatrixIRSuite {
 
   @Test def testCastTableToMatrixErrors(implicit ctx: ExecuteContext): Unit = {
     val rdata = ArraySeq(
-      Row(1, "fish", FastSeq(Row("x", 2.0))),
-      Row(2, "cat", FastSeq(Row("b", 0.0), Row("y", 0.1))),
-      Row(3, "dog", FastSeq(Row("c", -1.0), Row("z", 30.0))),
+      RowSeq(1, "fish", FastSeq(RowSeq("x", 2.0))),
+      RowSeq(2, "cat", FastSeq(RowSeq("b", 0.0), RowSeq("y", 0.1))),
+      RowSeq(3, "dog", FastSeq(RowSeq("c", -1.0), RowSeq("z", 30.0))),
     )
     val cdata = ArraySeq(
-      Row(1, "atag"),
-      Row(2, "btag"),
+      RowSeq(1, "atag"),
+      RowSeq(2, "btag"),
     )
     val rowTab = makeLocalizedTable(rdata, cdata)
 
@@ -361,9 +361,9 @@ class MatrixIRSuite {
     }
 
     val rdata2 = ArraySeq(
-      Row(1, "fish", null),
-      Row(2, "cat", FastSeq(Row("b", 0.0), Row("y", 0.1))),
-      Row(3, "dog", FastSeq(Row("c", -1.0), Row("z", 30.0))),
+      RowSeq(1, "fish", null),
+      RowSeq(2, "cat", FastSeq(RowSeq("b", 0.0), RowSeq("y", 0.1))),
+      RowSeq(3, "dog", FastSeq(RowSeq("c", -1.0), RowSeq("z", 30.0))),
     )
     val rowTab2 = makeLocalizedTable(rdata2, cdata)
     val mir2 = CastTableToMatrix(rowTab2, "__entries", "__cols", ArraySeq("col_idx"))

--- a/hail/hail/test/src/is/hail/expr/ir/OrderingSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/OrderingSuite.scala
@@ -471,7 +471,7 @@ class OrderingSuite {
       ctx.r.pool.scopedRegion { region =>
         val soff = pset.unstagedStoreJavaObject(sm, set, region)
 
-        val eoff = pTuple.unstagedStoreJavaObject(sm, Row(elem), region)
+        val eoff = pTuple.unstagedStoreJavaObject(sm, RowSeq(elem), region)
 
         val fb = EmitFunctionBuilder[Region, Long, Long, Int](ctx, "binary_search")
         val cset = fb.getCodeParam[Long](2)
@@ -524,7 +524,7 @@ class OrderingSuite {
         val soff = pDict.unstagedStoreJavaObject(sm, dict, region)
 
         val ptuple = PCanonicalTuple(false, FastSeq(pDict.keyType): _*)
-        val eoff = ptuple.unstagedStoreJavaObject(sm, Row(key), region)
+        val eoff = ptuple.unstagedStoreJavaObject(sm, RowSeq(key), region)
 
         val fb = EmitFunctionBuilder[Region, Long, Long, Int](ctx, "binary_search_dict")
         val cdict = fb.getCodeParam[Long](2)
@@ -679,7 +679,7 @@ class OrderingSuite {
     val rs = for {
       x <- xs
       s <- ss
-    } yield Row(x, s)
+    } yield RowSeq(x, s)
 
     for {
       r <- rs

--- a/hail/hail/test/src/is/hail/expr/ir/PruneSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/PruneSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.expr.ir
 
 import is.hail.ParameterizedTest
+import is.hail.annotations.RowSeq
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
 import is.hail.collection.compat.immutable.ArraySeq
@@ -16,7 +17,6 @@ import is.hail.types.virtual._
 
 import scala.collection.mutable
 
-import org.apache.spark.sql.Row
 import org.json4s.JValue
 import org.junit.jupiter.api.Test
 
@@ -154,9 +154,15 @@ class PruneSuite {
               )),
               "global" -> TStruct("g1" -> TInt32, "g2" -> TInt32),
             ),
-            Row(
-              FastSeq(Row("hi", FastSeq(Row(1)), "bye", Row(2, FastSeq(Row("bar"))), "foo")),
-              Row(5, 10),
+            RowSeq(
+              FastSeq(RowSeq(
+                "hi",
+                FastSeq(RowSeq(1)),
+                "bye",
+                RowSeq(2, FastSeq(RowSeq("bar"))),
+                "foo",
+              )),
+              RowSeq(5, 10),
             ),
           ),
           None,
@@ -194,8 +200,8 @@ class PruneSuite {
     ctx,
     mType,
     RVD.empty(ctx, mType.canonicalTableType.canonicalRVDType),
-    Row(1, 1.0),
-    FastSeq(Row("1", 2, FastSeq(Row(3)))),
+    RowSeq(1, 1.0),
+    FastSeq(RowSeq("1", 2, FastSeq(RowSeq(3)))),
   )
 
   def mr(implicit ctx: ExecuteContext) = MatrixRead(

--- a/hail/hail/test/src/is/hail/expr/ir/RequirednessSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/RequirednessSuite.scala
@@ -2,6 +2,7 @@ package is.hail.expr.ir
 
 import is.hail.ParameterizedTest
 import is.hail.TestUtils._
+import is.hail.annotations.RowSeq
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
 import is.hail.collection.compat.immutable.ArraySeq
@@ -20,7 +21,6 @@ import is.hail.types.virtual._
 
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.spark.sql.Row
 import org.junit.jupiter.api.Test
 
 class RequirednessSuite {
@@ -123,7 +123,7 @@ class RequirednessSuite {
       IsNA(I32(5)),
       Cast(I32(5), TFloat64),
       Die("mumblefoo", TFloat64),
-      Literal(TStruct("x" -> TInt32), Row(1)),
+      Literal(TStruct("x" -> TInt32), RowSeq(1)),
       MakeArray(FastSeq(I32(4)), TArray(TInt32)),
       MakeStruct(FastSeq("x" -> I32(4), "y" -> Str("foo"))),
       MakeTuple.ordered(FastSeq(I32(5), Str("bar"))),
@@ -207,7 +207,7 @@ class RequirednessSuite {
     }
 
     val value =
-      Literal(pDisc.virtualType, Row(null, IndexedSeq(1), IndexedSeq(Row(1, IndexedSeq(1)))))
+      Literal(pDisc.virtualType, RowSeq(null, IndexedSeq(1), IndexedSeq(RowSeq(1, IndexedSeq(1)))))
     nodes += ((WriteValue(value, Str("foo"), vr), PCanonicalString(required)))
     nodes += ((WriteValue(NA(pDisc.virtualType), Str("foo"), vr), PCanonicalString(optional)))
     nodes += ((WriteValue(value, NA(TString), vr), PCanonicalString(optional)))

--- a/hail/hail/test/src/is/hail/expr/ir/SimplifySuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/SimplifySuite.scala
@@ -3,6 +3,7 @@ package is.hail.expr.ir
 import is.hail.{ExecStrategy, ParameterizedTest}
 import is.hail.ExecStrategy.ExecStrategy
 import is.hail.TestUtils._
+import is.hail.annotations.RowSeq
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
 import is.hail.collection.compat.immutable.ArraySeq
@@ -14,7 +15,6 @@ import is.hail.types.virtual._
 import is.hail.utils.Interval
 import is.hail.variant.Locus
 
-import org.apache.spark.sql.Row
 import org.junit.jupiter.api.{Disabled, Test}
 import org.scalactic.{Equivalence, Prettifier}
 import org.scalatest.matchers.{MatchResult, Matcher}
@@ -62,7 +62,7 @@ class SimplifySuite {
       "rowField",
       "globalField",
     ))
-    assertEvalsTo(tmwzj, Row(FastSeq(Row(), Row(), Row())))
+    assertEvalsTo(tmwzj, RowSeq(FastSeq(RowSeq(), RowSeq(), RowSeq())))
   }
 
   @Test def testRepartitionableMapUpdatesForUpstreamOptimizations(implicit ctx: ExecuteContext)
@@ -79,7 +79,7 @@ class SimplifySuite {
     assertEvalsTo(TableAggregate(checksRepartitioningIR, IRAggCount), 1L)
   }
 
-  lazy val base = Literal(TStruct("1" -> TInt32, "2" -> TInt32), Row(1, 2))
+  lazy val base = Literal(TStruct("1" -> TInt32, "2" -> TInt32), RowSeq(1, 2))
 
   @Test def testInsertFieldsRewriteRules(implicit ctx: ExecuteContext): Unit = {
     val ir1 =
@@ -131,7 +131,7 @@ class SimplifySuite {
   }
 
   lazy val base2 =
-    Literal(TStruct("A" -> TInt32, "B" -> TInt32, "C" -> TInt32, "D" -> TInt32), Row(1, 2, 3, 4))
+    Literal(TStruct("A" -> TInt32, "B" -> TInt32, "C" -> TInt32, "D" -> TInt32), RowSeq(1, 2, 3, 4))
 
   @Test def testInsertFieldsWhereFieldBeingInsertedCouldBeSelected(implicit ctx: ExecuteContext)
     : Unit = {
@@ -422,11 +422,11 @@ class SimplifySuite {
     def r = Ref(TableIR.rowName, tir.typ.rowType)
     tir = TableMapRows(tir, InsertFields(r, FastSeq("idx2" -> GetField(r, "idx"))))
     tir = TableKeyBy(tir, FastSeq("idx", "idx2"))
-    tir = TableFilterIntervals(tir, FastSeq(Interval(Row(0), Row(1), true, false)), false)
-    tir = TableFilterIntervals(tir, FastSeq(Interval(Row(8), Row(10), true, false)), false)
+    tir = TableFilterIntervals(tir, FastSeq(Interval(RowSeq(0), RowSeq(1), true, false)), false)
+    tir = TableFilterIntervals(tir, FastSeq(Interval(RowSeq(8), RowSeq(10), true, false)), false)
     assert(Simplify(ctx, tir).asInstanceOf[TableFilterIntervals].intervals == FastSeq(
-      Interval(Row(0), Row(1), true, false),
-      Interval(Row(8), Row(10), true, false),
+      Interval(RowSeq(0), RowSeq(1), true, false),
+      Interval(RowSeq(8), RowSeq(10), true, false),
     ))
   }
 
@@ -443,16 +443,16 @@ class SimplifySuite {
     val tzrr = tzr.tr.asInstanceOf[TableNativeZippedReader]
 
     val intervals1 = FastSeq(
-      Interval(Row(Locus("1", 100000)), Row(Locus("1", 200000)), true, false),
-      Interval(Row(Locus("2", 100000)), Row(Locus("2", 200000)), true, false),
+      Interval(RowSeq(Locus("1", 100000)), RowSeq(Locus("1", 200000)), true, false),
+      Interval(RowSeq(Locus("2", 100000)), RowSeq(Locus("2", 200000)), true, false),
     )
     val intervals2 = FastSeq(
-      Interval(Row(Locus("1", 150000)), Row(Locus("1", 250000)), true, false),
-      Interval(Row(Locus("2", 150000)), Row(Locus("2", 250000)), true, false),
+      Interval(RowSeq(Locus("1", 150000)), RowSeq(Locus("1", 250000)), true, false),
+      Interval(RowSeq(Locus("2", 150000)), RowSeq(Locus("2", 250000)), true, false),
     )
     val intersection = FastSeq(
-      Interval(Row(Locus("1", 150000)), Row(Locus("1", 200000)), true, false),
-      Interval(Row(Locus("2", 150000)), Row(Locus("2", 200000)), true, false),
+      Interval(RowSeq(Locus("1", 150000)), RowSeq(Locus("1", 200000)), true, false),
+      Interval(RowSeq(Locus("2", 150000)), RowSeq(Locus("2", 200000)), true, false),
     )
 
     val exp1 =
@@ -516,7 +516,7 @@ class SimplifySuite {
     t = TableKeyBy(t, FastSeq("x"))
     t = TableFilterIntervals(
       t,
-      FastSeq(Interval(Row(-10), Row(10), includesStart = true, includesEnd = false)),
+      FastSeq(Interval(RowSeq(-10), RowSeq(10), includesStart = true, includesEnd = false)),
       keep = true,
     )
 

--- a/hail/hail/test/src/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/TableIRSuite.scala
@@ -3,7 +3,7 @@ package is.hail.expr.ir
 import is.hail.{ExecStrategy, ParameterizedTest}
 import is.hail.ExecStrategy.ExecStrategy
 import is.hail.TestUtils._
-import is.hail.annotations.SafeNDArray
+import is.hail.annotations.{RowSeq, SafeNDArray}
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
 import is.hail.collection.compat.immutable.ArraySeq
@@ -62,12 +62,12 @@ class TableIRSuite {
     val uids = for {
       (partSize, partIndex) <- partition(10, 3).zipWithIndex
       i <- 0 until partSize
-    } yield Row(partIndex.toLong, i.toLong)
-    val expectedRows = (0 until 10).lazyZip(uids).map((i, uid) => Row(i, uid))
-    val expectedGlobals = Row(57)
+    } yield RowSeq(partIndex.toLong, i.toLong)
+    val expectedRows = (0 until 10).lazyZip(uids).map((i, uid) => RowSeq(i, uid))
+    val expectedGlobals = RowSeq(57)
 
-    assertEvalsTo(TableCollect(read), Row(expectedRows, expectedGlobals))
-    assertEvalsTo(TableCollect(droppedRows), Row(FastSeq(), expectedGlobals))
+    assertEvalsTo(TableCollect(read), RowSeq(expectedRows, expectedGlobals))
+    assertEvalsTo(TableCollect(droppedRows), RowSeq(FastSeq(), expectedGlobals))
   }
 
   @Test def testCountRead(implicit ctx: ExecuteContext): Unit = {
@@ -81,8 +81,8 @@ class TableIRSuite {
     val t = TableRange(10, 2)
     val row = Ref(TableIR.rowName, t.typ.rowType)
     val node = collect(TableMapRows(t, InsertFields(row, FastSeq("x" -> GetField(row, "idx")))))
-    assertEvalsTo(collect(t), Row(ArraySeq.tabulate(10)(Row(_)), Row()))
-    assertEvalsTo(node, Row(ArraySeq.tabulate(10)(i => Row(i, i)), Row()))
+    assertEvalsTo(collect(t), RowSeq(ArraySeq.tabulate(10)(RowSeq(_)), RowSeq()))
+    assertEvalsTo(node, RowSeq(ArraySeq.tabulate(10)(i => RowSeq(i, i)), RowSeq()))
   }
 
   @Test def testNestedRangeCollect(implicit ctx: ExecuteContext): Unit = {
@@ -97,12 +97,12 @@ class TableIRSuite {
     )
     assertEvalsTo(
       collect(m),
-      Row(
+      RowSeq(
         FastSeq(
-          Row(0, FastSeq(Row(0), Row(1))),
-          Row(1, FastSeq(Row(0), Row(1))),
+          RowSeq(0, FastSeq(RowSeq(0), RowSeq(1))),
+          RowSeq(1, FastSeq(RowSeq(0), RowSeq(1))),
         ),
-        Row(),
+        RowSeq(),
       ),
     )
   }
@@ -120,7 +120,7 @@ class TableIRSuite {
     ))
     assertEvalsTo(
       node,
-      Row(ArraySeq.tabulate(10)(i => Row(i, ArraySeq.range(0, i).sum.toLong)), Row()),
+      RowSeq(ArraySeq.tabulate(10)(i => RowSeq(i, ArraySeq.range(0, i).sum.toLong)), RowSeq()),
     )
   }
 
@@ -130,7 +130,7 @@ class TableIRSuite {
     val newGlobals =
       InsertFields(Ref(TableIR.globalName, t.typ.globalType), FastSeq("x" -> collect(t)))
     val node = TableGetGlobals(TableMapGlobals(t, newGlobals))
-    assertEvalsTo(node, Row(Row(ArraySeq.tabulate(10)(i => Row(i)), Row())))
+    assertEvalsTo(node, RowSeq(RowSeq(ArraySeq.tabulate(10)(i => RowSeq(i)), RowSeq())))
   }
 
   @Test def testCollectGlobals(implicit ctx: ExecuteContext): Unit = {
@@ -146,10 +146,10 @@ class TableIRSuite {
       ),
     )
 
-    val collectedT = Row(ArraySeq.tabulate(10)(i => Row(i)), Row())
-    val expected = ArraySeq.tabulate(10)(i => Row(i, collectedT))
+    val collectedT = RowSeq(ArraySeq.tabulate(10)(i => RowSeq(i)), RowSeq())
+    val expected = ArraySeq.tabulate(10)(i => RowSeq(i, collectedT))
 
-    assertEvalsTo(collect(node), Row(expected, Row(collectedT)))
+    assertEvalsTo(collect(node), RowSeq(expected, RowSeq(collectedT)))
   }
 
   @Test def testRangeExplode(implicit ctx: ExecuteContext): Unit = {
@@ -162,8 +162,8 @@ class TableIRSuite {
       InsertFields(row, FastSeq("x" -> ToArray(StreamRange(0, GetField(row, "idx"), 1)))),
     )
     val node = TableExplode(t2, FastSeq("x"))
-    val expected = ArraySeq.range(0, 10).flatMap(i => ArraySeq.range(0, i).map(Row(i, _)))
-    assertEvalsTo(collect(node), Row(expected, Row()))
+    val expected = ArraySeq.range(0, 10).flatMap(i => ArraySeq.range(0, i).map(RowSeq(i, _)))
+    assertEvalsTo(collect(node), RowSeq(expected, RowSeq()))
 
     val t3 = TableMapRows(
       t,
@@ -175,8 +175,8 @@ class TableIRSuite {
     )
     val node2 = TableExplode(t3, FastSeq("x", "y"))
     val expected2 =
-      ArraySeq.range(0, 10).flatMap(i => ArraySeq.range(0, i).map(j => Row(i, Row(j))))
-    assertEvalsTo(collect(node2), Row(expected2, Row()))
+      ArraySeq.range(0, 10).flatMap(i => ArraySeq.range(0, i).map(j => RowSeq(i, RowSeq(j))))
+    assertEvalsTo(collect(node2), RowSeq(expected2, RowSeq()))
   }
 
   @Test def testFilter(implicit ctx: ExecuteContext): Unit = {
@@ -194,9 +194,9 @@ class TableIRSuite {
       ),
     )
 
-    val expected = ArraySeq.tabulate(10)(Row(_)).filter(_.get(0) == 4)
+    val expected = ArraySeq.tabulate(10)(RowSeq(_)).filter(_.get(0) == 4)
 
-    assertEvalsTo(collect(node), Row(expected, Row(4)))
+    assertEvalsTo(collect(node), RowSeq(expected, RowSeq(4)))
   }
 
   @Test def testFilterIntervals(implicit ctx: ExecuteContext): Unit = {
@@ -210,10 +210,12 @@ class TableIRSuite {
       var t: TableIR = TableRange(10, 5)
       t = TableFilterIntervals(
         t,
-        intervals.map(i => Interval(Row(i.start), Row(i.end), i.includesStart, i.includesEnd)),
+        intervals.map(i =>
+          Interval(RowSeq(i.start), RowSeq(i.end), i.includesStart, i.includesEnd)
+        ),
         keep,
       )
-      assertEvalsTo(GetField(collect(t), "rows"), expected.map(Row(_)))
+      assertEvalsTo(GetField(collect(t), "rows"), expected.map(RowSeq(_)))
     }
 
     assertFilterIntervals(
@@ -276,13 +278,13 @@ class TableIRSuite {
         Ref(TableIR.rowName, t.typ.rowType),
         FastSeq(
           "a" -> Str("foo"),
-          "b" -> Literal(TTuple(TInt32, TString), Row(1, "hello")),
+          "b" -> Literal(TTuple(TInt32, TString), RowSeq(1, "hello")),
         ),
       ),
     )
 
-    val expected = ArraySeq.tabulate(10)(Row(_, "foo", Row(1, "hello")))
-    assertEvalsTo(collect(node), Row(expected, Row()))
+    val expected = ArraySeq.tabulate(10)(RowSeq(_, "foo", RowSeq(1, "hello")))
+    assertEvalsTo(collect(node), RowSeq(expected, RowSeq()))
   }
 
   @Test def testScanCountBehavesLikeIndex(implicit ctx: ExecuteContext): Unit = {
@@ -292,7 +294,7 @@ class TableIRSuite {
 
     val newRow = InsertFields(oldRow, FastSeq("idx2" -> IRScanCount))
     val newTable = TableMapRows(t, newRow)
-    val expected = ArraySeq.tabulate(20)(i => Row(i, i.toLong))
+    val expected = ArraySeq.tabulate(20)(i => RowSeq(i, i.toLong))
     assertEvalsTo(
       ArraySort(
         ToStream(TableAggregate(newTable, IRAggCollect(Ref(TableIR.rowName, newRow.typ)))),
@@ -310,7 +312,7 @@ class TableIRSuite {
     val newRow = InsertFields(oldRow, FastSeq("range" -> IRScanCollect(GetField(oldRow, "idx"))))
     val newTable = TableMapRows(t, newRow)
 
-    val expected = ArraySeq.tabulate(20)(i => Row(i, ArraySeq.range(0, i)))
+    val expected = ArraySeq.tabulate(20)(i => RowSeq(i, ArraySeq.range(0, i)))
     assertEvalsTo(
       ArraySort(
         ToStream(TableAggregate(newTable, IRAggCollect(Ref(TableIR.rowName, newRow.typ)))),
@@ -433,44 +435,44 @@ class TableIRSuite {
   ).map(Row.fromTuple)
 
   val expectedZipJoin = ArraySeq(
-    (3, 1, FastSeq(Row(-1), null)),
-    (3, 2, FastSeq(Row(-1), null)),
-    (6, 1, FastSeq(null, Row(1))),
-    (6, 2, FastSeq(null, Row(1))),
-    (11, 1, FastSeq(Row(-1), null)),
-    (11, 2, FastSeq(Row(-1), null)),
-    (16, 1, FastSeq(Row(-1), null)),
-    (16, 2, FastSeq(Row(-1), null)),
-    (17, 1, FastSeq(Row(-1), Row(1))),
-    (17, 2, FastSeq(Row(-1), Row(1))),
-    (18, 1, FastSeq(null, Row(1))),
-    (18, 2, FastSeq(null, Row(1))),
-    (21, 1, FastSeq(null, Row(1))),
-    (21, 2, FastSeq(null, Row(1))),
-    (22, 1, FastSeq(Row(-1), Row(1))),
-    (22, 2, FastSeq(Row(-1), Row(1))),
-    (23, 1, FastSeq(Row(-1), null)),
-    (23, 2, FastSeq(Row(-1), null)),
-    (26, 1, FastSeq(Row(-1), null)),
-    (26, 2, FastSeq(Row(-1), null)),
-    (27, 1, FastSeq(Row(-1), Row(1))),
-    (27, 2, FastSeq(Row(-1), Row(1))),
-    (28, 1, FastSeq(null, Row(1))),
-    (28, 2, FastSeq(null, Row(1))),
-    (31, 1, FastSeq(null, Row(1))),
-    (31, 2, FastSeq(null, Row(1))),
-    (32, 1, FastSeq(Row(-1), Row(1))),
-    (32, 2, FastSeq(Row(-1), Row(1))),
-    (33, 1, FastSeq(Row(-1), null)),
-    (33, 2, FastSeq(Row(-1), null)),
-    (36, 1, FastSeq(Row(-1), null)),
-    (36, 2, FastSeq(Row(-1), null)),
-    (37, 1, FastSeq(Row(-1), Row(1))),
-    (37, 2, FastSeq(Row(-1), Row(1))),
-    (38, 1, FastSeq(null, Row(1))),
-    (38, 2, FastSeq(null, Row(1))),
-    (41, 1, FastSeq(null, Row(1))),
-    (41, 2, FastSeq(null, Row(1))),
+    (3, 1, FastSeq(RowSeq(-1), null)),
+    (3, 2, FastSeq(RowSeq(-1), null)),
+    (6, 1, FastSeq(null, RowSeq(1))),
+    (6, 2, FastSeq(null, RowSeq(1))),
+    (11, 1, FastSeq(RowSeq(-1), null)),
+    (11, 2, FastSeq(RowSeq(-1), null)),
+    (16, 1, FastSeq(RowSeq(-1), null)),
+    (16, 2, FastSeq(RowSeq(-1), null)),
+    (17, 1, FastSeq(RowSeq(-1), RowSeq(1))),
+    (17, 2, FastSeq(RowSeq(-1), RowSeq(1))),
+    (18, 1, FastSeq(null, RowSeq(1))),
+    (18, 2, FastSeq(null, RowSeq(1))),
+    (21, 1, FastSeq(null, RowSeq(1))),
+    (21, 2, FastSeq(null, RowSeq(1))),
+    (22, 1, FastSeq(RowSeq(-1), RowSeq(1))),
+    (22, 2, FastSeq(RowSeq(-1), RowSeq(1))),
+    (23, 1, FastSeq(RowSeq(-1), null)),
+    (23, 2, FastSeq(RowSeq(-1), null)),
+    (26, 1, FastSeq(RowSeq(-1), null)),
+    (26, 2, FastSeq(RowSeq(-1), null)),
+    (27, 1, FastSeq(RowSeq(-1), RowSeq(1))),
+    (27, 2, FastSeq(RowSeq(-1), RowSeq(1))),
+    (28, 1, FastSeq(null, RowSeq(1))),
+    (28, 2, FastSeq(null, RowSeq(1))),
+    (31, 1, FastSeq(null, RowSeq(1))),
+    (31, 2, FastSeq(null, RowSeq(1))),
+    (32, 1, FastSeq(RowSeq(-1), RowSeq(1))),
+    (32, 2, FastSeq(RowSeq(-1), RowSeq(1))),
+    (33, 1, FastSeq(RowSeq(-1), null)),
+    (33, 2, FastSeq(RowSeq(-1), null)),
+    (36, 1, FastSeq(RowSeq(-1), null)),
+    (36, 2, FastSeq(RowSeq(-1), null)),
+    (37, 1, FastSeq(RowSeq(-1), RowSeq(1))),
+    (37, 2, FastSeq(RowSeq(-1), RowSeq(1))),
+    (38, 1, FastSeq(null, RowSeq(1))),
+    (38, 2, FastSeq(null, RowSeq(1))),
+    (41, 1, FastSeq(null, RowSeq(1))),
+    (41, 2, FastSeq(null, RowSeq(1))),
   ).map(Row.fromTuple)
 
   val expectedOuterJoin = ArraySeq(
@@ -570,7 +572,7 @@ class TableIRSuite {
       TableParallelize(
         Literal(
           TStruct("rows" -> TArray(leftType), "global" -> TStruct.empty),
-          Row(leftData.map(leftProjectF.asInstanceOf[Row => Row]), Row()),
+          RowSeq(leftData.map(leftProjectF.asInstanceOf[Row => Row]), RowSeq()),
         ),
         Some(lParts),
       ),
@@ -582,7 +584,7 @@ class TableIRSuite {
       TableParallelize(
         Literal(
           TStruct("rows" -> TArray(rightType), "global" -> TStruct.empty),
-          Row(rightData.map(rightProjectF.asInstanceOf[Row => Row]), Row()),
+          RowSeq(rightData.map(rightProjectF.asInstanceOf[Row => Row]), RowSeq()),
         ),
         Some(rParts),
       ),
@@ -607,7 +609,7 @@ class TableIRSuite {
       )
     )
 
-    assertEvalsTo(joined, Row(expectedOuterJoin.filter(pred).map(joinProjectF), Row()))
+    assertEvalsTo(joined, RowSeq(expectedOuterJoin.filter(pred).map(joinProjectF), RowSeq()))
   }
 
   def unionData() =
@@ -622,7 +624,7 @@ class TableIRSuite {
       TableParallelize(
         Literal(
           TStruct("rows" -> TArray(rowType), "global" -> TStruct.empty),
-          Row(leftData, Row()),
+          RowSeq(leftData, RowSeq()),
         ),
         Some(lParts),
       ),
@@ -633,7 +635,7 @@ class TableIRSuite {
       TableParallelize(
         Literal(
           TStruct("rows" -> TArray(rowType), "global" -> TStruct.empty),
-          Row(rightData, Row()),
+          RowSeq(rightData, RowSeq()),
         ),
         Some(rParts),
       ),
@@ -642,7 +644,7 @@ class TableIRSuite {
 
     val merged = collect(TableUnion(FastSeq(left, right)))
 
-    assertEvalsTo(merged, Row(expectedUnion, Row()))
+    assertEvalsTo(merged, RowSeq(expectedUnion, RowSeq()))
   }
 
   @ParameterizedTest("unionData")
@@ -652,7 +654,7 @@ class TableIRSuite {
       TableParallelize(
         Literal(
           TStruct("rows" -> TArray(rowType), "global" -> TStruct.empty),
-          Row(leftData, Row()),
+          RowSeq(leftData, RowSeq()),
         ),
         Some(lParts),
       ),
@@ -663,7 +665,7 @@ class TableIRSuite {
       TableParallelize(
         Literal(
           TStruct("rows" -> TArray(rowType), "global" -> TStruct.empty),
-          Row(rightData, Row()),
+          RowSeq(rightData, RowSeq()),
         ),
         Some(rParts),
       ),
@@ -672,7 +674,7 @@ class TableIRSuite {
 
     val merged = collect(TableMultiWayZipJoin(FastSeq(left, right), "row", "global"))
 
-    assertEvalsTo(merged, Row(expectedZipJoin, Row(FastSeq(Row(), Row()))))
+    assertEvalsTo(merged, RowSeq(expectedZipJoin, RowSeq(FastSeq(RowSeq(), RowSeq()))))
   }
 
   // Catches a bug in the partitioner created by the importer.
@@ -693,7 +695,7 @@ class TableIRSuite {
   @Test def testNativeReaderWithOverlappingPartitions(implicit ctx: ExecuteContext): Unit = {
     val path = getTestResource("sample.vcf-20-partitions-with-overlap.mt/rows")
     // i1 overlaps the first two partitions
-    val i1 = Interval(Row(Locus("20", 10200000)), Row(Locus("20", 10500000)), true, true)
+    val i1 = Interval(RowSeq(Locus("20", 10200000)), RowSeq(Locus("20", 10500000)), true, true)
 
     def test(filterIntervals: Boolean, expectedNParts: Int): Unit = {
       val opts = NativeReaderOptions(FastSeq(i1), TLocus("GRCh37"), filterIntervals)
@@ -712,7 +714,7 @@ class TableIRSuite {
   @Test def testTableKeyBy(implicit ctx: ExecuteContext): Unit = {
     implicit val execStrats = ExecStrategy.interpretOnly
     val data = ArraySeq(ArraySeq("A", 1), ArraySeq("A", 2), ArraySeq("B", 1))
-    val rdd = ctx.backend.asSpark.sc.parallelize(data.map(Row.fromSeq(_)))
+    val rdd = ctx.backend.asSpark.sc.parallelize(data.map(RowSeq.fromSeq(_)))
     val signature = TStruct(("field1", TString), ("field2", TInt32))
     val keyNames = FastSeq("field1", "field2")
     val tt = TableType(rowType = signature, key = keyNames, globalType = TStruct.empty)
@@ -739,7 +741,7 @@ class TableIRSuite {
       "global" -> TStruct("x" -> TString),
     )
     val length = 10
-    val value = Row(FastSeq(0 until length: _*).map(i => Row(0, "row" + i)), Row("global"))
+    val value = RowSeq(FastSeq(0 until length: _*).map(i => RowSeq(0, "row" + i)), RowSeq("global"))
 
     val par = TableParallelize(Literal(t, value))
 
@@ -754,7 +756,8 @@ class TableIRSuite {
       "global" -> TStruct("x" -> TString),
     )
     Array(1, 10, 17, 34, 103).foreach { length =>
-      val value = Row(FastSeq(0 until length: _*).map(i => Row(i, "row" + i)), Row("global"))
+      val value =
+        RowSeq(FastSeq(0 until length: _*).map(i => RowSeq(i, "row" + i)), RowSeq("global"))
       assertEvalsTo(
         collectNoKey(
           TableParallelize(
@@ -775,7 +778,7 @@ class TableIRSuite {
       "rows" -> TArray(TStruct("a" -> TInt32, "b" -> TString)),
       "global" -> TStruct("x" -> TString),
     )
-    val value = Row(FastSeq(Row(0, "row1"), Row(1, "row2")), Row("glob"))
+    val value = RowSeq(FastSeq(RowSeq(0, "row1"), RowSeq(1, "row2")), RowSeq("glob"))
 
     assertEvalsTo(
       TableCount(
@@ -796,7 +799,7 @@ class TableIRSuite {
       "global" -> TStruct("x" -> TString),
     )
     def makeData(length: Int): Row =
-      Row(FastSeq(0 until length: _*).map(i => Row(i, "row" + i)), Row("global"))
+      RowSeq(FastSeq(0 until length: _*).map(i => RowSeq(i, "row" + i)), RowSeq("global"))
     val numRowsToTakeArray = Array(0, 4, 7, 12)
     val numInitialPartitionsArray = Array(1, 2, 6, 10, 13)
     val initialDataLength = 10
@@ -830,11 +833,11 @@ class TableIRSuite {
     val numInitialPartitionsArray = Array(1, 3, 6, 10, 13)
     val initialDataLength = 10
     def makeData(length: Int): Row =
-      Row(
+      RowSeq(
         FastSeq((initialDataLength - length) until initialDataLength: _*).map(i =>
-          Row(i, "row" + i)
+          RowSeq(i, "row" + i)
         ),
-        Row("global"),
+        RowSeq("global"),
       )
     val initialData = makeData(initialDataLength)
 
@@ -879,9 +882,10 @@ class TableIRSuite {
       "rows" -> TArray(TStruct("a" -> TInt32, "b" -> TString)),
       "global" -> TStruct(("x", TString), ("y", TInt32)),
     )
-    val value = Row(FastSeq(0 until 10: _*).map(i => Row(i, "row" + i)), Row("globalVal", 3))
+    val value =
+      RowSeq(FastSeq(0 until 10: _*).map(i => RowSeq(i, "row" + i)), RowSeq("globalVal", 3))
     val adjustedValue =
-      Row(FastSeq(0 until 10: _*).map(i => Row(i + 3, "row" + i)), Row("globalVal", 3))
+      RowSeq(FastSeq(0 until 10: _*).map(i => RowSeq(i + 3, "row" + i)), RowSeq("globalVal", 3))
 
     val renameIR =
       TableRename(
@@ -923,9 +927,9 @@ class TableIRSuite {
     val innerRowRef = Ref(TableIR.rowName, t.field("rows").typ.asInstanceOf[TArray].elementType)
     val innerGlobalRef = Ref(TableIR.globalName, t.field("global").typ)
     val length = 10
-    val value = Row(FastSeq(0 until length: _*).map(i => Row(i, "row" + i)), Row("global"))
+    val value = RowSeq(FastSeq(0 until length: _*).map(i => RowSeq(i, "row" + i)), RowSeq("global"))
     val modifedValue =
-      Row(FastSeq(0 until length: _*).map(i => Row(i, "global")), Row("newGlobals"))
+      RowSeq(FastSeq(0 until length: _*).map(i => RowSeq(i, "global")), RowSeq("newGlobals"))
     assertEvalsTo(
       collectNoKey(
         TableMapGlobals(
@@ -1040,12 +1044,12 @@ class TableIRSuite {
     )
     assertEvalsTo(
       TableCollect(tr),
-      Row(
+      RowSeq(
         IndexedSeq.tabulate(10) { i =>
           val r = (0 until i).map(_.toLong).scanLeft(0L)(_ + _).init.sum
-          Row(i, r)
+          RowSeq(i, r)
         },
-        Row(),
+        RowSeq(),
       ),
     )
   }
@@ -1072,13 +1076,13 @@ class TableIRSuite {
     )
     assertEvalsTo(
       TableCollect(tr),
-      Row(
+      RowSeq(
         ArraySeq.tabulate(10)(i => (0 until i).map(_.toLong).scanLeft(0L)(_ + _).init.sum).scanLeft(
           0L
         )(_ + _)
           .zipWithIndex
-          .map { case (x, idx) => Row(idx, x) }.init,
-        Row(),
+          .map { case (x, idx) => RowSeq(idx, x) }.init,
+        RowSeq(),
       ),
     )
   }
@@ -1101,7 +1105,7 @@ class TableIRSuite {
     assertEvalsTo(
       ir,
       (0 until 10).flatMap(i =>
-        (0 until i).map(j => Row(i, j, (0 until j).sum.toLong, j.toLong))
+        (0 until i).map(j => RowSeq(i, j, (0 until j).sum.toLong, j.toLong))
       ).filter(_.getAs[Long](3) > 0),
     )
   }
@@ -1111,7 +1115,10 @@ class TableIRSuite {
     val keyedByX = TableKeyBy(tir, FastSeq("x"), true)
     val distinctByX = TableDistinct(keyedByX)
     assertEvalsTo(TableCount(distinctByX), 8L)
-    assertEvalsTo(collect(distinctByX), Row(FastSeq(2 to 9: _*).map(i => Row(i, 1, 0)), Row()))
+    assertEvalsTo(
+      collect(distinctByX),
+      RowSeq(FastSeq(2 to 9: _*).map(i => RowSeq(i, 1, 0)), RowSeq()),
+    )
 
     val keyedByXAndY = TableKeyBy(tir, FastSeq("x", "y"), true)
     val distinctByXAndY = TableDistinct(keyedByXAndY)
@@ -1127,7 +1134,7 @@ class TableIRSuite {
     tir = TableOrderBy(tir, FastSeq(SortField("idx", Descending)))
     val x = GetField(TableCollect(tir), "rows")
 
-    assertEvalsTo(x, (0 until 10).reverse.map(i => Row(i)))
+    assertEvalsTo(x, (0 until 10).reverse.map(i => RowSeq(i)))
   }
 
   @Test def testTableLeftJoinRightDistinctRangeTables(implicit ctx: ExecuteContext): Unit = {
@@ -1140,11 +1147,11 @@ class TableIRSuite {
       val joinedRanges = TableLeftJoinRightDistinct(rangeTable1, rangeTable2, "foo")
       assertEvalsTo(TableCount(joinedRanges), 10L)
 
-      val expectedJoinCollectResult = Row(
-        (0 until 5).map(i => Row(FastSeq(i, Row(i)): _*)) ++ (5 until 10).map(i =>
-          Row(FastSeq(i, null): _*)
+      val expectedJoinCollectResult = RowSeq(
+        (0 until 5).map(i => RowSeq(FastSeq(i, RowSeq(i)): _*)) ++ (5 until 10).map(i =>
+          RowSeq(FastSeq(i, null): _*)
         ),
-        Row(),
+        RowSeq(),
       )
       assertEvalsTo(collect(joinedRanges), expectedJoinCollectResult)
     }
@@ -1159,7 +1166,7 @@ class TableIRSuite {
     tir = TableMapRows(tir, ir)
     assertEvalsTo(
       collect(tir),
-      Row(FastSeq(Row(0, FastSeq(FastSeq(0, 1), FastSeq(2, 3), FastSeq(4)))), Row()),
+      RowSeq(FastSeq(RowSeq(0, FastSeq(FastSeq(0, 1), FastSeq(2, 3), FastSeq(4)))), RowSeq()),
     )
   }
 
@@ -1170,9 +1177,9 @@ class TableIRSuite {
     "global" -> TStruct("x" -> TString),
   )
 
-  val value1 = Row(
-    FastSeq(0 until parTable1Length: _*).map(i => Row("row" + i, i * i, s"t1_$i")),
-    Row("global"),
+  val value1 = RowSeq(
+    FastSeq(0 until parTable1Length: _*).map(i => RowSeq("row" + i, i * i, s"t1_$i")),
+    RowSeq("global"),
   )
 
   val table1 = TableParallelize(Literal(parTable1Type, value1), Some(2))
@@ -1185,7 +1192,10 @@ class TableIRSuite {
   )
 
   val value2 =
-    Row(FastSeq(0 until parTable2Length: _*).map(i => Row("row" + i, -2 * i, s"t2_$i")), Row(15))
+    RowSeq(
+      FastSeq(0 until parTable2Length: _*).map(i => RowSeq("row" + i, -2 * i, s"t2_$i")),
+      RowSeq(15),
+    )
 
   val table2 = TableParallelize(Literal(parTable2Type, value2), Some(3))
 
@@ -1200,11 +1210,11 @@ class TableIRSuite {
     assertEvalsTo(TableCount(joinedParKeyedByA), parTable1Length.toLong)
     assertEvalsTo(
       collect(joinedParKeyedByA),
-      Row(
+      RowSeq(
         FastSeq(0 until parTable1Length: _*).map(i =>
-          Row("row" + i, i * i, s"t1_$i", Row(-2 * i, s"t2_$i"))
+          RowSeq("row" + i, i * i, s"t1_$i", RowSeq(-2 * i, s"t2_$i"))
         ),
-        Row("global"),
+        RowSeq("global"),
       ),
     )
   }
@@ -1218,11 +1228,11 @@ class TableIRSuite {
     assertEvalsTo(TableCount(joinedParKeyedByAAndB), parTable1Length.toLong)
     assertEvalsTo(
       collect(joinedParKeyedByAAndB),
-      Row(
+      RowSeq(
         FastSeq(0 until parTable1Length: _*).map(i =>
-          Row("row" + i, i * i, s"t1_$i", Row(-2 * i, s"t2_$i"))
+          RowSeq("row" + i, i * i, s"t1_$i", RowSeq(-2 * i, s"t2_$i"))
         ),
-        Row("global"),
+        RowSeq("global"),
       ),
     )
   }
@@ -1245,7 +1255,7 @@ class TableIRSuite {
     val left =
       TableKeyBy(
         TableParallelize(MakeStruct(FastSeq(
-          "rows" -> Literal(TArray(TStruct("a" -> TInt32)), (0 until 9).map(Row(_))),
+          "rows" -> Literal(TArray(TStruct("a" -> TInt32)), (0 until 9).map(RowSeq(_))),
           "global" -> MakeStruct(FastSeq("left" -> Str("globals"))),
         ))),
         FastSeq("a"),
@@ -1257,7 +1267,7 @@ class TableIRSuite {
         TableParallelize(MakeStruct(FastSeq(
           "rows" -> Literal(
             TArray(TStruct("interval" -> TInterval(TInt32), "b" -> TInt32)),
-            intervals.zipWithIndex.map { case (i, idx) => Row(i, idx) },
+            intervals.zipWithIndex.map { case (i, idx) => RowSeq(i, idx) },
           ),
           "global" -> MakeStruct(FastSeq("bye" -> I32(-1))),
         ))),
@@ -1269,19 +1279,19 @@ class TableIRSuite {
 
     assertEvalsTo(
       collect(join),
-      Row(
+      RowSeq(
         FastSeq(
-          Row(0, FastSeq()),
-          Row(1, FastSeq(Row(0))),
-          Row(2, FastSeq(Row(0))),
-          Row(3, FastSeq(Row(2), Row(0))),
-          Row(4, FastSeq(Row(2), Row(0), Row(3))),
-          Row(5, FastSeq(Row(2), Row(0), Row(3))),
-          Row(6, FastSeq(Row(3))),
-          Row(7, FastSeq(Row(4))),
-          Row(8, FastSeq()),
+          RowSeq(0, FastSeq()),
+          RowSeq(1, FastSeq(RowSeq(0))),
+          RowSeq(2, FastSeq(RowSeq(0))),
+          RowSeq(3, FastSeq(RowSeq(2), RowSeq(0))),
+          RowSeq(4, FastSeq(RowSeq(2), RowSeq(0), RowSeq(3))),
+          RowSeq(5, FastSeq(RowSeq(2), RowSeq(0), RowSeq(3))),
+          RowSeq(6, FastSeq(RowSeq(3))),
+          RowSeq(7, FastSeq(RowSeq(4))),
+          RowSeq(8, FastSeq()),
         ),
-        Row("globals"),
+        RowSeq("globals"),
       ),
     )
   }
@@ -1302,18 +1312,18 @@ class TableIRSuite {
 
     assertEvalsTo(
       collect(keyByXAndAggregateSum),
-      Row(
+      RowSeq(
         FastSeq(
-          Row(2, 1L),
-          Row(3, 5L),
-          Row(4, 14L),
-          Row(5, 30L),
-          Row(6, 55L),
-          Row(7, 91L),
-          Row(8, 140L),
-          Row(9, 204L),
+          RowSeq(2, 1L),
+          RowSeq(3, 5L),
+          RowSeq(4, 14L),
+          RowSeq(5, 30L),
+          RowSeq(6, 55L),
+          RowSeq(7, 91L),
+          RowSeq(8, 140L),
+          RowSeq(9, 204L),
         ),
-        Row(),
+        RowSeq(),
       ),
     )
 
@@ -1326,18 +1336,18 @@ class TableIRSuite {
     )
     assertEvalsTo(
       collect(keyByXPlusTwoAndAggregateSum),
-      Row(
+      RowSeq(
         FastSeq(
-          Row(4, 1L),
-          Row(5, 5L),
-          Row(6, 14L),
-          Row(7, 30L),
-          Row(8, 55L),
-          Row(9, 91L),
-          Row(10, 140L),
-          Row(11, 204L),
+          RowSeq(4, 1L),
+          RowSeq(5, 5L),
+          RowSeq(6, 14L),
+          RowSeq(7, 30L),
+          RowSeq(8, 55L),
+          RowSeq(9, 91L),
+          RowSeq(10, 140L),
+          RowSeq(11, 204L),
         ),
-        Row(),
+        RowSeq(),
       ),
     )
 
@@ -1350,18 +1360,18 @@ class TableIRSuite {
     )
     assertEvalsTo(
       collect(keyByZAndAggregateSum),
-      Row(
+      RowSeq(
         FastSeq(
-          Row(0, 120L),
-          Row(1, 112L),
-          Row(2, 98L),
-          Row(3, 80L),
-          Row(4, 60L),
-          Row(5, 40L),
-          Row(6, 22L),
-          Row(7, 8L),
+          RowSeq(0, 120L),
+          RowSeq(1, 112L),
+          RowSeq(2, 98L),
+          RowSeq(3, 80L),
+          RowSeq(4, 60L),
+          RowSeq(5, 40L),
+          RowSeq(6, 22L),
+          RowSeq(7, 8L),
         ),
-        Row(),
+        RowSeq(),
       ),
     )
   }
@@ -1384,8 +1394,8 @@ class TableIRSuite {
 
     assertEvalsTo(
       x,
-      Row(
-        (0 until 10).map(i => Row(i, "foo")),
+      RowSeq(
+        (0 until 10).map(i => RowSeq(i, "foo")),
         0 until 5,
       ),
     )
@@ -1437,11 +1447,11 @@ class TableIRSuite {
     assertEvalsTo(
       x,
       FastSeq(
-        Row(0, Row(0L, FastSeq())),
-        Row(1, Row(1L, FastSeq(0))),
-        Row(2, Row(2L, FastSeq(0, 1))),
-        Row(3, Row(3L, FastSeq(0, 1, 2))),
-        Row(4, Row(4L, FastSeq(0, 1, 2, 3))),
+        RowSeq(0, RowSeq(0L, FastSeq())),
+        RowSeq(1, RowSeq(1L, FastSeq(0))),
+        RowSeq(2, RowSeq(2L, FastSeq(0, 1))),
+        RowSeq(3, RowSeq(3L, FastSeq(0, 1, 2))),
+        RowSeq(4, RowSeq(4L, FastSeq(0, 1, 2, 3))),
       ),
     )
   }
@@ -1464,7 +1474,7 @@ class TableIRSuite {
       }
     val table =
       TableParallelize(makestruct("rows" -> ToArray(rows), "global" -> makestruct()), None)
-    assertEvalsTo(TableCollect(table), Row(FastSeq(Row(Row(1))), Row()))
+    assertEvalsTo(TableCollect(table), RowSeq(FastSeq(RowSeq(RowSeq(1))), RowSeq()))
   }
 
   @Test def testTableNativeZippedReaderWithPrefixKey(implicit ctx: ExecuteContext): Unit = {
@@ -1513,14 +1523,14 @@ class TableIRSuite {
           mapIR(part)(InsertFields(_, FastSeq("str" -> Str("foo"))))
         }
       ),
-      Row(IndexedSeq.tabulate(20)(i => Row(i, "foo")), Row("Hello")),
+      RowSeq(IndexedSeq.tabulate(20)(i => RowSeq(i, "foo")), RowSeq("Hello")),
     )
 
     assertEvalsTo(
       collect(
         mapPartitions(table)((_, part) => filterIR(part)(GetField(_, "idx") > 0))
       ),
-      Row(IndexedSeq.tabulate(20)(i => Row(i)).filter(_.getAs[Int](0) > 0), Row("Hello")),
+      RowSeq(IndexedSeq.tabulate(20)(i => RowSeq(i)).filter(_.getAs[Int](0) > 0), RowSeq("Hello")),
     )
 
     assertEvalsTo(
@@ -1531,7 +1541,7 @@ class TableIRSuite {
           }
         }
       ),
-      Row((0 until 20).flatMap(i => (0 until 3).map(j => Row("Hello", j))), Row("Hello")),
+      Row((0 until 20).flatMap(i => (0 until 3).map(j => RowSeq("Hello", j))), RowSeq("Hello")),
     )
 
     assertEvalsTo(
@@ -1543,13 +1553,13 @@ class TableIRSuite {
           )(x => !IsNA(x))
         }
       ),
-      Row(
+      RowSeq(
         IndexedSeq.tabulate(20) { i =>
           // 0,1,2,3,4,5,6,7,8,9,... ==>
           // 0,0,0,0,0,5,5,5,5,5,...
           Row((i / 5) * 5)
         },
-        Row("Hello"),
+        RowSeq("Hello"),
       ),
     )
 

--- a/hail/hail/test/src/is/hail/expr/ir/lowering/LowerDistributedSortSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/lowering/LowerDistributedSortSuite.scala
@@ -3,6 +3,7 @@ package is.hail.expr.ir.lowering
 import is.hail.{ExecStrategy, ParameterizedTest}
 import is.hail.ExecStrategy.ExecStrategy
 import is.hail.TestUtils._
+import is.hail.annotations.RowSeq
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
 import is.hail.collection.compat.immutable.ArraySeq
@@ -40,7 +41,10 @@ class LowerDistributedSortSuite {
     )
     val elementType = TStruct(("key1", TInt32), ("key2", TInt32), ("value", TInt32))
     val data1 =
-      ToStream(Literal(TArray(elementType), dataKeys.map { case (k1, k2) => Row(k1, k2, k1 * k1) }))
+      ToStream(Literal(
+        TArray(elementType),
+        dataKeys.map { case (k1, k2) => RowSeq(k1, k2, k1 * k1) },
+      ))
     val sampleSeq = ToStream(Literal(TArray(TInt32), IndexedSeq(0, 2, 3, 7)))
 
     val sampled = samplePartition(
@@ -51,20 +55,25 @@ class LowerDistributedSortSuite {
 
     assertEvalsTo(
       sampled,
-      Row(Row(0, -1), Row(9, 1), IndexedSeq(Row(0, 0), Row(1, 4), Row(2, 8), Row(6, 9)), false),
+      RowSeq(
+        RowSeq(0, -1),
+        RowSeq(9, 1),
+        IndexedSeq(RowSeq(0, 0), RowSeq(1, 4), RowSeq(2, 8), RowSeq(6, 9)),
+        false,
+      ),
     )
 
     val dataKeys2 = IndexedSeq((0, 0), (0, 1), (1, 0), (3, 3))
     val elementType2 = TStruct(("key1", TInt32), ("key2", TInt32))
     val data2 =
-      ToStream(Literal(TArray(elementType2), dataKeys2.map { case (k1, k2) => Row(k1, k2) }))
+      ToStream(Literal(TArray(elementType2), dataKeys2.map { case (k1, k2) => RowSeq(k1, k2) }))
     val sampleSeq2 = ToStream(Literal(TArray(TInt32), IndexedSeq(0)))
     val sampled2 = samplePartition(
       mapIR(data2)(s => SelectFields(s, IndexedSeq("key2", "key1"))),
       sampleSeq2,
       IndexedSeq(SortField("key2", Ascending), SortField("key1", Ascending)),
     )
-    assertEvalsTo(sampled2, Row(Row(0, 0), Row(3, 3), IndexedSeq(Row(0, 0)), false))
+    assertEvalsTo(sampled2, RowSeq(RowSeq(0, 0), RowSeq(3, 3), IndexedSeq(RowSeq(0, 0)), false))
   }
 
   def testDistributedSort: IndexedSeq[(TableIR, IndexedSeq[SortField])] = {

--- a/hail/hail/test/src/is/hail/expr/ir/table/TableGenSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/table/TableGenSuite.scala
@@ -3,6 +3,7 @@ package is.hail.expr.ir.table
 import is.hail.ExecStrategy
 import is.hail.ExecStrategy.ExecStrategy
 import is.hail.TestUtils._
+import is.hail.annotations.RowSeq
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
 import is.hail.expr.ir._
@@ -16,7 +17,6 @@ import is.hail.types.virtual._
 import is.hail.utils.{HailException, Interval}
 
 import org.apache.spark.SparkException
-import org.apache.spark.sql.Row
 import org.junit.jupiter.api.Test
 import org.scalatest.matchers.should.Matchers.{intercept => _, _}
 
@@ -113,7 +113,7 @@ class TableGenSuite {
   @Test
   def testLowering(implicit ctx: ExecuteContext): Unit = {
     val rows = collect(mkTableGen())
-    assertEvalsTo(rows, Row(FastSeq(0, 0).map(Row(_)), Row(0)))
+    assertEvalsTo(rows, RowSeq(FastSeq(0, 0).map(RowSeq(_)), RowSeq(0)))
   }
 
   @Test
@@ -138,8 +138,8 @@ class TableGenSuite {
         ctx.stateManager,
         TStruct("a" -> TInt32),
         FastSeq(
-          Interval(Row(0), Row(0), true, false),
-          Interval(Row(1), Row(1), true, false),
+          Interval(RowSeq(0), RowSeq(0), true, false),
+          Interval(RowSeq(1), RowSeq(1), true, false),
         ),
       )),
       errorId = Some(errorId),

--- a/hail/hail/test/src/is/hail/io/AvroReaderSuite.scala
+++ b/hail/hail/test/src/is/hail/io/AvroReaderSuite.scala
@@ -3,6 +3,7 @@ package is.hail.io
 import is.hail.ExecStrategy
 import is.hail.ExecStrategy.ExecStrategy
 import is.hail.TestUtils._
+import is.hail.annotations.RowSeq
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
 import is.hail.collection.compat.immutable.ArraySeq
@@ -29,11 +30,11 @@ class AvroReaderSuite {
     .endRecord()
 
   private val testValue = IndexedSeq(
-    Row(0, null, 0f, 0d, null),
-    Row(1, 1L, 1.0f, 1.0d, ""),
-    Row(-1, -1L, -1.0f, -1.0d, "minus one"),
-    Row(Int.MaxValue, Long.MaxValue, Float.MaxValue, Double.MaxValue, null),
-    Row(Int.MinValue, null, Float.MinPositiveValue, Double.MinPositiveValue, "MINIMUM STRING"),
+    RowSeq(0, null, 0f, 0d, null),
+    RowSeq(1, 1L, 1.0f, 1.0d, ""),
+    RowSeq(-1, -1L, -1.0f, -1.0d, "minus one"),
+    RowSeq(Int.MaxValue, Long.MaxValue, Float.MaxValue, Double.MaxValue, null),
+    RowSeq(Int.MinValue, null, Float.MinPositiveValue, Double.MinPositiveValue, "MINIMUM STRING"),
   )
 
   private val partitionReader = AvroPartitionReader(testSchema, "rowUID")
@@ -73,7 +74,7 @@ class AvroReaderSuite {
       partitionReader,
     ))
     val testValueWithUIDs = testValue.zipWithIndex.map { case (x, i) =>
-      Row(x(0), x(1), x(2), x(3), x(4), Row(0L, i.toLong))
+      RowSeq(x(0), x(1), x(2), x(3), x(4), RowSeq(0L, i.toLong))
     }
     assertEvalsTo(ir, testValueWithUIDs)
   }
@@ -85,7 +86,9 @@ class AvroReaderSuite {
       partitionReader.fullRowType.typeAfterSelect(FastSeq(0, 2, 4)),
       partitionReader,
     ))
-    val expected = testValue.map { case Row(int, _, float, _, string) => Row(int, float, string) }
+    val expected = testValue.map { case Row(int, _, float, _, string) =>
+      RowSeq(int, float, string)
+    }
     assertEvalsTo(ir, expected)
   }
 }

--- a/hail/hail/test/src/is/hail/io/IndexSuite.scala
+++ b/hail/hail/test/src/is/hail/io/IndexSuite.scala
@@ -2,7 +2,7 @@ package is.hail.io
 
 import is.hail.ParameterizedTest
 import is.hail.TestUtils._
-import is.hail.annotations.Annotation
+import is.hail.annotations.{Annotation, RowSeq}
 import is.hail.backend.ExecuteContext
 import is.hail.collection.compat.immutable.ArraySeq
 import is.hail.collection.implicits.toRichIterator
@@ -11,7 +11,6 @@ import is.hail.types.physical.{PCanonicalString, PCanonicalStruct, PInt32, PType
 import is.hail.types.virtual._
 import is.hail.utils._
 
-import org.apache.spark.sql.Row
 import org.junit.jupiter.api.Test
 
 class IndexSuite {
@@ -30,7 +29,7 @@ class IndexSuite {
     "whale", "zebra", "zebra", "zebra")
 
   val leafsWithDups = stringsWithDups.zipWithIndex.map { case (s, i) =>
-    LeafChild(s, i.toLong, Row())
+    LeafChild(s, i.toLong, RowSeq())
   }
 
   def writeReadGivesSameAsInput() = (1 to strings.length).map(i => strings.take(i))
@@ -115,7 +114,7 @@ class IndexSuite {
     val file = ctx.createTmpPath("test", "idx")
     val attributes: Map[String, Any] = Map("foo" -> true, "bar" -> 5)
 
-    val a: (Int) => Annotation = (i: Int) => Row(i % 2 == 0)
+    val a: (Int) => Annotation = (i: Int) => RowSeq(i % 2 == 0)
 
     for (branchingFactor <- 2 to 5) {
       writeIndex(
@@ -159,7 +158,7 @@ class IndexSuite {
       writeIndex(
         file,
         stringsWithDups,
-        stringsWithDups.indices.map(i => Row()),
+        stringsWithDups.indices.map(i => RowSeq()),
         TStruct.empty,
         branchingFactor,
       )
@@ -192,7 +191,7 @@ class IndexSuite {
       writeIndex(
         file,
         stringsWithDups,
-        stringsWithDups.indices.map(i => Row()),
+        stringsWithDups.indices.map(i => RowSeq()),
         TStruct.empty,
         branchingFactor,
       )
@@ -222,7 +221,7 @@ class IndexSuite {
   @Test def testRangeIterator(implicit ctx: ExecuteContext): Unit = {
     for (branchingFactor <- 2 to 5) {
       val file = ctx.createTmpPath("range", "idx")
-      val a = { (i: Int) => Row() }
+      val a = { (i: Int) => RowSeq() }
       writeIndex(
         file,
         stringsWithDups,
@@ -250,7 +249,7 @@ class IndexSuite {
       writeIndex(
         file,
         stringsWithDups,
-        stringsWithDups.indices.map(i => Row()),
+        stringsWithDups.indices.map(i => RowSeq()),
         TStruct.empty,
         branchingFactor,
       )
@@ -272,7 +271,7 @@ class IndexSuite {
       writeIndex(
         file,
         stringsWithDups,
-        stringsWithDups.indices.map(i => Row()),
+        stringsWithDups.indices.map(i => RowSeq()),
         TStruct.empty,
         branchingFactor,
       )
@@ -451,8 +450,8 @@ class IndexSuite {
       val file = ctx.createTmpPath("from", "idx")
       writeIndex(
         file,
-        stringsWithDups.zipWithIndex.map { case (s, i) => Row(s, i) },
-        stringsWithDups.indices.map(i => Row()),
+        stringsWithDups.zipWithIndex.map { case (s, i) => RowSeq(s, i) },
+        stringsWithDups.indices.map(i => RowSeq()),
         keyType,
         +PCanonicalStruct(),
         branchingFactor,
@@ -460,7 +459,7 @@ class IndexSuite {
       )
 
       val leafChildren = stringsWithDups.zipWithIndex.map { case (s, i) =>
-        LeafChild(Row(s, i), i.toLong, Row())
+        LeafChild(RowSeq(s, i), i.toLong, RowSeq())
       }
 
       val index = indexReader(
@@ -470,8 +469,8 @@ class IndexSuite {
       )
       assertEq(
         index.queryByInterval(
-          Row("cat", 3),
-          Row("cat", 5),
+          RowSeq("cat", 3),
+          RowSeq("cat", 5),
           includesStart = true,
           includesEnd = false,
         ).toFastSeq,
@@ -479,8 +478,8 @@ class IndexSuite {
       )
       assertEq(
         index.queryByInterval(
-          Row("cat"),
-          Row("cat", 5),
+          RowSeq("cat"),
+          RowSeq("cat", 5),
           includesStart = true,
           includesEnd = false,
         ).toFastSeq,
@@ -488,8 +487,8 @@ class IndexSuite {
       )
       assertEq(
         index.queryByInterval(
-          Row(),
-          Row(),
+          RowSeq(),
+          RowSeq(),
           includesStart = true,
           includesEnd = true,
         ).toFastSeq,
@@ -497,8 +496,8 @@ class IndexSuite {
       )
       assertEq(
         index.queryByInterval(
-          Row(),
-          Row("cat"),
+          RowSeq(),
+          RowSeq("cat"),
           includesStart = true,
           includesEnd = false,
         ).toFastSeq,
@@ -506,8 +505,8 @@ class IndexSuite {
       )
       assertEq(
         index.queryByInterval(
-          Row("zebra"),
-          Row(),
+          RowSeq("zebra"),
+          RowSeq(),
           includesStart = true,
           includesEnd = true,
         ).toFastSeq,
@@ -522,7 +521,7 @@ class IndexSuite {
       writeIndex(
         file,
         stringsWithDups,
-        stringsWithDups.indices.map(i => Row()),
+        stringsWithDups.indices.map(i => RowSeq()),
         TStruct.empty,
         branchingFactor,
       )

--- a/hail/hail/test/src/is/hail/io/compress/BGzipCodecSuite.scala
+++ b/hail/hail/test/src/is/hail/io/compress/BGzipCodecSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.io.compress
 
 import is.hail.TestUtils._
+import is.hail.annotations.RowSeq
 import is.hail.backend.ExecuteContext
 import is.hail.collection.compat.immutable.ArraySeq
 import is.hail.collection.implicits.toRichIterator
@@ -16,7 +17,6 @@ import scala.jdk.CollectionConverters._
 import htsjdk.samtools.util.BlockCompressedFilePointerUtil
 import org.apache.{hadoop => hd}
 import org.apache.commons.io.IOUtils
-import org.apache.spark.sql.Row
 import org.junit.jupiter.api.Test
 import org.scalacheck.Gen._
 import org.scalacheck.Prop.forAll
@@ -145,7 +145,7 @@ class BGzipCodecSuite {
       val contexts = (0 until (splits.length - 1))
         .map { i =>
           val end = makeVirtualOffset(splits(i + 1), 0)
-          Row(i, 0, compPath, splits(i), end, true)
+          RowSeq(i, 0, compPath, splits(i), end, true)
         }
       val lines2 = GenericLines.collect(fs, GenericLines.read(fs, contexts, false, false))
       lines2 should equal(lines)

--- a/hail/hail/test/src/is/hail/methods/ExprSuite.scala
+++ b/hail/hail/test/src/is/hail/methods/ExprSuite.scala
@@ -1,6 +1,7 @@
 package is.hail.methods
 
 import is.hail.TestUtils._
+import is.hail.annotations.RowSeq
 import is.hail.backend.{ExecuteContext, HailStateManager}
 import is.hail.expr._
 import is.hail.expr.ir.IRParser
@@ -8,7 +9,6 @@ import is.hail.scalacheck._
 import is.hail.types.virtual._
 import is.hail.utils.StringEscapeUtils._
 
-import org.apache.spark.sql.Row
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
 import org.junit.jupiter.api.Test
@@ -71,10 +71,10 @@ class ExprSuite {
   }
 
   @Test def testImportEmptyJSONObjectAsStruct(): Unit =
-    assertEq(JSONAnnotationImpex.importAnnotation(parse("{}"), TStruct()), Row())
+    assertEq(JSONAnnotationImpex.importAnnotation(parse("{}"), TStruct()), RowSeq())
 
   @Test def testExportEmptyJSONObjectAsStruct(): Unit =
-    assertEq(compact(render(JSONAnnotationImpex.exportAnnotation(Row(), TStruct()))), "{}")
+    assertEq(compact(render(JSONAnnotationImpex.exportAnnotation(RowSeq(), TStruct()))), "{}")
 
   @Test def testRoundTripEmptyJSONObject(): Unit = {
     val actual = JSONAnnotationImpex.exportAnnotation(
@@ -86,10 +86,10 @@ class ExprSuite {
 
   @Test def testRoundTripEmptyStruct(): Unit = {
     val actual = JSONAnnotationImpex.importAnnotation(
-      JSONAnnotationImpex.exportAnnotation(Row(), TStruct()),
+      JSONAnnotationImpex.exportAnnotation(RowSeq(), TStruct()),
       TStruct(),
     )
-    assertEq(actual, Row())
+    assertEq(actual, RowSeq())
   }
 
   @Test def testImpexes(implicit ctx: ExecuteContext): Unit = {

--- a/hail/hail/test/src/is/hail/rvd/RVDPartitionerSuite.scala
+++ b/hail/hail/test/src/is/hail/rvd/RVDPartitionerSuite.scala
@@ -1,12 +1,12 @@
 package is.hail.rvd
 
+import is.hail.annotations.RowSeq
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
 import is.hail.collection.compat.immutable.ArraySeq
 import is.hail.types.virtual.{TInt32, TStruct}
 import is.hail.utils.Interval
 
-import org.apache.spark.sql.Row
 import org.junit.jupiter.api.{BeforeEach, Test}
 
 class RVDPartitionerSuite {
@@ -20,9 +20,9 @@ class RVDPartitionerSuite {
       ctx.stateManager,
       kType,
       ArraySeq(
-        Interval(Row(1, 0), Row(4, 3), true, false),
-        Interval(Row(4, 3), Row(7, 9), true, false),
-        Interval(Row(7, 11), Row(10, 0), true, true),
+        Interval(RowSeq(1, 0), RowSeq(4, 3), true, false),
+        Interval(RowSeq(4, 3), RowSeq(7, 9), true, false),
+        Interval(RowSeq(7, 11), RowSeq(10, 0), true, true),
       ),
     )
   }
@@ -32,124 +32,131 @@ class RVDPartitionerSuite {
       ctx.stateManager,
       TStruct(("A", TInt32), ("B", TInt32)),
       ArraySeq(
-        Interval(Row(1, 0), Row(4, 3), true, true),
-        Interval(Row(4, 3), Row(4, 3), true, true),
-        Interval(Row(4, 3), Row(7, 9), true, false),
-        Interval(Row(7, 11), Row(10, 0), true, true),
+        Interval(RowSeq(1, 0), RowSeq(4, 3), true, true),
+        Interval(RowSeq(4, 3), RowSeq(4, 3), true, true),
+        Interval(RowSeq(4, 3), RowSeq(7, 9), true, false),
+        Interval(RowSeq(7, 11), RowSeq(10, 0), true, true),
       ),
     )
     val extended = p.extendKey(kType)
     assert(extended.rangeBounds sameElements Array(
-      Interval(Row(1, 0), Row(4, 3), true, true),
-      Interval(Row(4, 3), Row(7, 9), false, false),
-      Interval(Row(7, 11), Row(10, 0), true, true),
+      Interval(RowSeq(1, 0), RowSeq(4, 3), true, true),
+      Interval(RowSeq(4, 3), RowSeq(7, 9), false, false),
+      Interval(RowSeq(7, 11), RowSeq(10, 0), true, true),
     ))
   }
 
   @Test def testGetPartitionWithPartitionKeys(): Unit = {
-    assert(partitioner.lowerBound(Row(-1, 7)) == 0)
-    assert(partitioner.upperBound(Row(-1, 7)) == 0)
+    assert(partitioner.lowerBound(RowSeq(-1, 7)) == 0)
+    assert(partitioner.upperBound(RowSeq(-1, 7)) == 0)
 
-    assert(partitioner.lowerBound(Row(4, 2)) == 0)
-    assert(partitioner.upperBound(Row(4, 2)) == 1)
+    assert(partitioner.lowerBound(RowSeq(4, 2)) == 0)
+    assert(partitioner.upperBound(RowSeq(4, 2)) == 1)
 
-    assert(partitioner.lowerBound(Row(4, 3)) == 1)
-    assert(partitioner.upperBound(Row(4, 3)) == 2)
+    assert(partitioner.lowerBound(RowSeq(4, 3)) == 1)
+    assert(partitioner.upperBound(RowSeq(4, 3)) == 2)
 
-    assert(partitioner.lowerBound(Row(5, -10259)) == 1)
-    assert(partitioner.upperBound(Row(5, -10259)) == 2)
+    assert(partitioner.lowerBound(RowSeq(5, -10259)) == 1)
+    assert(partitioner.upperBound(RowSeq(5, -10259)) == 2)
 
-    assert(partitioner.lowerBound(Row(7, 9)) == 2)
-    assert(partitioner.upperBound(Row(7, 9)) == 2)
+    assert(partitioner.lowerBound(RowSeq(7, 9)) == 2)
+    assert(partitioner.upperBound(RowSeq(7, 9)) == 2)
 
-    assert(partitioner.lowerBound(Row(12, 19)) == 3)
-    assert(partitioner.upperBound(Row(12, 19)) == 3)
+    assert(partitioner.lowerBound(RowSeq(12, 19)) == 3)
+    assert(partitioner.upperBound(RowSeq(12, 19)) == 3)
   }
 
   @Test def testGetPartitionWithLargerKeys(): Unit = {
-    assert(partitioner.lowerBound(Row(0, 1, 3)) == 0)
-    assert(partitioner.upperBound(Row(0, 1, 3)) == 0)
+    assert(partitioner.lowerBound(RowSeq(0, 1, 3)) == 0)
+    assert(partitioner.upperBound(RowSeq(0, 1, 3)) == 0)
 
-    assert(partitioner.lowerBound(Row(2, 7, 5)) == 0)
-    assert(partitioner.upperBound(Row(2, 7, 5)) == 1)
+    assert(partitioner.lowerBound(RowSeq(2, 7, 5)) == 0)
+    assert(partitioner.upperBound(RowSeq(2, 7, 5)) == 1)
 
-    assert(partitioner.lowerBound(Row(4, 2, 1, 2.7, "bar")) == 0)
+    assert(partitioner.lowerBound(RowSeq(4, 2, 1, 2.7, "bar")) == 0)
 
-    assert(partitioner.lowerBound(Row(7, 9, 7)) == 2)
-    assert(partitioner.upperBound(Row(7, 9, 7)) == 2)
+    assert(partitioner.lowerBound(RowSeq(7, 9, 7)) == 2)
+    assert(partitioner.upperBound(RowSeq(7, 9, 7)) == 2)
 
-    assert(partitioner.lowerBound(Row(11, 1, 42)) == 3)
+    assert(partitioner.lowerBound(RowSeq(11, 1, 42)) == 3)
   }
 
   @Test def testGetPartitionPKWithSmallerKeys(): Unit = {
-    assert(partitioner.lowerBound(Row(2)) == 0)
-    assert(partitioner.upperBound(Row(2)) == 1)
+    assert(partitioner.lowerBound(RowSeq(2)) == 0)
+    assert(partitioner.upperBound(RowSeq(2)) == 1)
 
-    assert(partitioner.lowerBound(Row(4)) == 0)
-    assert(partitioner.upperBound(Row(4)) == 2)
+    assert(partitioner.lowerBound(RowSeq(4)) == 0)
+    assert(partitioner.upperBound(RowSeq(4)) == 2)
 
-    assert(partitioner.lowerBound(Row(11)) == 3)
-    assert(partitioner.upperBound(Row(11)) == 3)
+    assert(partitioner.lowerBound(RowSeq(11)) == 3)
+    assert(partitioner.upperBound(RowSeq(11)) == 3)
   }
 
   @Test def testGetPartitionRange(): Unit = {
-    assert(partitioner.queryInterval(Interval(Row(3, 4), Row(7, 11), true, true)) == Seq(0, 1, 2))
-    assert(partitioner.queryInterval(Interval(Row(3, 4), Row(7, 9), true, false)) == Seq(0, 1))
-    assert(partitioner.queryInterval(Interval(Row(4), Row(5), true, true)) == Seq(0, 1))
-    assert(partitioner.queryInterval(Interval(Row(4), Row(5), false, true)) == Seq(1))
-    assert(partitioner.queryInterval(Interval(Row(-1, 7), Row(0, 9), true, false)) == Seq())
+    assert(partitioner.queryInterval(Interval(RowSeq(3, 4), RowSeq(7, 11), true, true)) == Seq(
+      0,
+      1,
+      2,
+    ))
+    assert(partitioner.queryInterval(Interval(RowSeq(3, 4), RowSeq(7, 9), true, false)) == Seq(
+      0,
+      1,
+    ))
+    assert(partitioner.queryInterval(Interval(RowSeq(4), RowSeq(5), true, true)) == Seq(0, 1))
+    assert(partitioner.queryInterval(Interval(RowSeq(4), RowSeq(5), false, true)) == Seq(1))
+    assert(partitioner.queryInterval(Interval(RowSeq(-1, 7), RowSeq(0, 9), true, false)) == Seq())
   }
 
   @Test def testGetSafePartitionKeyRange(): Unit = {
-    assert(partitioner.queryKey(Row(0, 0)).isEmpty)
-    assert(partitioner.queryKey(Row(7, 10)).isEmpty)
-    assert(partitioner.queryKey(Row(7, 11)) == Range.inclusive(2, 2))
+    assert(partitioner.queryKey(RowSeq(0, 0)).isEmpty)
+    assert(partitioner.queryKey(RowSeq(7, 10)).isEmpty)
+    assert(partitioner.queryKey(RowSeq(7, 11)) == Range.inclusive(2, 2))
   }
 
   @Test def testGenerateDisjoint(implicit ctx: ExecuteContext): Unit = {
     val intervals = ArraySeq(
-      Interval(Row(1, 0, 4), Row(4, 3, 2), true, false),
-      Interval(Row(4, 3, 5), Row(7, 9, 1), true, false),
-      Interval(Row(7, 11, 3), Row(10, 0, 1), true, true),
-      Interval(Row(11, 0, 2), Row(11, 0, 15), false, true),
-      Interval(Row(11, 0, 15), Row(11, 0, 20), true, false),
+      Interval(RowSeq(1, 0, 4), RowSeq(4, 3, 2), true, false),
+      Interval(RowSeq(4, 3, 5), RowSeq(7, 9, 1), true, false),
+      Interval(RowSeq(7, 11, 3), RowSeq(10, 0, 1), true, true),
+      Interval(RowSeq(11, 0, 2), RowSeq(11, 0, 15), false, true),
+      Interval(RowSeq(11, 0, 15), RowSeq(11, 0, 20), true, false),
     )
 
     val p3 = RVDPartitioner.generate(ctx.stateManager, ArraySeq("A", "B", "C"), kType, intervals)
     assert(p3.satisfiesAllowedOverlap(2))
     assert(p3.rangeBounds sameElements
       Array(
-        Interval(Row(1, 0, 4), Row(4, 3, 2), true, false),
-        Interval(Row(4, 3, 5), Row(7, 9, 1), true, false),
-        Interval(Row(7, 11, 3), Row(10, 0, 1), true, true),
-        Interval(Row(11, 0, 2), Row(11, 0, 15), false, true),
-        Interval(Row(11, 0, 15), Row(11, 0, 20), false, false),
+        Interval(RowSeq(1, 0, 4), RowSeq(4, 3, 2), true, false),
+        Interval(RowSeq(4, 3, 5), RowSeq(7, 9, 1), true, false),
+        Interval(RowSeq(7, 11, 3), RowSeq(10, 0, 1), true, true),
+        Interval(RowSeq(11, 0, 2), RowSeq(11, 0, 15), false, true),
+        Interval(RowSeq(11, 0, 15), RowSeq(11, 0, 20), false, false),
       ))
 
     val p2 = RVDPartitioner.generate(ctx.stateManager, ArraySeq("A", "B"), kType, intervals)
     assert(p2.satisfiesAllowedOverlap(1))
     assert(p2.rangeBounds sameElements
       Array(
-        Interval(Row(1, 0, 4), Row(4, 3), true, true),
-        Interval(Row(4, 3), Row(7, 9, 1), false, false),
-        Interval(Row(7, 11, 3), Row(10, 0, 1), true, true),
-        Interval(Row(11, 0, 2), Row(11, 0, 20), false, false),
+        Interval(RowSeq(1, 0, 4), RowSeq(4, 3), true, true),
+        Interval(RowSeq(4, 3), RowSeq(7, 9, 1), false, false),
+        Interval(RowSeq(7, 11, 3), RowSeq(10, 0, 1), true, true),
+        Interval(RowSeq(11, 0, 2), RowSeq(11, 0, 20), false, false),
       ))
 
     val p1 = RVDPartitioner.generate(ctx.stateManager, ArraySeq("A"), kType, intervals)
     assert(p1.satisfiesAllowedOverlap(0))
     assert(p1.rangeBounds sameElements
       Array(
-        Interval(Row(1, 0, 4), Row(4), true, true),
-        Interval(Row(4), Row(7), false, true),
-        Interval(Row(7), Row(10, 0, 1), false, true),
-        Interval(Row(11, 0, 2), Row(11, 0, 20), false, false),
+        Interval(RowSeq(1, 0, 4), RowSeq(4), true, true),
+        Interval(RowSeq(4), RowSeq(7), false, true),
+        Interval(RowSeq(7), RowSeq(10, 0, 1), false, true),
+        Interval(RowSeq(11, 0, 2), RowSeq(11, 0, 20), false, false),
       ))
   }
 
   @Test def testGenerateEmptyKey(implicit ctx: ExecuteContext): Unit = {
-    val intervals1 = ArraySeq(Interval(Row(), Row(), true, true))
-    val intervals5 = ArraySeq.fill(5)(Interval(Row(), Row(), true, true))
+    val intervals1 = ArraySeq(Interval(RowSeq(), RowSeq(), true, true))
+    val intervals5 = ArraySeq.fill(5)(Interval(RowSeq(), RowSeq(), true, true))
 
     val p5 = RVDPartitioner.generate(ctx.stateManager, FastSeq(), TStruct.empty, intervals5)
     assert(p5.rangeBounds == intervals1)
@@ -168,9 +175,9 @@ class RVDPartitionerSuite {
         ctx.stateManager,
         kType,
         ArraySeq(
-          Interval(Row(1), Row(10), true, false),
-          Interval(Row(12), Row(13), true, false),
-          Interval(Row(14), Row(19), true, false),
+          Interval(RowSeq(1), RowSeq(10), true, false),
+          Interval(RowSeq(12), RowSeq(13), true, false),
+          Interval(RowSeq(14), RowSeq(19), true, false),
         ),
       )
     val right =
@@ -178,19 +185,19 @@ class RVDPartitionerSuite {
         ctx.stateManager,
         kType,
         ArraySeq(
-          Interval(Row(1), Row(4), true, false),
-          Interval(Row(4), Row(5), true, false),
-          Interval(Row(7), Row(16), true, true),
-          Interval(Row(19), Row(20), true, true),
+          Interval(RowSeq(1), RowSeq(4), true, false),
+          Interval(RowSeq(4), RowSeq(5), true, false),
+          Interval(RowSeq(7), RowSeq(16), true, true),
+          Interval(RowSeq(19), RowSeq(20), true, true),
         ),
       )
     assert(left.intersect(right).rangeBounds sameElements
       Array(
-        Interval(Row(1), Row(4), true, false),
-        Interval(Row(4), Row(5), true, false),
-        Interval(Row(7), Row(10), true, false),
-        Interval(Row(12), Row(13), true, false),
-        Interval(Row(14), Row(16), true, true),
+        Interval(RowSeq(1), RowSeq(4), true, false),
+        Interval(RowSeq(4), RowSeq(5), true, false),
+        Interval(RowSeq(7), RowSeq(10), true, false),
+        Interval(RowSeq(12), RowSeq(13), true, false),
+        Interval(RowSeq(14), RowSeq(16), true, true),
       ))
   }
 }

--- a/hail/hail/test/src/is/hail/scalacheck/ArbitraryGenomicInstances.scala
+++ b/hail/hail/test/src/is/hail/scalacheck/ArbitraryGenomicInstances.scala
@@ -1,6 +1,6 @@
 package is.hail.scalacheck
 
-import is.hail.annotations.Annotation
+import is.hail.annotations.{Annotation, RowSeq}
 import is.hail.collection.compat.immutable.ArraySeq
 import is.hail.utils.{triangle, uniqueMaxIndex}
 import is.hail.variant._
@@ -9,7 +9,6 @@ import is.hail.variant.Sex.Sex
 
 import scala.collection.compat._
 
-import org.apache.spark.sql.Row
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen._
@@ -180,7 +179,7 @@ private[scalacheck] trait ArbitraryGenomicInstances {
         yield {
           val c =
             gp.flatMap(a => Option(uniqueMaxIndex(a))).map(Call2.fromUnphasedDiploidGtIndex(_))
-          Row(
+          RowSeq(
             c.orNull,
             gp.map(gpx => gpx.map(p => p.toDouble / 32768): IndexedSeq[Double]).orNull,
           )

--- a/hail/hail/test/src/is/hail/types/encoded/ETypeSuite.scala
+++ b/hail/hail/test/src/is/hail/types/encoded/ETypeSuite.scala
@@ -2,7 +2,7 @@ package is.hail.types.encoded
 
 import is.hail.ParameterizedTest
 import is.hail.TestUtils._
-import is.hail.annotations.{Annotation, Region, SafeNDArray, SafeRow}
+import is.hail.annotations.{Annotation, Region, RowSeq, SafeNDArray, SafeRow}
 import is.hail.asm4s.Code
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
@@ -13,7 +13,6 @@ import is.hail.rvd.AbstractRVDSpec
 import is.hail.types.physical._
 import is.hail.types.virtual._
 
-import org.apache.spark.sql.Row
 import org.json4s.jackson.Serialization
 import org.junit.jupiter.api.Test
 
@@ -162,7 +161,7 @@ class ETypeSuite {
       false,
     )
 
-    val data = FastSeq(Row(1, null, "abc", FastSeq(Row(7L), Row(8L))))
+    val data = FastSeq(RowSeq(1, null, "abc", FastSeq(RowSeq(7L), RowSeq(8L))))
 
     assertEqualEncodeDecode(inPType, etype, outPType, data)
   }
@@ -206,7 +205,7 @@ class ETypeSuite {
       true,
     )
 
-    val dataStruct = Row(dataInt2, 3)
+    val dataStruct = RowSeq(dataInt2, 3)
 
     assertEq(
       encodeDecode(
@@ -215,7 +214,7 @@ class ETypeSuite {
         pOnlyReadB,
         dataStruct,
       ),
-      Row(3),
+      RowSeq(3),
     )
   }
 
@@ -254,7 +253,7 @@ class ETypeSuite {
       "two_byte_boundary" -> PInt32Required,
       "three_byte_boundary" -> PInt32Required,
     )
-    val data = Row(0, 1, -1, Int.MaxValue, Int.MinValue, 127, 16383, 2097151)
+    val data = RowSeq(0, 1, -1, Int.MaxValue, Int.MinValue, 127, 16383, 2097151)
     assertEqualEncodeDecode(ptype, etype, ptype, data)
   }
 
@@ -279,7 +278,7 @@ class ETypeSuite {
       "min" -> PInt64Required,
       "int_max_plus_one" -> PInt64Required,
     )
-    val data = Row(0L, 1L, -1L, Long.MaxValue, Long.MinValue, Int.MaxValue.toLong + 1L)
+    val data = RowSeq(0L, 1L, -1L, Long.MaxValue, Long.MinValue, Int.MaxValue.toLong + 1L)
     assertEqualEncodeDecode(ptype, etype, ptype, data)
   }
 
@@ -336,14 +335,14 @@ class ETypeSuite {
       ))
     val toDecode = toEncode
     val data = FastSeq(
-      Row(1, 2f, true),
+      RowSeq(1, 2f, true),
       null,
-      Row(3, null, false),
-      Row(4, 5f, true),
+      RowSeq(3, null, false),
+      RowSeq(4, 5f, true),
       null,
-      Row(6, 7f, false),
-      Row(8, null, true),
-      Row(9, 10f, false),
+      RowSeq(6, 7f, false),
+      RowSeq(8, null, true),
+      RowSeq(9, 10f, false),
     )
 
     assertEqualEncodeDecode(toEncode, etype, toDecode, data)

--- a/hail/hail/test/src/is/hail/types/physical/PNDArraySuite.scala
+++ b/hail/hail/test/src/is/hail/types/physical/PNDArraySuite.scala
@@ -1,6 +1,6 @@
 package is.hail.types.physical
 
-import is.hail.annotations.{Region, SafeNDArray, UnsafeRow}
+import is.hail.annotations.{Region, RowSeq, SafeNDArray, UnsafeRow}
 import is.hail.asm4s._
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
@@ -8,7 +8,6 @@ import is.hail.expr.ir.{EmitCodeBuilder, EmitFunctionBuilder}
 import is.hail.methods.LocalWhitening
 import is.hail.types.physical.stypes.interfaces.{ColonIndex => Colon, _}
 
-import org.apache.spark.sql.Row
 import org.junit.jupiter.api.Test
 
 class PNDArraySuite extends PhysicalTestUtils {
@@ -492,7 +491,7 @@ class PNDArraySuite extends PhysicalTestUtils {
     val pNDOfStructs2 =
       PCanonicalNDArray(PCanonicalStruct(true, ("x", PInt32()), ("y", PInt32Required)), 1)
     val annotationNDOfStructs =
-      new SafeNDArray(IndexedSeq(5L), (0 until 5).map(idx => Row(idx, idx + 100)))
+      new SafeNDArray(IndexedSeq(5L), (0 until 5).map(idx => RowSeq(idx, idx + 100)))
 
     val addr5 = pNDOfStructs1.unstagedStoreJavaObject(
       ctx.stateManager,

--- a/hail/hail/test/src/is/hail/types/physical/PTypeSuite.scala
+++ b/hail/hail/test/src/is/hail/types/physical/PTypeSuite.scala
@@ -2,6 +2,7 @@ package is.hail.types.physical
 
 import is.hail.ParameterizedTest
 import is.hail.TestUtils._
+import is.hail.annotations.RowSeq
 import is.hail.collection.FastSeq
 import is.hail.collection.compat.immutable.ArraySeq
 import is.hail.rvd.AbstractRVDSpec
@@ -9,7 +10,6 @@ import is.hail.types.virtual._
 import is.hail.utils._
 import is.hail.variant.ReferenceGenome
 
-import org.apache.spark.sql.Row
 import org.json4s.jackson.Serialization
 import org.junit.jupiter.api.Test
 
@@ -69,7 +69,7 @@ class PTypeSuite {
     val p = TStruct("a" -> TInt32, "b" -> TInt32)
     val d = TDict(p, p)
     assertEq(
-      PType.literalPType(d, Map(Row(3, null) -> Row(null, 3))),
+      PType.literalPType(d, Map(RowSeq(3, null) -> RowSeq(null, 3))),
       PCanonicalDict(
         PCanonicalStruct(true, "a" -> PInt32(true), "b" -> PInt32()),
         PCanonicalStruct(true, "a" -> PInt32(), "b" -> PInt32(true)),

--- a/hail/hail/test/src/is/hail/types/virtual/TStructSuite.scala
+++ b/hail/hail/test/src/is/hail/types/virtual/TStructSuite.scala
@@ -2,11 +2,10 @@ package is.hail.types.virtual
 
 import is.hail.ParameterizedTest
 import is.hail.TestUtils._
-import is.hail.annotations.{Annotation, Inserter}
+import is.hail.annotations.{Annotation, Inserter, RowSeq}
 import is.hail.collection.FastSeq
 import is.hail.collection.compat.immutable.ArraySeq
 
-import org.apache.spark.sql.Row
 import org.junit.jupiter.api.Test
 
 class TStructSuite {
@@ -71,12 +70,12 @@ class TStructSuite {
 
   def testInsert() =
     ArraySeq[(Inserter, Annotation, Any, Annotation)](
-      (TStruct("a" -> TInt32).insert(TInt32, FastSeq("a"))._2, null, 0, Row(0)),
-      (TStruct("a" -> TInt32).insert(TInt32, FastSeq("a"))._2, Row(0), 1, Row(1)),
-      (TStruct("a" -> TInt32).insert(TInt32, FastSeq("b"))._2, null, 0, Row(null, 0)),
-      (TStruct("a" -> TInt32).insert(TInt32, FastSeq("b"))._2, Row(0), 1, Row(0, 1)),
-      (TStruct.empty.insert(TInt32, FastSeq("a", "b"))._2, null, 0, Row(Row(0))),
-      (TStruct("a" -> TInt32).insert(TInt32, FastSeq("a", "b"))._2, Row(0), 1, Row(Row(1))),
+      (TStruct("a" -> TInt32).insert(TInt32, FastSeq("a"))._2, null, 0, RowSeq(0)),
+      (TStruct("a" -> TInt32).insert(TInt32, FastSeq("a"))._2, RowSeq(0), 1, RowSeq(1)),
+      (TStruct("a" -> TInt32).insert(TInt32, FastSeq("b"))._2, null, 0, RowSeq(null, 0)),
+      (TStruct("a" -> TInt32).insert(TInt32, FastSeq("b"))._2, RowSeq(0), 1, RowSeq(0, 1)),
+      (TStruct.empty.insert(TInt32, FastSeq("a", "b"))._2, null, 0, RowSeq(RowSeq(0))),
+      (TStruct("a" -> TInt32).insert(TInt32, FastSeq("a", "b"))._2, RowSeq(0), 1, RowSeq(RowSeq(1))),
     )
 
   @ParameterizedTest

--- a/hail/hail/test/src/is/hail/utils/IntervalSuite.scala
+++ b/hail/hail/test/src/is/hail/utils/IntervalSuite.scala
@@ -2,14 +2,13 @@ package is.hail.utils
 
 import is.hail.ParameterizedTest
 import is.hail.TestUtils.cartesian
-import is.hail.annotations.ExtendedOrdering
+import is.hail.annotations.{ExtendedOrdering, RowSeq}
 import is.hail.backend.{ExecuteContext, HailStateManager}
 import is.hail.collection.compat.immutable.ArraySeq
 import is.hail.collection.implicits.toRichIterable
 import is.hail.rvd.RVDPartitioner
 import is.hail.types.virtual.{TInt32, TStruct}
 
-import org.apache.spark.sql.Row
 import org.junit.jupiter.api.{BeforeEach, Test}
 
 class IntervalSuite {
@@ -144,7 +143,7 @@ class IntervalSuite {
   @Test def interval_tree_agrees_with_set_interval_tree_contains(): Unit =
     cartesian(test_itrees, points).foreach { case (set_itree, p) =>
       val itree = set_itree.intervalTree
-      assert(itree.contains(Row(p)) == set_itree.contains(p))
+      assert(itree.contains(RowSeq(p)) == set_itree.contains(p))
     }
 
   @Test def interval_tree_agrees_with_set_interval_tree_probably_overlaps(): Unit =
@@ -164,7 +163,7 @@ class IntervalSuite {
   @Test def interval_tree_agrees_with_set_interval_tree_query_values(): Unit =
     cartesian(test_itrees, points).foreach { case (set_itree, point) =>
       val itree = set_itree.intervalTree
-      val result = itree.queryKey(Row(point))
+      val result = itree.queryKey(RowSeq(point))
       assert(result.areDistinct())
       assert(result.toSet == set_itree.queryValues(point))
     }
@@ -196,7 +195,7 @@ case class SetInterval(start: Int, end: Int, includesStart: Boolean, includesEnd
 
   val interval: Interval = Interval(start, end, includesStart, includesEnd)
 
-  val rowInterval: Interval = Interval(Row(start), Row(end), includesStart, includesEnd)
+  val rowInterval: Interval = Interval(RowSeq(start), RowSeq(end), includesStart, includesEnd)
 
   def contains(point: Int): Boolean = doubledPointSet.contains(2 * point)
 

--- a/hail/hail/test/src/is/hail/utils/MultiArray2.scala
+++ b/hail/hail/test/src/is/hail/utils/MultiArray2.scala
@@ -33,7 +33,7 @@ class MultiArray2[@specialized(Int, Long, Float, Double, Boolean) T](
     override def length: Int = n1
   }
 
-  def row(i: Int) = new Row(i)
+  def row(i: Int): Row = new Row(i)
   def column(j: Int) = new Column(j)
 
   def rows: Iterable[Row] = for (i <- rowIndices) yield row(i)

--- a/hail/hail/test/src/is/hail/utils/RowIntervalSuite.scala
+++ b/hail/hail/test/src/is/hail/utils/RowIntervalSuite.scala
@@ -2,6 +2,7 @@ package is.hail.utils
 
 import is.hail.ExecStrategy
 import is.hail.TestUtils._
+import is.hail.annotations.RowSeq
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
 import is.hail.expr.ir
@@ -43,184 +44,243 @@ class RowIntervalSuite {
   }
 
   @Test def testContains(implicit ctx: ExecuteContext): Unit = {
-    assertContains(Interval(Row(0, 1, 5), Row(1, 2, 4), true, true), Row(1, 1, 3))
-    assertContains(Interval(Row(0, 1, 5), Row(1, 2, 4), true, true), Row(0, 1, 5))
+    assertContains(Interval(RowSeq(0, 1, 5), RowSeq(1, 2, 4), true, true), RowSeq(1, 1, 3))
+    assertContains(Interval(RowSeq(0, 1, 5), RowSeq(1, 2, 4), true, true), RowSeq(0, 1, 5))
     assertContains(
-      Interval(Row(0, 1, 5), Row(1, 2, 4), false, true),
-      Row(0, 1, 5),
+      Interval(RowSeq(0, 1, 5), RowSeq(1, 2, 4), false, true),
+      RowSeq(0, 1, 5),
       shouldContain = false,
     )
     assertContains(
-      Interval(Row(0, 1, 5), Row(1, 2, 4), true, false),
-      Row(1, 2, 4),
-      shouldContain = false,
-    )
-
-    assertContains(Interval(Row(0, 1), Row(1, 2, 4), true, true), Row(0, 1, 5))
-    assertContains(
-      Interval(Row(0, 1), Row(1, 2, 4), false, true),
-      Row(0, 1, 5),
-      shouldContain = false,
-    )
-    assertContains(Interval(Row(0, 1), Row(0, 1, 4), true, true), Row(0, 1, 4))
-    assertContains(
-      Interval(Row(0, 1), Row(0, 1, 4), true, false),
-      Row(0, 1, 4),
+      Interval(RowSeq(0, 1, 5), RowSeq(1, 2, 4), true, false),
+      RowSeq(1, 2, 4),
       shouldContain = false,
     )
 
-    assertContains(Interval(Row(0, 1), Row(1, 2, 4), true, true), Row(0, 1, 5))
+    assertContains(Interval(RowSeq(0, 1), RowSeq(1, 2, 4), true, true), RowSeq(0, 1, 5))
     assertContains(
-      Interval(Row(0, 1), Row(1, 2, 4), false, true),
-      Row(0, 1, 5),
+      Interval(RowSeq(0, 1), RowSeq(1, 2, 4), false, true),
+      RowSeq(0, 1, 5),
       shouldContain = false,
     )
-    assertContains(Interval(Row(0, 1), Row(0, 1, 4), true, true), Row(0, 1, 4))
+    assertContains(Interval(RowSeq(0, 1), RowSeq(0, 1, 4), true, true), RowSeq(0, 1, 4))
     assertContains(
-      Interval(Row(0, 1), Row(0, 1, 4), true, false),
-      Row(0, 1, 4),
+      Interval(RowSeq(0, 1), RowSeq(0, 1, 4), true, false),
+      RowSeq(0, 1, 4),
       shouldContain = false,
     )
 
-    assertContains(Interval(Row(), Row(1, 2, 4), true, true), Row(1, 2, 4))
-    assertContains(Interval(Row(), Row(1, 2, 4), true, false), Row(1, 2, 4), shouldContain = false)
-    assertContains(Interval(Row(1, 2, 4), Row(), true, true), Row(1, 2, 4))
-    assertContains(Interval(Row(1, 2, 4), Row(), false, true), Row(1, 2, 4), shouldContain = false)
+    assertContains(Interval(RowSeq(0, 1), RowSeq(1, 2, 4), true, true), RowSeq(0, 1, 5))
+    assertContains(
+      Interval(RowSeq(0, 1), RowSeq(1, 2, 4), false, true),
+      RowSeq(0, 1, 5),
+      shouldContain = false,
+    )
+    assertContains(Interval(RowSeq(0, 1), RowSeq(0, 1, 4), true, true), RowSeq(0, 1, 4))
+    assertContains(
+      Interval(RowSeq(0, 1), RowSeq(0, 1, 4), true, false),
+      RowSeq(0, 1, 4),
+      shouldContain = false,
+    )
 
-    assert(Interval(Row(0, 1, 5, 7), Row(2, 1, 4, 5), true, false).contains(pord, Row(0, 1, 6)))
-    assert(!Interval(Row(0, 1, 5, 7), Row(2, 1, 4, 5), true, false).contains(pord, Row(0, 1, 5)))
-    assert(!Interval(Row(0, 1, 5, 7), Row(2, 1, 4, 5), false, false).contains(pord, Row(0, 1, 5)))
+    assertContains(Interval(RowSeq(), RowSeq(1, 2, 4), true, true), RowSeq(1, 2, 4))
+    assertContains(
+      Interval(RowSeq(), RowSeq(1, 2, 4), true, false),
+      RowSeq(1, 2, 4),
+      shouldContain = false,
+    )
+    assertContains(Interval(RowSeq(1, 2, 4), RowSeq(), true, true), RowSeq(1, 2, 4))
+    assertContains(
+      Interval(RowSeq(1, 2, 4), RowSeq(), false, true),
+      RowSeq(1, 2, 4),
+      shouldContain = false,
+    )
+
+    assert(Interval(RowSeq(0, 1, 5, 7), RowSeq(2, 1, 4, 5), true, false).contains(
+      pord,
+      RowSeq(0, 1, 6),
+    ))
+    assert(!Interval(RowSeq(0, 1, 5, 7), RowSeq(2, 1, 4, 5), true, false).contains(
+      pord,
+      RowSeq(0, 1, 5),
+    ))
+    assert(!Interval(RowSeq(0, 1, 5, 7), RowSeq(2, 1, 4, 5), false, false).contains(
+      pord,
+      RowSeq(0, 1, 5),
+    ))
   }
 
   @Test def testAbovePosition(implicit ctx: ExecuteContext): Unit = {
-    assert(Interval(Row(0, 1, 5), Row(1, 2, 4), true, true).isAbovePosition(pord, Row(0, 1, 4)))
-    assert(Interval(Row(0, 1, 5), Row(1, 2, 4), false, true).isAbovePosition(pord, Row(0, 1, 5)))
-    assert(!Interval(Row(0, 1, 5), Row(1, 2, 4), true, true).isAbovePosition(pord, Row(0, 1, 5)))
-    assert(!Interval(Row(0, 1, 5), Row(1, 2, 4), true, false).isAbovePosition(pord, Row(1, 2, 4)))
-
-    assert(Interval(Row(0, 1), Row(1, 2, 4), true, true).isAbovePosition(pord, Row(0, 0, 5)))
-    assert(Interval(Row(0, 1), Row(1, 2, 4), false, true).isAbovePosition(pord, Row(0, 1, 5)))
-    assert(!Interval(Row(0, 1), Row(0, 1, 4), true, true).isAbovePosition(pord, Row(0, 1, 4)))
-
-    assert(Interval(Row(0, 1, 2, 3), Row(1, 2, 3, 4), true, true).isAbovePosition(
+    assert(Interval(RowSeq(0, 1, 5), RowSeq(1, 2, 4), true, true).isAbovePosition(
       pord,
-      Row(0, 1, 1, 4),
+      RowSeq(0, 1, 4),
     ))
-    assert(!Interval(Row(0, 1, 2, 3), Row(1, 2, 3, 4), true, true).isAbovePosition(
+    assert(Interval(RowSeq(0, 1, 5), RowSeq(1, 2, 4), false, true).isAbovePosition(
       pord,
-      Row(0, 1, 2, 2),
+      RowSeq(0, 1, 5),
+    ))
+    assert(!Interval(RowSeq(0, 1, 5), RowSeq(1, 2, 4), true, true).isAbovePosition(
+      pord,
+      RowSeq(0, 1, 5),
+    ))
+    assert(!Interval(RowSeq(0, 1, 5), RowSeq(1, 2, 4), true, false).isAbovePosition(
+      pord,
+      RowSeq(1, 2, 4),
+    ))
+
+    assert(Interval(RowSeq(0, 1), RowSeq(1, 2, 4), true, true).isAbovePosition(
+      pord,
+      RowSeq(0, 0, 5),
+    ))
+    assert(Interval(RowSeq(0, 1), RowSeq(1, 2, 4), false, true).isAbovePosition(
+      pord,
+      RowSeq(0, 1, 5),
+    ))
+    assert(!Interval(RowSeq(0, 1), RowSeq(0, 1, 4), true, true).isAbovePosition(
+      pord,
+      RowSeq(0, 1, 4),
+    ))
+
+    assert(Interval(RowSeq(0, 1, 2, 3), RowSeq(1, 2, 3, 4), true, true).isAbovePosition(
+      pord,
+      RowSeq(0, 1, 1, 4),
+    ))
+    assert(!Interval(RowSeq(0, 1, 2, 3), RowSeq(1, 2, 3, 4), true, true).isAbovePosition(
+      pord,
+      RowSeq(0, 1, 2, 2),
     ))
   }
 
   @Test def testBelowPosition(implicit ctx: ExecuteContext): Unit = {
-    assert(Interval(Row(0, 1, 5), Row(1, 2, 4), true, true).isBelowPosition(pord, Row(1, 2, 5)))
-    assert(Interval(Row(0, 1, 5), Row(1, 2, 4), true, false).isBelowPosition(pord, Row(1, 2, 4)))
-    assert(!Interval(Row(0, 1, 5), Row(1, 2, 4), true, true).isBelowPosition(pord, Row(1, 2, 4)))
-    assert(!Interval(Row(0, 1, 5), Row(1, 2, 4), true, false).isBelowPosition(pord, Row(0, 2, 4)))
+    assert(Interval(RowSeq(0, 1, 5), RowSeq(1, 2, 4), true, true).isBelowPosition(
+      pord,
+      RowSeq(1, 2, 5),
+    ))
+    assert(Interval(RowSeq(0, 1, 5), RowSeq(1, 2, 4), true, false).isBelowPosition(
+      pord,
+      RowSeq(1, 2, 4),
+    ))
+    assert(!Interval(RowSeq(0, 1, 5), RowSeq(1, 2, 4), true, true).isBelowPosition(
+      pord,
+      RowSeq(1, 2, 4),
+    ))
+    assert(!Interval(RowSeq(0, 1, 5), RowSeq(1, 2, 4), true, false).isBelowPosition(
+      pord,
+      RowSeq(0, 2, 4),
+    ))
 
-    assert(Interval(Row(1, 1, 8), Row(1, 2), true, true).isBelowPosition(pord, Row(1, 3, 6)))
-    assert(Interval(Row(1, 1, 8), Row(1, 2), false, false).isBelowPosition(pord, Row(1, 2, 5)))
-    assert(!Interval(Row(1, 1, 8), Row(1, 2), true, true).isBelowPosition(pord, Row(1, 2, 5)))
+    assert(Interval(RowSeq(1, 1, 8), RowSeq(1, 2), true, true).isBelowPosition(
+      pord,
+      RowSeq(1, 3, 6),
+    ))
+    assert(Interval(RowSeq(1, 1, 8), RowSeq(1, 2), false, false).isBelowPosition(
+      pord,
+      RowSeq(1, 2, 5),
+    ))
+    assert(!Interval(RowSeq(1, 1, 8), RowSeq(1, 2), true, true).isBelowPosition(
+      pord,
+      RowSeq(1, 2, 5),
+    ))
   }
 
   @Test def testAbutts(implicit ctx: ExecuteContext): Unit = {
-    assert(Interval(Row(0, 1, 5), Row(1, 2, 4), true, true).abutts(
+    assert(Interval(RowSeq(0, 1, 5), RowSeq(1, 2, 4), true, true).abutts(
       pord,
-      Interval(Row(1, 2, 4), Row(1, 3, 4), false, true),
+      Interval(RowSeq(1, 2, 4), RowSeq(1, 3, 4), false, true),
     ))
-    assert(!Interval(Row(0, 1, 5), Row(1, 2, 4), true, true).abutts(
+    assert(!Interval(RowSeq(0, 1, 5), RowSeq(1, 2, 4), true, true).abutts(
       pord,
-      Interval(Row(1, 2, 4), Row(1, 3, 4), true, true),
+      Interval(RowSeq(1, 2, 4), RowSeq(1, 3, 4), true, true),
     ))
 
-    assert(Interval(Row(0, 1), Row(1, 2), true, true).abutts(
+    assert(Interval(RowSeq(0, 1), RowSeq(1, 2), true, true).abutts(
       pord,
-      Interval(Row(1, 2), Row(1, 3), false, true),
+      Interval(RowSeq(1, 2), RowSeq(1, 3), false, true),
     ))
-    assert(!Interval(Row(0, 1), Row(1, 2), true, true).abutts(
+    assert(!Interval(RowSeq(0, 1), RowSeq(1, 2), true, true).abutts(
       pord,
-      Interval(Row(1, 2), Row(1, 3), true, true),
+      Interval(RowSeq(1, 2), RowSeq(1, 3), true, true),
     ))
   }
 
   @Test def testLteqWithOverlap(implicit ctx: ExecuteContext): Unit = {
     val eord = pord.intervalEndpointOrdering
     assert(!eord.lteqWithOverlap(3)(
-      IntervalEndpoint(Row(0, 1, 6), -1),
-      IntervalEndpoint(Row(0, 1, 5), 1),
+      IntervalEndpoint(RowSeq(0, 1, 6), -1),
+      IntervalEndpoint(RowSeq(0, 1, 5), 1),
     ))
 
     assert(eord.lteqWithOverlap(3)(
-      IntervalEndpoint(Row(0, 1, 5), 1),
-      IntervalEndpoint(Row(0, 1, 5), -1),
+      IntervalEndpoint(RowSeq(0, 1, 5), 1),
+      IntervalEndpoint(RowSeq(0, 1, 5), -1),
     ))
     assert(!eord.lteqWithOverlap(2)(
-      IntervalEndpoint(Row(0, 1, 5), 1),
-      IntervalEndpoint(Row(0, 1, 5), -1),
+      IntervalEndpoint(RowSeq(0, 1, 5), 1),
+      IntervalEndpoint(RowSeq(0, 1, 5), -1),
     ))
 
     assert(eord.lteqWithOverlap(2)(
-      IntervalEndpoint(Row(0, 1, 5), -1),
-      IntervalEndpoint(Row(0, 1, 5), -1),
+      IntervalEndpoint(RowSeq(0, 1, 5), -1),
+      IntervalEndpoint(RowSeq(0, 1, 5), -1),
     ))
     assert(!eord.lteqWithOverlap(1)(
-      IntervalEndpoint(Row(0, 1, 5), -1),
-      IntervalEndpoint(Row(0, 1, 5), -1),
+      IntervalEndpoint(RowSeq(0, 1, 5), -1),
+      IntervalEndpoint(RowSeq(0, 1, 5), -1),
     ))
 
     assert(eord.lteqWithOverlap(2)(
-      IntervalEndpoint(Row(0, 1, 2), -1),
-      IntervalEndpoint(Row(0, 1, 5), -1),
+      IntervalEndpoint(RowSeq(0, 1, 2), -1),
+      IntervalEndpoint(RowSeq(0, 1, 5), -1),
     ))
     assert(!eord.lteqWithOverlap(1)(
-      IntervalEndpoint(Row(0, 1, 2), -1),
-      IntervalEndpoint(Row(0, 1, 5), -1),
+      IntervalEndpoint(RowSeq(0, 1, 2), -1),
+      IntervalEndpoint(RowSeq(0, 1, 5), -1),
     ))
 
     assert(eord.lteqWithOverlap(1)(
-      IntervalEndpoint(Row(0, 1), -1),
-      IntervalEndpoint(Row(0, 1), -1),
+      IntervalEndpoint(RowSeq(0, 1), -1),
+      IntervalEndpoint(RowSeq(0, 1), -1),
     ))
     assert(!eord.lteqWithOverlap(0)(
-      IntervalEndpoint(Row(0, 1), -1),
-      IntervalEndpoint(Row(0, 1), -1),
+      IntervalEndpoint(RowSeq(0, 1), -1),
+      IntervalEndpoint(RowSeq(0, 1), -1),
     ))
 
     assert(eord.lteqWithOverlap(1)(
-      IntervalEndpoint(Row(0, 1, 5), -1),
-      IntervalEndpoint(Row(0, 2), -1),
+      IntervalEndpoint(RowSeq(0, 1, 5), -1),
+      IntervalEndpoint(RowSeq(0, 2), -1),
     ))
     assert(!eord.lteqWithOverlap(0)(
-      IntervalEndpoint(Row(0, 1, 5), -1),
-      IntervalEndpoint(Row(0, 2), -1),
+      IntervalEndpoint(RowSeq(0, 1, 5), -1),
+      IntervalEndpoint(RowSeq(0, 2), -1),
     ))
 
     assert(eord.lteqWithOverlap(0)(
-      IntervalEndpoint(Row(0), -1),
-      IntervalEndpoint(Row(0), -1),
+      IntervalEndpoint(RowSeq(0), -1),
+      IntervalEndpoint(RowSeq(0), -1),
     ))
     assert(eord.lteqWithOverlap(0)(
-      IntervalEndpoint(Row(0), -1),
-      IntervalEndpoint(Row(0, 1, 2), 1),
+      IntervalEndpoint(RowSeq(0), -1),
+      IntervalEndpoint(RowSeq(0, 1, 2), 1),
     ))
     assert(eord.lteqWithOverlap(0)(
-      IntervalEndpoint(Row(0, 3), -1),
-      IntervalEndpoint(Row(1, 2), -1),
+      IntervalEndpoint(RowSeq(0, 3), -1),
+      IntervalEndpoint(RowSeq(1, 2), -1),
     ))
     assert(!eord.lteqWithOverlap(-1)(
-      IntervalEndpoint(Row(0, 3), -1),
-      IntervalEndpoint(Row(1, 2), -1),
+      IntervalEndpoint(RowSeq(0, 3), -1),
+      IntervalEndpoint(RowSeq(1, 2), -1),
     ))
     assert(!eord.lteqWithOverlap(-1)(
-      IntervalEndpoint(Row(), 1),
-      IntervalEndpoint(Row(), -1),
+      IntervalEndpoint(RowSeq(), 1),
+      IntervalEndpoint(RowSeq(), -1),
     ))
   }
 
   @Test def testIsValid(implicit ctx: ExecuteContext): Unit = {
-    assert(Interval.isValid(pord, Row(0, 1, 5), Row(0, 2), false, false))
-    assert(!Interval.isValid(pord, Row(0, 1, 5), Row(0, 0), false, false))
-    assert(Interval.isValid(pord, Row(0, 1, 5), Row(0, 1), false, true))
-    assert(!Interval.isValid(pord, Row(0, 1, 5), Row(0, 1), false, false))
+    assert(Interval.isValid(pord, RowSeq(0, 1, 5), RowSeq(0, 2), false, false))
+    assert(!Interval.isValid(pord, RowSeq(0, 1, 5), RowSeq(0, 0), false, false))
+    assert(Interval.isValid(pord, RowSeq(0, 1, 5), RowSeq(0, 1), false, true))
+    assert(!Interval.isValid(pord, RowSeq(0, 1, 5), RowSeq(0, 1), false, false))
   }
 }


### PR DESCRIPTION
This change came about while investigating performance regressions between hail 0.2.128 and 0.2.138. In this case, the source of the slowdown was in the compiler itself from building arrays and copying them and the GC pressure that results.

This change adds`RowSeq` as a lightweight alternative `Row` implementation, reducing intermediate copies. The trouble with spark's usual`Row`is that the underlying array of data is copied on construction and when you pattern match. 

Summary of changes:

- Change all `Row.fromSeq` and `Row.apply` calls to to their `RowSeq` counterparts.
- Refactor `importAnnotationInternal` in `AnnotationImpex` to match on the `JValue` variant first then on the `Type`, rather than matching the (jv, t) pair. This eliminates repeated destructuring of the same `JValue` across multiple branches.

This change does not affect the broad-managed batch service in gcp.