### PR TITLE
[auth] Add /api/ implementations of remaining html-only queries

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -31,6 +31,7 @@ from gear import (
     monitor_endpoints_middleware,
     setup_aiohttp_session,
     transaction,
+    version_response,
 )
 from gear.auth import AIOHTTPHandler, get_session_id
 from gear.cloud_config import get_global_config
@@ -605,10 +606,30 @@ async def rest_login(request: web.Request) -> web.Response:
     })
 
 
+@routes.get('/api/v1alpha/version')
+@auth.maybe_authenticated_user
+async def get_version(_, userdata: Optional[UserData]) -> web.Response:
+    return version_response(userdata)
+
+
 @routes.get('/api/v1alpha/oauth2-client')
 async def hailctl_oauth_client(request):  # pylint: disable=unused-argument
     idp = IdentityProvider.GOOGLE if CLOUD == 'gcp' else IdentityProvider.MICROSOFT
     return json_response({'idp': idp.value, 'oauth2_client': request.app[AppKeys.HAILCTL_CLIENT_CONFIG]})
+
+
+@routes.get('/api/v1alpha/support')
+async def get_support(request):  # pylint: disable=unused-argument
+    try:
+        global_config = get_global_config()
+        support_email = global_config.get('support_email', '')
+    except (FileNotFoundError, OSError):
+        support_email = ''
+    return json_response({
+        'cloud': CLOUD,
+        'inactive_user_timeout_days': INACTIVE_USER_TIMEOUT_DAYS,
+        'support_email': support_email,
+    })
 
 
 @routes.get('/roles')

--- a/auth/auth/templates/openapi.yaml
+++ b/auth/auth/templates/openapi.yaml
@@ -501,6 +501,46 @@ paths:
               schema:
                 type: string
 
+  /api/v1alpha/version:
+    get:
+      summary: Get service version
+      description: Returns the current version of the auth service. Available to unauthenticated users (version info may differ for authenticated users).
+      tags: [Authentication]
+      responses:
+        '200':
+          description: Version information retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  version:
+                    type: string
+                    description: Current version of the auth service
+
+  /api/v1alpha/support:
+    get:
+      summary: Get support information
+      description: Returns support contact information and deployment configuration details.
+      tags: [Authentication]
+      responses:
+        '200':
+          description: Support information retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  cloud:
+                    type: string
+                    description: Cloud provider (e.g. gcp)
+                  inactive_user_timeout_days:
+                    type: integer
+                    description: Number of days after which inactive users are timed out
+                  support_email:
+                    type: string
+                    description: Support email address (may be empty if not configured)
+
   /api/v1alpha/oauth2-client:
     get:
       summary: Get OAuth2 client configuration

--- a/auth/auth/templates/openapi.yaml
+++ b/auth/auth/templates/openapi.yaml
@@ -504,24 +504,21 @@ paths:
   /api/v1alpha/version:
     get:
       summary: Get service version
-      description: Returns the current version of the auth service. Available to unauthenticated users (version info may differ for authenticated users).
+      description: Returns the current version of the auth service as plain text. Available to unauthenticated users; sysadmins receive the full version string while others receive only the base version (prefix before the first '-').
       tags: [Authentication]
       responses:
         '200':
-          description: Version information retrieved successfully
+          description: Version string retrieved successfully
           content:
-            application/json:
+            text/plain:
               schema:
-                type: object
-                properties:
-                  version:
-                    type: string
-                    description: Current version of the auth service
+                type: string
+                description: Service version string
 
   /api/v1alpha/support:
     get:
       summary: Get support information
-      description: Returns support contact information and deployment configuration details.
+      description: Returns support contact information and deployment configuration details. Available to unauthenticated users.
       tags: [Authentication]
       responses:
         '200':

--- a/auth/auth/templates/openapi.yaml
+++ b/auth/auth/templates/openapi.yaml
@@ -112,12 +112,6 @@ components:
           type: boolean
           description: "Whether the operation was successful"
 
-  securitySchemes:
-    developerAuth:
-      type: http
-      scheme: bearer
-      description: Hail authentication token (permissions are checked per-endpoint)
-
 paths:
   /api/v1alpha/userinfo:
     get:
@@ -137,8 +131,6 @@ paths:
     get:
       summary: List all users
       tags: [User Management]
-      security:
-        - developerAuth: []
       responses:
         '200':
           description: List of users retrieved successfully
@@ -155,8 +147,6 @@ paths:
     get:
       summary: Get user by username
       tags: [User Management]
-      security:
-        - developerAuth: []
       parameters:
         - name: username
           in: path
@@ -175,8 +165,6 @@ paths:
     delete:
       summary: Delete user
       tags: [User Management]
-      security:
-        - developerAuth: []
       parameters:
         - name: username
           in: path
@@ -193,8 +181,6 @@ paths:
     post:
       summary: Create new user
       tags: [User Management]
-      security:
-        - developerAuth: []
       parameters:
         - name: username
           in: path
@@ -290,8 +276,6 @@ paths:
       summary: Verify system permission
       description: Verify that the authenticated user has a specific system permission
       tags: [Authentication]
-      security:
-        - developerAuth: []
       parameters:
         - name: permission
           in: query
@@ -357,8 +341,6 @@ paths:
       summary: Get system roles and permissions for a specific user
       description: Get all system roles and permissions for a specific user by their user ID
       tags: [System Roles]
-      security:
-        - developerAuth: []
       parameters:
         - name: user_id
           in: path
@@ -390,8 +372,6 @@ paths:
       summary: Modify system roles for a specific user
       description: Add or remove a system role for a specific user. The request body must contain exactly one of 'role_addition' or 'role_removal' fields, but not both.
       tags: [System Roles]
-      security:
-        - developerAuth: []
       parameters:
         - name: user_id
           in: path
@@ -469,8 +449,6 @@ paths:
       summary: Get all system role assignments
       description: Get all system roles with their assigned users and permissions
       tags: [System Roles]
-      security:
-        - developerAuth: []
       responses:
         '200':
           description: All system role assignments retrieved successfully


### PR DESCRIPTION
Auth only spin-off of #15514.

## Change Description

Completes the REST api endpoint set as a fully featured way to query the system, fetch data, and mutate state.

Motivation:
1. Allow hailctl (with future hailctl tool implementations, or via the hailctl curl fallback) to access all system state.
2. Allow full investigation of the deployed system state with command line commands and scripts.
3. Allow for local UI development against live APIs for rapid prototyping, development and testing without the current 40m build/deploy/test cycle. 
4. Supporting UI elements that combine data from multiple services (eg comparing actual charged billing data from batch with the cloud billing data in monitoring)

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a medium security impact

### Impact Description

I'm asserting that there is nothing new that can be done here, since everything is currently possible via the html pages already. But the permissions on each API should be validated, and the refactors are increasing the surface area of the services even if the functionality is not new.

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
