### PR TITLE
[batch] Prevent an error that's logged every minute

### DIFF
--- a/hail/python/hailtop/aiocloud/aiogoogle/client/logging_client.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/client/logging_client.py
@@ -24,7 +24,7 @@ class PagedEntryIterator:
 
         # in case a response is empty but there are more pages
         while True:
-            assert self._page
+            assert self._page is not None
             # an empty page has no entries
             if (
                 'entries' in self._page


### PR DESCRIPTION
## Change Description

We see an AssertionError being logged by the batch-driver at least once a minute:

```
message: "in process_activity_logs"

Traceback (most recent call last):
  File "/opt/venv/lib/python3.11/site-packages/hailtop/utils/utils.py", line 916, in retry_long_running
    return await f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/hailtop/utils/utils.py", line 960, in loop
    await f(*args, **kwargs)
  File "/opt/venv/lib/python3.11/site-packages/batch/cloud/gcp/driver/driver.py", line 178, in process_activity_logs
    await process_outstanding_events(self.db, _process_activity_log_events_since)
  File "/opt/venv/lib/python3.11/site-packages/batch/driver/driver.py", line 19, in process_outstanding_events
    mark = await process_events_since(mark)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/batch/cloud/gcp/driver/driver.py", line 168, in _process_activity_log_events_since
    return await process_activity_log_events_since(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/batch/cloud/gcp/driver/activity_logs.py", line 114, in process_activity_log_events_since
    async for event in await activity_logs_client.list_entries(body=body):
  File "/opt/venv/lib/python3.11/site-packages/hailtop/aiocloud/aiogoogle/client/logging_client.py", line 27, in __anext__
    assert self._page
           ^^^^^^^^^^
AssertionError
```

Printing `self._page` in the `assert` shows that the value that is being returned by the preceding code is an empty `dict`, which decays to false and triggers the assert. I'm not familiar with this particular code, but making the assert trigger only for `None` prevents the error being logged and does not appear to have caused any unfortunate side-effects.

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has no security impact

### Impact Description

Low-level refactoring of non-security code

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
