### PR TITLE
[compiler] register `RowSeq` with `Kryo` + fix missing calls to `Row`

### DIFF
--- a/hail/hail/src/is/hail/annotations/Annotation.scala
+++ b/hail/hail/src/is/hail/annotations/Annotation.scala
@@ -56,7 +56,7 @@ object Annotation {
   }
 }
 
-private[annotations] class RowSeq(values: ArraySeq[Any]) extends Row {
+class RowSeq(values: ArraySeq[Any]) extends Row {
   override def length: Int = values.length
   override def get(i: Int): Any = values(i)
   override def copy(): Row = this

--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -1045,7 +1045,7 @@ object LowerTableIR extends Logging {
             },
           ),
           TableStageDependency.none,
-          ToStream(Literal(TArray(contextType), ranges.map(Row.fromTuple))),
+          ToStream(Literal(TArray(contextType), ranges.map(RowSeq.fromTuple))),
           ctxRef =>
             StreamRange(ctxRef.get("start"), ctxRef.get("end"), 1, true)
               .streamMap(i => makestruct("idx" -> i)),

--- a/hail/hail/src/is/hail/kryo/HailKryoRegistrator.scala
+++ b/hail/hail/src/is/hail/kryo/HailKryoRegistrator.scala
@@ -1,22 +1,41 @@
 package is.hail.kryo
 
-import is.hail.annotations.{Region, UnsafeIndexedSeq, UnsafeRow}
-import is.hail.utils.{Interval, SerializableHadoopConfiguration}
+import is.hail.annotations.{Region, RegionMemory, RegionPool, RowSeq, UnsafeIndexedSeq, UnsafeRow}
+import is.hail.collection.compat.immutable.ArraySeq
+import is.hail.collection.implicits.toRichArray
+import is.hail.utils.{Interval, IntervalEndpoint, SerializableHadoopConfiguration}
 import is.hail.variant.Locus
 
-import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.{Kryo, Serializer}
+import com.esotericsoftware.kryo.io.{Input, Output}
 import com.esotericsoftware.kryo.serializers.JavaSerializer
 import org.apache.spark.serializer.KryoRegistrator
 import org.apache.spark.sql.catalyst.expressions.GenericRow
 
 class HailKryoRegistrator extends KryoRegistrator {
   override def registerClasses(kryo: Kryo): Unit = {
+    kryo.addDefaultSerializer(classOf[ArraySeq[_]], new ArraySeqSerializer)
     kryo.register(classOf[SerializableHadoopConfiguration], new JavaSerializer())
     kryo.register(classOf[UnsafeRow])
     kryo.register(classOf[GenericRow])
+    kryo.register(classOf[RowSeq])
     kryo.register(classOf[Locus])
     kryo.register(classOf[Interval])
+    kryo.register(classOf[IntervalEndpoint])
     kryo.register(classOf[UnsafeIndexedSeq])
     kryo.register(classOf[Region])
+    kryo.register(classOf[RegionPool])
+    kryo.register(classOf[RegionMemory])
   }
+}
+
+// Recall that primitive and object arrays are not subtypes on the jvm.
+// We write the underlying array type to ensure that we recover the correct
+// array type from the input stream.
+class ArraySeqSerializer extends Serializer[ArraySeq[_]](true, true) {
+  override def write(kryo: Kryo, output: Output, xs: ArraySeq[_]): Unit =
+    kryo.writeClassAndObject(output, xs.unsafeArray)
+
+  override def read(kryo: Kryo, input: Input, `type`: Class[ArraySeq[_]]): ArraySeq[_] =
+    kryo.readClassAndObject(input).asInstanceOf[Array[_]].unsafeToArraySeq
 }

--- a/hail/hail/test/src/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/Aggregators2Suite.scala
@@ -1045,7 +1045,7 @@ class Aggregators2Suite {
       )
     )
 
-    assertEvalsTo(ir, Row((0 until 10).map(i => RowSeq(i, 2L * i + 12L)), RowSeq()))(
+    assertEvalsTo(ir, RowSeq((0 until 10).map(i => RowSeq(i, 2L * i + 12L)), RowSeq()))(
       ctx,
       ExecStrategy.interpretOnly,
     )

--- a/hail/hail/test/src/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/TableIRSuite.scala
@@ -354,7 +354,7 @@ class TableIRSuite {
     (36, 2, -1),
     (37, 1, -1),
     (37, 2, -1),
-  ).map(Row.fromTuple)
+  ).map(RowSeq.fromTuple)
 
   val rightData = FastSeq(
     (6, 1, 1),
@@ -381,7 +381,7 @@ class TableIRSuite {
     (38, 2, 1),
     (41, 1, 1),
     (41, 2, 1),
-  ).map(Row.fromTuple)
+  ).map(RowSeq.fromTuple)
 
   val expectedUnion = ArraySeq(
     (3, 1, -1),
@@ -432,7 +432,7 @@ class TableIRSuite {
     (38, 2, 1),
     (41, 1, 1),
     (41, 2, 1),
-  ).map(Row.fromTuple)
+  ).map(RowSeq.fromTuple)
 
   val expectedZipJoin = ArraySeq(
     (3, 1, FastSeq(RowSeq(-1), null)),
@@ -473,7 +473,7 @@ class TableIRSuite {
     (38, 2, FastSeq(null, RowSeq(1))),
     (41, 1, FastSeq(null, RowSeq(1))),
     (41, 2, FastSeq(null, RowSeq(1))),
-  ).map(Row.fromTuple)
+  ).map(RowSeq.fromTuple)
 
   val expectedOuterJoin = ArraySeq(
     (3, 1, -1, null, null),
@@ -524,7 +524,7 @@ class TableIRSuite {
     (38, null, null, 2, 1),
     (41, null, null, 1, 1),
     (41, null, null, 2, 1),
-  ).map(Row.fromTuple)
+  ).map(RowSeq.fromTuple)
 
   val joinTypes = ArraySeq(
     ("outer", (row: Row) => true),
@@ -1541,7 +1541,7 @@ class TableIRSuite {
           }
         }
       ),
-      Row((0 until 20).flatMap(i => (0 until 3).map(j => RowSeq("Hello", j))), RowSeq("Hello")),
+      RowSeq((0 until 20).flatMap(i => (0 until 3).map(j => RowSeq("Hello", j))), RowSeq("Hello")),
     )
 
     assertEvalsTo(
@@ -1557,7 +1557,7 @@ class TableIRSuite {
         IndexedSeq.tabulate(20) { i =>
           // 0,1,2,3,4,5,6,7,8,9,... ==>
           // 0,0,0,0,0,5,5,5,5,5,...
-          Row((i / 5) * 5)
+          RowSeq((i / 5) * 5)
         },
         RowSeq("Hello"),
       ),

--- a/hail/hail/test/src/is/hail/kryo/KryoSuite.scala
+++ b/hail/hail/test/src/is/hail/kryo/KryoSuite.scala
@@ -1,0 +1,39 @@
+package is.hail.kryo
+
+import is.hail.ParameterizedTest
+import is.hail.collection.compat.immutable.ArraySeq
+
+import com.esotericsoftware.kryo.Kryo
+import com.esotericsoftware.kryo.io.{Input, Output}
+import org.junit.jupiter.api.BeforeAll
+
+class KryoSuite {
+  private var kryo: Kryo = _
+
+  @BeforeAll def setupClass(): Unit = {
+    kryo = new Kryo()
+    new HailKryoRegistrator().registerClasses(kryo)
+  }
+
+  def ArraySeqSerialization() =
+    ArraySeq(
+      null,
+      ArraySeq.empty[String],
+      ArraySeq("a", "b", "c"),
+      ArraySeq("a", null, "c"),
+      ArraySeq('a', 'b'),
+      ArraySeq(1.byteValue(), 2.byteValue),
+      ArraySeq(1.shortValue, 2.shortValue),
+      ArraySeq(1, 2, 3),
+      ArraySeq(1L, 2L, 3L),
+      ArraySeq(true, false),
+    )
+
+  @ParameterizedTest("ArraySeqSerialization")
+  def testArraySeqSerialization(xs: ArraySeq[_]): Unit = {
+    val output = new Output(1024, -1)
+    kryo.writeClassAndObject(output, xs)
+    val ys = kryo.readClassAndObject(new Input(output.toBytes))
+    assert((xs == ys) && (xs == null || xs.getClass == ys.getClass))
+  }
+}

--- a/hail/hail/test/src/is/hail/scalacheck/GenVal.scala
+++ b/hail/hail/test/src/is/hail/scalacheck/GenVal.scala
@@ -1,8 +1,9 @@
 package is.hail.scalacheck
 
-import is.hail.annotations.{Annotation => An, SafeNDArray}
+import is.hail.annotations.{Annotation => An, RowSeq, SafeNDArray}
 import is.hail.backend.ExecuteContext
 import is.hail.collection.compat.immutable.ArraySeq
+import is.hail.collection.implicits.toRichArray
 import is.hail.scalacheck
 import is.hail.types.physical._
 import is.hail.types.virtual._
@@ -11,7 +12,6 @@ import is.hail.utils.Interval
 import scala.collection.compat._
 
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.catalyst.expressions.GenericRow
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen._
@@ -42,7 +42,7 @@ private[scalacheck] trait GenVal {
             values <- sequence(sizes.lazyZip(t.types).map { case (s, t) =>
               resize(s, genVal(ctx, t))
             })
-          } yield new GenericRow(values)
+          } yield new RowSeq(values.unsafeToArraySeq)
         case _: PBoolean =>
           arbitrary[Boolean]
         case _: PBinary =>


### PR DESCRIPTION
I missed this in #15561. Registering with Kryo is recommended for performance - kryo doesn't need to serialise the full type name, for example.
This change does not affect the broad-managed batch service in gcp.