### PR TITLE
[make] exit the updater early if envoy is up to date

### DIFF
--- a/update-envoy.py
+++ b/update-envoy.py
@@ -64,7 +64,7 @@ def main() -> None:
 
     if current_version == latest_version:
         print(f'Already up to date: v{current_version}')
-        sys.exit(0)
+        sys.exit(2)
 
     print(f'Updating v{current_version} -> v{latest_version}')
     update_files(current_version, latest_version)


### PR DESCRIPTION
## Change Description

Updates the envoy update make target early if envoy is already up to date.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

