### PR TITLE
[ci] Add /api/ implementations of remaining html-only queries

### DIFF
--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -786,15 +786,21 @@ UPDATE globals SET frozen_merge_deploy = 0;
     raise web.HTTPFound(deploy_config.external_url('ci', '/'))
 
 
-async def _fetch_active_namespaces(db: Database) -> list:
+async def _fetch_active_namespaces(db: Database, namespace: Optional[str] = None) -> list:
+    where = 'WHERE active_namespaces.namespace = %s' if namespace is not None else ''
+    args = (namespace,) if namespace is not None else ()
     namespaces = [
         r
-        async for r in db.execute_and_fetchall("""
+        async for r in db.execute_and_fetchall(
+            f"""
 SELECT active_namespaces.*, JSON_OBJECTAGG(service, rate_limit_rps) as services
 FROM active_namespaces
 LEFT JOIN deployed_services
 ON active_namespaces.namespace = deployed_services.namespace
-GROUP BY active_namespaces.namespace""")
+{where}
+GROUP BY active_namespaces.namespace""",
+            args,
+        )
     ]
     for ns in namespaces:
         ns['services'] = json.loads(ns['services']) or {}
@@ -1176,10 +1182,10 @@ async def api_authorize_sha(request: web.Request, _) -> web.Response:
 async def api_get_namespace(request: web.Request, _) -> web.Response:
     db = request.app[AppKeys.DB]
     namespace = request.match_info['namespace']
-    record = await db.select_and_fetchone('SELECT * FROM active_namespaces WHERE namespace = %s', (namespace,))
-    if not record:
+    namespaces = await _fetch_active_namespaces(db, namespace=namespace)
+    if not namespaces:
         raise web.HTTPNotFound()
-    return json_response(dict(record))
+    return json_response(namespaces[0])
 
 
 @routes.put('/api/v1alpha/namespaces/{namespace}')

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -33,6 +33,7 @@ from gear import (
     json_response,
     monitor_endpoints_middleware,
     setup_aiohttp_session,
+    version_response,
 )
 from gear.profiling import install_profiler_if_requested
 from hailtop import __version__, aiotools, httpx, uvloopx
@@ -168,6 +169,13 @@ def wb_and_pr_from_request(request: web.Request) -> Tuple[WatchedBranch, PR]:
     return wb, wb.prs[pr_number]
 
 
+def _wb_by_branch(branch_name: str) -> WatchedBranch:
+    for wb in watched_branches:
+        if wb.branch.name == branch_name:
+            return wb
+    raise web.HTTPNotFound()
+
+
 def filter_jobs(jobs):
     filtered: Dict[str, list] = {
         state: []
@@ -198,6 +206,43 @@ async def _populate_batch_context(page_context: Dict[str, Any], batch: Batch) ->
         page_context['logging_queries'] = None
 
 
+async def _active_pr_json(wb: WatchedBranch, pr: PR) -> dict:
+    _do_not_merge = frozenset(('WIP', 'stacked PR'))
+    deploy_batch = wb.deploy_batch
+    blocking_deploy_batch_id = (
+        deploy_batch.id if deploy_batch and isinstance(deploy_batch, Batch) and wb.deploy_state is None else None
+    )
+    batch = pr.batch
+    batch_summary = None
+    if batch and isinstance(batch, Batch):
+        status = await batch.last_known_status()
+        batch_summary = {
+            'id': batch.id,
+            'state': status.get('state'),
+            'cost': status.get('cost'),
+            'artifacts_uri': f'{STORAGE_URI}/build/{batch.attributes["token"]}',
+        }
+    return {
+        'review_approved': pr.review_state == 'approved',
+        'checks_all_pass': len(pr.last_known_github_status) > 0 and pr.build_succeeding_on_all_platforms(),
+        'is_up_to_date': pr.is_up_to_date(),
+        'blocking_labels': [label for label in pr.labels if label in ('WIP', 'stacked PR')],
+        'is_mergeable': pr.is_mergeable(),
+        'prs_ahead_in_queue': [
+            {'number': p.number, 'title': p.title, 'is_merge_candidate': p is wb.merge_candidate}
+            for p in wb.prs_in_merge_priority_order()
+            if p.number != pr.number
+            and p.merge_priority() > pr.merge_priority()
+            and p.review_state == 'approved'
+            and not any(label in _do_not_merge for label in p.labels)
+            and not p.build_failed_on_at_least_one_platform()
+        ],
+        'is_merge_candidate': wb.merge_candidate is not None and wb.merge_candidate.number == pr.number,
+        'blocking_deploy_batch_id': blocking_deploy_batch_id,
+        'batch': batch_summary,
+    }
+
+
 async def _populate_active_pr_context(
     page_context: Dict[str, Any], wb: WatchedBranch, pr_number: int, db: Database
 ) -> None:
@@ -205,33 +250,11 @@ async def _populate_active_pr_context(
     page_context['pr'] = pr
     page_context['active_pr'] = True
     page_context['pr_authorized'] = await pr.authorized(db)
-
-    # Merge eligibility checklist
-    page_context['review_approved'] = pr.review_state == 'approved'
-    page_context['checks_all_pass'] = len(pr.last_known_github_status) > 0 and pr.build_succeeding_on_all_platforms()
-    page_context['is_up_to_date'] = pr.is_up_to_date()
-    page_context['blocking_labels'] = [label for label in pr.labels if label in ('WIP', 'stacked PR')]
-    page_context['is_mergeable'] = pr.is_mergeable()
-
-    # Merge queue: approved, non-blocked, non-failing PRs with higher priority
-    _do_not_merge = frozenset(('WIP', 'stacked PR'))
     page_context['build_failing'] = pr.build_failed_on_at_least_one_platform()
-    page_context['prs_ahead_in_queue'] = [
-        {'number': p.number, 'title': p.title, 'is_merge_candidate': p is wb.merge_candidate}
-        for p in wb.prs_in_merge_priority_order()
-        if p.number != pr.number
-        and p.merge_priority() > pr.merge_priority()
-        and p.review_state == 'approved'
-        and not any(label in _do_not_merge for label in p.labels)
-        and not p.build_failed_on_at_least_one_platform()
-    ]
-    page_context['is_merge_candidate'] = wb.merge_candidate is not None and wb.merge_candidate.number == pr.number
 
-    # Deploy batch blocking next merge (running but not yet complete)
-    deploy_batch = wb.deploy_batch
-    page_context['blocking_deploy_batch_id'] = (
-        deploy_batch.id if deploy_batch and isinstance(deploy_batch, Batch) and wb.deploy_state is None else None
-    )
+    active_data = await _active_pr_json(wb, pr)
+    page_context.update(active_data)
+    page_context.pop('batch', None)
 
     batch = pr.batch
     if batch:
@@ -330,19 +353,15 @@ def storage_uri_to_url(uri: str) -> str:
     return uri
 
 
-async def retry_pr(wb: WatchedBranch, pr: PR, request: web.Request, userdata: UserData):
-    app = request.app
-    session = await aiohttp_session.get_session(request)
-
+async def _retry_pr_core(wb: WatchedBranch, pr: PR, app: web.Application, username: str) -> Optional[str]:
+    """Executes the retry logic. Returns an error message on failure, None on success."""
     if pr.batch is None:
         log.info(f'retry cannot be requested for PR #{pr.number} because it has no batch')
-        set_message(session, f'Retry cannot be requested for PR #{pr.number} because it has no batch.', 'error')
-        return
+        return 'Retry cannot be requested because this PR has no batch.'
 
     if isinstance(pr.batch, MergeFailureBatch):
         log.info(f'retry cannot be requested for PR #{pr.number} because it was a merge failure')
-        set_message(session, f'Retry cannot be requested for PR #{pr.number} because it was a merge failure.', 'error')
-        return
+        return 'Retry cannot be requested because this PR had a merge failure.'
 
     batch_id = pr.batch.id
     db = app[AppKeys.DB]
@@ -363,7 +382,7 @@ async def retry_pr(wb: WatchedBranch, pr: PR, request: web.Request, userdata: Us
                     wb.branch.short_str(),
                     pr.source_branch.name,
                     pr.source_sha,
-                    userdata['username'],
+                    username,
                 ),
             )
 
@@ -374,9 +393,17 @@ async def retry_pr(wb: WatchedBranch, pr: PR, request: web.Request, userdata: Us
     await wb.notify_batch_changed(
         db, app[AppKeys.BATCH_CLIENT], app[AppKeys.GH_CLIENT], app[AppKeys.FROZEN_MERGE_DEPLOY]
     )
-
     log.info(f'retry requested for PR: {pr.number}')
-    set_message(session, f'Retry requested for PR #{pr.number}.', 'info')
+    return None
+
+
+async def retry_pr(wb: WatchedBranch, pr: PR, request: web.Request, userdata: UserData):
+    session = await aiohttp_session.get_session(request)
+    error = await _retry_pr_core(wb, pr, request.app, userdata['username'])
+    if error:
+        set_message(session, error, 'error')
+    else:
+        set_message(session, f'Retry requested for PR #{pr.number}.', 'info')
 
 
 @routes.post('/watched_branches/{watched_branch_index}/pr/{pr_number}/retry')
@@ -594,6 +621,12 @@ async def batch_callback_handler(request: web.Request):
                     )
 
 
+@routes.get('/api/v1alpha/version')
+@auth.maybe_authenticated_user
+async def get_version(_, userdata: Optional[UserData]) -> web.Response:
+    return version_response(userdata)
+
+
 @routes.get('/api/v1alpha/deploy_status')
 @auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
 async def deploy_status(request: web.Request, _) -> web.Response:
@@ -753,11 +786,7 @@ UPDATE globals SET frozen_merge_deploy = 0;
     raise web.HTTPFound(deploy_config.external_url('ci', '/'))
 
 
-@routes.get('/namespaces')
-@web_security_headers
-@auth.authenticated_users_with_permission(SystemPermission.READ_CI)
-async def get_active_namespaces(request: web.Request, userdata: UserData) -> web.Response:
-    db = request.app[AppKeys.DB]
+async def _fetch_active_namespaces(db: Database) -> list:
     namespaces = [
         r
         async for r in db.execute_and_fetchall("""
@@ -769,10 +798,15 @@ GROUP BY active_namespaces.namespace""")
     ]
     for ns in namespaces:
         ns['services'] = json.loads(ns['services']) or {}
-    context = {
-        'namespaces': namespaces,
-    }
-    return await render_template('ci', request, userdata, 'namespaces.html', context)
+    return namespaces
+
+
+@routes.get('/namespaces')
+@web_security_headers
+@auth.authenticated_users_with_permission(SystemPermission.READ_CI)
+async def get_active_namespaces(request: web.Request, userdata: UserData) -> web.Response:
+    namespaces = await _fetch_active_namespaces(request.app[AppKeys.DB])
+    return await render_template('ci', request, userdata, 'namespaces.html', {'namespaces': namespaces})
 
 
 @routes.post('/namespaces/{namespace}/services/add')
@@ -797,7 +831,7 @@ WHERE namespace = %s AND service = %s
         set_message(session, 'Service already registered', 'info')
     else:
         await db.execute_insertone(
-            'INSERT INTO deployed_services VALUES (%s, %s)',
+            'INSERT INTO deployed_services (`namespace`, `service`) VALUES (%s, %s)',
             (namespace, service),
         )
 
@@ -814,7 +848,7 @@ async def update_namespaced_service(request: web.Request, _) -> NoReturn:
     post = await request.post()
     rate_limit = post['rate_limit'] or None
 
-    await db.execute_insertone(
+    await db.execute_update(
         """UPDATE deployed_services SET rate_limit_rps = %s WHERE namespace = %s AND service = %s""",
         (rate_limit, namespace, service),
     )
@@ -951,6 +985,278 @@ LIMIT %s
         'cursor': rows[-1]['id'] if has_more else None,
         'has_more': has_more,
     })
+
+
+def _pr_config_json(cfg: PRConfig) -> dict:
+    return {
+        **cfg,
+        'assignees': list(cfg['assignees']),
+        'reviewers': list(cfg['reviewers']),
+        'labels': list(cfg['labels']),
+    }
+
+
+def _wb_config_json(cfg: Dict[str, Any]) -> dict:
+    return {
+        **cfg,
+        'prs': [_pr_config_json(pr) for pr in cfg['prs']],
+        'gh_status_names': list(cfg['gh_status_names']),
+    }
+
+
+@routes.get('/api/v1alpha/watched_branches')
+@auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
+async def api_watched_branches(request: web.Request, _) -> web.Response:
+    result = [
+        {
+            'branch': wb.branch.name,
+            'branch_fqn': wb.branch.short_str(),
+            'repo': wb.branch.repo.short_str(),
+            'sha': wb.sha,
+            'deploy_state': wb.deploy_state,
+            'deploy_batch_id': wb.deploy_batch.id if wb.deploy_batch and isinstance(wb.deploy_batch, Batch) else None,
+            'n_prs': len(wb.prs) if wb.prs else 0,
+            'merge_candidate': wb.merge_candidate.short_str() if wb.merge_candidate else None,
+        }
+        for wb in watched_branches
+    ]
+    return json_response({'branches': result, 'frozen': request.app[AppKeys.FROZEN_MERGE_DEPLOY]})
+
+
+@routes.get('/api/v1alpha/watched_branches/{branch}/prs')
+@auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
+async def api_watched_branch_prs(request: web.Request, _) -> web.Response:
+    wb = _wb_by_branch(request.match_info['branch'])
+    prs = [_pr_config_json(await pr_config(request.app, pr)) for pr in (wb.prs or {}).values()]
+    return json_response(prs)
+
+
+@routes.get('/api/v1alpha/watched_branches/{branch}/prs/{number}')
+@auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
+async def api_watched_branch_pr(request: web.Request, _) -> web.Response:
+    wb = _wb_by_branch(request.match_info['branch'])
+    try:
+        pr_number = int(request.match_info['number'])
+    except ValueError as exc:
+        raise web.HTTPBadRequest(text='PR number must be an integer') from exc
+
+    if wb.prs and pr_number in wb.prs:
+        pr = wb.prs[pr_number]
+        result = _pr_config_json(await pr_config(request.app, pr))
+        result.update(await _active_pr_json(wb, pr))
+        return json_response(result)
+
+    try:
+        gh_pr = await request.app[AppKeys.GH_CLIENT].getitem(f'/repos/{wb.branch.repo.short_str()}/pulls/{pr_number}')
+        return json_response({
+            'number': gh_pr['number'],
+            'title': gh_pr['title'],
+            'labels': [label['name'] for label in gh_pr.get('labels', [])],
+            'merged': gh_pr['merged'],
+            'merge_commit_sha': gh_pr.get('merge_commit_sha') if gh_pr['merged'] else None,
+        })
+    except gidgethub.HTTPException as e:
+        if e.status_code == 404:
+            raise web.HTTPNotFound()
+        log.exception('GitHub API error fetching PR %s', pr_number)
+        raise web.HTTPBadGateway(text='GitHub API error')
+    except ClientError as exc:
+        log.exception('GitHub API network error fetching PR %s', pr_number)
+        raise web.HTTPBadGateway(text='GitHub API unreachable') from exc
+
+
+@routes.get('/api/v1alpha/namespaces')
+@auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
+async def api_namespaces(request: web.Request, _) -> web.Response:
+    namespaces = await _fetch_active_namespaces(request.app[AppKeys.DB])
+    return json_response(namespaces)
+
+
+@routes.get('/api/v1alpha/me')
+@auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
+async def api_me(request: web.Request, userdata: UserData) -> web.Response:
+    user = next(
+        (u for u in AUTHORIZED_USERS if u.hail_username == userdata['username']),
+        None,
+    )
+    if user is None:
+        raise web.HTTPNotFound()
+
+    wbs = [await watched_branch_config(request.app, wb, i) for i, wb in enumerate(watched_branches)]
+    pr_wbs = [_wb_config_json(w) for w in filter_wbs(wbs, lambda pr: is_pr_author(user.gh_username, pr))]
+    review_wbs = [_wb_config_json(w) for w in filter_wbs(wbs, lambda pr: is_pr_reviewer(user.gh_username, pr))]
+    actionable_wbs = [_wb_config_json(w) for w in filter_wbs(wbs, lambda pr: pr_requires_action(user.gh_username, pr))]
+
+    batch_client = request.app[AppKeys.BATCH_CLIENT]
+    dev_deploys_iter = batch_client.list_batches(f'user={user.hail_username} dev_deploy=1', limit=10)
+    dev_deploys = sorted([b async for b in dev_deploys_iter], key=lambda b: b.id, reverse=True)
+
+    return json_response({
+        'hail_username': user.hail_username,
+        'gh_username': user.gh_username,
+        'pr_wbs': pr_wbs,
+        'review_wbs': review_wbs,
+        'actionable_wbs': actionable_wbs,
+        'dev_deploys': [await b.last_known_status() for b in dev_deploys],
+    })
+
+
+@routes.get('/api/v1alpha/authorized_shas')
+@auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
+async def api_authorized_shas(request: web.Request, _) -> web.Response:
+    db = request.app[AppKeys.DB]
+    rows = [r['sha'] async for r in db.execute_and_fetchall('SELECT sha FROM authorized_shas ORDER BY sha')]
+    return json_response(rows)
+
+
+@routes.get('/api/v1alpha/teams')
+@auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
+async def api_teams(_request: web.Request, _) -> web.Response:
+    result: Dict[str, list] = {team: [] for team in TEAMS}
+    for user in AUTHORIZED_USERS:
+        for team in user.teams:
+            if team in result:
+                result[team].append({'gh_username': user.gh_username, 'hail_username': user.hail_username})
+    return json_response(result)
+
+
+@routes.post('/api/v1alpha/freeze')
+@auth.authenticated_users_with_permission(SystemPermission.MANAGE_CI, redirect=False)
+async def api_freeze(request: web.Request, _) -> web.Response:
+    app = request.app
+    if app[AppKeys.FROZEN_MERGE_DEPLOY]:
+        raise web.HTTPConflict(text='CI is already frozen.')
+    await app[AppKeys.DB].execute_update('UPDATE globals SET frozen_merge_deploy = 1;')
+    app[AppKeys.FROZEN_MERGE_DEPLOY] = True
+    return json_response({'frozen': True})
+
+
+@routes.post('/api/v1alpha/unfreeze')
+@auth.authenticated_users_with_permission(SystemPermission.MANAGE_CI, redirect=False)
+async def api_unfreeze(request: web.Request, _) -> web.Response:
+    app = request.app
+    if not app[AppKeys.FROZEN_MERGE_DEPLOY]:
+        raise web.HTTPConflict(text='CI is already unfrozen.')
+    await app[AppKeys.DB].execute_update('UPDATE globals SET frozen_merge_deploy = 0;')
+    app[AppKeys.FROZEN_MERGE_DEPLOY] = False
+    return json_response({'frozen': False})
+
+
+@routes.post('/api/v1alpha/watched_branches/{branch}/prs/{number}/retry')
+@auth.authenticated_users_with_permission(SystemPermission.MANAGE_CI, redirect=False)
+async def api_retry_pr(request: web.Request, userdata: UserData) -> web.Response:
+    wb = _wb_by_branch(request.match_info['branch'])
+    try:
+        pr_number = int(request.match_info['number'])
+    except ValueError as exc:
+        raise web.HTTPBadRequest(text='PR number must be an integer') from exc
+    if not wb.prs or pr_number not in wb.prs:
+        raise web.HTTPNotFound()
+    pr = wb.prs[pr_number]
+    error = await asyncio.shield(_retry_pr_core(wb, pr, request.app, userdata['username']))
+    if error:
+        raise web.HTTPBadRequest(text=error)
+    return web.Response(status=200)
+
+
+@routes.post('/api/v1alpha/authorize_sha')
+@auth.authenticated_users_with_permission(SystemPermission.MANAGE_CI, redirect=False)
+async def api_authorize_sha(request: web.Request, _) -> web.Response:
+    params = await json_request(request)
+    sha = str(params.get('sha', '')).strip()
+    if not sha:
+        raise web.HTTPBadRequest(text='sha is required')
+    await request.app[AppKeys.DB].execute_insertone('INSERT INTO authorized_shas (sha) VALUES (%s);', sha)
+    log.info(f'authorized sha: {sha}')
+    return web.Response(status=201)
+
+
+@routes.get('/api/v1alpha/namespaces/{namespace}')
+@auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
+async def api_get_namespace(request: web.Request, _) -> web.Response:
+    db = request.app[AppKeys.DB]
+    namespace = request.match_info['namespace']
+    record = await db.select_and_fetchone('SELECT * FROM active_namespaces WHERE namespace = %s', (namespace,))
+    if not record:
+        raise web.HTTPNotFound()
+    return json_response(dict(record))
+
+
+@routes.put('/api/v1alpha/namespaces/{namespace}')
+@auth.authenticated_users_with_permission(SystemPermission.MANAGE_CI, redirect=False)
+async def api_put_namespace(request: web.Request, _) -> web.Response:
+    db = request.app[AppKeys.DB]
+    namespace = request.match_info['namespace']
+    existing = await db.execute_and_fetchone('SELECT 1 FROM active_namespaces WHERE namespace = %s', (namespace,))
+    if existing:
+        return json_response({'namespace': namespace})
+    await db.execute_insertone('INSERT INTO active_namespaces (`namespace`) VALUES (%s)', (namespace,))
+    return web.Response(status=201)
+
+
+@routes.delete('/api/v1alpha/namespaces/{namespace}')
+@auth.authenticated_users_with_permission(SystemPermission.MANAGE_CI, redirect=False)
+async def api_delete_namespace(request: web.Request, _) -> web.Response:
+    db = request.app[AppKeys.DB]
+    namespace = request.match_info['namespace']
+    await remove_namespace_from_db(db, namespace)
+    return web.Response(status=204)
+
+
+@routes.get('/api/v1alpha/namespaces/{namespace}/services/{service}')
+@auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
+async def api_get_namespace_service(request: web.Request, _) -> web.Response:
+    db = request.app[AppKeys.DB]
+    namespace = request.match_info['namespace']
+    service = request.match_info['service']
+    record = await db.select_and_fetchone(
+        'SELECT * FROM deployed_services WHERE namespace = %s AND service = %s', (namespace, service)
+    )
+    if not record:
+        raise web.HTTPNotFound()
+    return json_response(dict(record))
+
+
+@routes.put('/api/v1alpha/namespaces/{namespace}/services/{service}')
+@auth.authenticated_users_with_permission(SystemPermission.MANAGE_CI, redirect=False)
+async def api_put_namespace_service(request: web.Request, _) -> web.Response:
+    db = request.app[AppKeys.DB]
+    namespace = request.match_info['namespace']
+    service = request.match_info['service']
+    existing = await db.select_and_fetchone(
+        'SELECT 1 FROM deployed_services WHERE namespace = %s AND service = %s', (namespace, service)
+    )
+    if existing:
+        return json_response({'namespace': namespace, 'service': service})
+    await db.execute_insertone(
+        'INSERT INTO deployed_services (`namespace`, `service`) VALUES (%s, %s)', (namespace, service)
+    )
+    return web.Response(status=201)
+
+
+@routes.patch('/api/v1alpha/namespaces/{namespace}/services/{service}')
+@auth.authenticated_users_with_permission(SystemPermission.MANAGE_CI, redirect=False)
+async def api_update_namespace_service(request: web.Request, _) -> web.Response:
+    db = request.app[AppKeys.DB]
+    namespace = request.match_info['namespace']
+    service = request.match_info['service']
+    params = await json_request(request)
+    rate_limit_rps = params.get('rate_limit_rps')
+    await db.execute_update(
+        'UPDATE deployed_services SET rate_limit_rps = %s WHERE namespace = %s AND service = %s',
+        (rate_limit_rps, namespace, service),
+    )
+    return web.Response(status=200)
+
+
+@routes.delete('/api/v1alpha/namespaces/{namespace}/services/{service}')
+@auth.authenticated_users_with_permission(SystemPermission.MANAGE_CI, redirect=False)
+async def api_delete_namespace_service(request: web.Request, _) -> web.Response:
+    db = request.app[AppKeys.DB]
+    namespace = request.match_info['namespace']
+    service = request.match_info['service']
+    await db.execute_update('DELETE FROM deployed_services WHERE namespace = %s AND service = %s', (namespace, service))
+    return web.Response(status=204)
 
 
 async def cleanup_expired_namespaces(db: Database):

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -51,7 +51,7 @@ from web_common import (
     web_security_headers_swagger,
 )
 
-from .constants import AUTHORIZED_USERS, TEAMS
+from .constants import AUTHORIZED_USERS, TEAMS, User
 from .environment import CLOUD, DEFAULT_NAMESPACE, DOMAIN, STORAGE_URI
 from .envoy import Service, create_cds_response, create_rds_response
 from .github import PR, WIP, FQBranch, MergeFailureBatch, Repo, UnwatchedBranch, WatchedBranch, select_random_teammate
@@ -1002,6 +1002,22 @@ def _pr_config_json(cfg: PRConfig) -> dict:
     }
 
 
+def _pr_flat_json(cfg: PRConfig, wb: WatchedBranchConfig) -> dict:
+    return {
+        'number': cfg['number'],
+        'title': cfg['title'],
+        'wb_index': wb['index'],
+        'wb_name': wb['branch'],
+        'build_state': cfg['build_state'],
+        'out_of_date': cfg['out_of_date'],
+        'gh_statuses': cfg['gh_statuses'],
+        'labels': list(cfg['labels']),
+        'source_branch_name': cfg['source_branch_name'],
+        'review_state': cfg['review_state'],
+        'author': cfg['author'],
+    }
+
+
 def _wb_config_json(cfg: Dict[str, Any]) -> dict:
     return {
         **cfg,
@@ -1078,34 +1094,71 @@ async def api_namespaces(request: web.Request, _) -> web.Response:
     return json_response(namespaces)
 
 
+def _lookup_developer(username: str) -> User:
+    user = next((u for u in AUTHORIZED_USERS if u.hail_username == username), None)
+    if user is None:
+        raise web.HTTPNotFound(text='No such dev-authorized user. Check AUTHORIZED_USERS in constants.py.')
+    return user
+
+
 @routes.get('/api/v1alpha/developers/{username}')
 @auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
 async def api_developer(request: web.Request, _: UserData) -> web.Response:
-    username = request.match_info['username']
-    user = next(
-        (u for u in AUTHORIZED_USERS if u.hail_username == username),
-        None,
-    )
-    if user is None:
-        raise web.HTTPNotFound(text='No such dev-authorized user. Check AUTHORIZED_USERS in constants.py.')
+    user = _lookup_developer(request.match_info['username'])
+    return json_response({'hail_username': user.hail_username, 'gh_username': user.gh_username})
 
+
+@routes.get('/api/v1alpha/developers/{username}/prs')
+@auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
+async def api_developer_prs(request: web.Request, _: UserData) -> web.Response:
+    user = _lookup_developer(request.match_info['username'])
     wbs = [await watched_branch_config(request.app, wb, i) for i, wb in enumerate(watched_branches)]
-    pr_wbs = [_wb_config_json(w) for w in filter_wbs(wbs, lambda pr: is_pr_author(user.gh_username, pr))]
-    review_wbs = [_wb_config_json(w) for w in filter_wbs(wbs, lambda pr: is_pr_reviewer(user.gh_username, pr))]
-    actionable_wbs = [_wb_config_json(w) for w in filter_wbs(wbs, lambda pr: pr_requires_action(user.gh_username, pr))]
+    open_prs = [_pr_flat_json(pr, wb) for wb in wbs for pr in wb['prs'] if is_pr_author(user.gh_username, pr)]
+    reviewer_prs = [_pr_flat_json(pr, wb) for wb in wbs for pr in wb['prs'] if is_pr_reviewer(user.gh_username, pr)]
+    action_required_prs = [
+        _pr_flat_json(pr, wb) for wb in wbs for pr in wb['prs'] if pr_requires_action(user.gh_username, pr)
+    ]
+    return json_response({'open': open_prs, 'reviewer': reviewer_prs, 'action_required': action_required_prs})
 
+
+@routes.get('/api/v1alpha/developers/{username}/prs/open')
+@auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
+async def api_developer_prs_open(request: web.Request, _: UserData) -> web.Response:
+    user = _lookup_developer(request.match_info['username'])
+    wbs = [await watched_branch_config(request.app, wb, i) for i, wb in enumerate(watched_branches)]
+    return json_response([
+        _pr_flat_json(pr, wb) for wb in wbs for pr in wb['prs'] if is_pr_author(user.gh_username, pr)
+    ])
+
+
+@routes.get('/api/v1alpha/developers/{username}/prs/reviewer')
+@auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
+async def api_developer_prs_reviewer(request: web.Request, _: UserData) -> web.Response:
+    user = _lookup_developer(request.match_info['username'])
+    wbs = [await watched_branch_config(request.app, wb, i) for i, wb in enumerate(watched_branches)]
+    return json_response([
+        _pr_flat_json(pr, wb) for wb in wbs for pr in wb['prs'] if is_pr_reviewer(user.gh_username, pr)
+    ])
+
+
+@routes.get('/api/v1alpha/developers/{username}/prs/action_required')
+@auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
+async def api_developer_prs_action_required(request: web.Request, _: UserData) -> web.Response:
+    user = _lookup_developer(request.match_info['username'])
+    wbs = [await watched_branch_config(request.app, wb, i) for i, wb in enumerate(watched_branches)]
+    return json_response([
+        _pr_flat_json(pr, wb) for wb in wbs for pr in wb['prs'] if pr_requires_action(user.gh_username, pr)
+    ])
+
+
+@routes.get('/api/v1alpha/developers/{username}/dev_deploys')
+@auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
+async def api_developer_dev_deploys(request: web.Request, _: UserData) -> web.Response:
+    user = _lookup_developer(request.match_info['username'])
     batch_client = request.app[AppKeys.BATCH_CLIENT]
     dev_deploys_iter = batch_client.list_batches(f'user={user.hail_username} dev_deploy=1', limit=10)
     dev_deploys = sorted([b async for b in dev_deploys_iter], key=lambda b: b.id, reverse=True)
-
-    return json_response({
-        'hail_username': user.hail_username,
-        'gh_username': user.gh_username,
-        'pr_wbs': pr_wbs,
-        'review_wbs': review_wbs,
-        'actionable_wbs': actionable_wbs,
-        'dev_deploys': [await b.last_known_status() for b in dev_deploys],
-    })
+    return json_response([await b.last_known_status() for b in dev_deploys])
 
 
 @routes.get('/api/v1alpha/authorized_shas')

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -387,7 +387,7 @@ async def _retry_pr_core(wb: WatchedBranch, pr: PR, app: web.Application, userna
             )
 
     await db.execute_insertone('INSERT INTO invalidated_batches (batch_id) VALUES (%s);', batch_id)
-    pr.pending_build_reason = f'retry by {userdata["username"]}'
+    pr.pending_build_reason = f'retry by {username}'
     pr.batch = None
     pr.set_build_state(None)
     await wb.notify_batch_changed(
@@ -1080,7 +1080,7 @@ async def api_me(request: web.Request, userdata: UserData) -> web.Response:
         None,
     )
     if user is None:
-        raise web.HTTPNotFound()
+        raise web.HTTPNotFound(text='No such dev-authorized user. Check AUTHORIZED_USERS in constants.py.')
 
     wbs = [await watched_branch_config(request.app, wb, i) for i, wb in enumerate(watched_branches)]
     pr_wbs = [_wb_config_json(w) for w in filter_wbs(wbs, lambda pr: is_pr_author(user.gh_username, pr))]

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -1094,24 +1094,32 @@ async def api_namespaces(request: web.Request, _) -> web.Response:
     return json_response(namespaces)
 
 
-def _lookup_developer(username: str) -> User:
+def _lookup_developer(username: str, userdata: UserData) -> User:
+    if username == 'me':
+        username = userdata['username']
     user = next((u for u in AUTHORIZED_USERS if u.hail_username == username), None)
     if user is None:
         raise web.HTTPNotFound(text='No such dev-authorized user. Check AUTHORIZED_USERS in constants.py.')
     return user
 
 
+@routes.get('/api/v1alpha/developers')
+@auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
+async def api_developers(_request: web.Request, _: UserData) -> web.Response:
+    return json_response([{'hail_username': u.hail_username, 'gh_username': u.gh_username} for u in AUTHORIZED_USERS])
+
+
 @routes.get('/api/v1alpha/developers/{username}')
 @auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
-async def api_developer(request: web.Request, _: UserData) -> web.Response:
-    user = _lookup_developer(request.match_info['username'])
+async def api_developer(request: web.Request, userdata: UserData) -> web.Response:
+    user = _lookup_developer(request.match_info['username'], userdata)
     return json_response({'hail_username': user.hail_username, 'gh_username': user.gh_username})
 
 
 @routes.get('/api/v1alpha/developers/{username}/prs')
 @auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
-async def api_developer_prs(request: web.Request, _: UserData) -> web.Response:
-    user = _lookup_developer(request.match_info['username'])
+async def api_developer_prs(request: web.Request, userdata: UserData) -> web.Response:
+    user = _lookup_developer(request.match_info['username'], userdata)
     wbs = [await watched_branch_config(request.app, wb, i) for i, wb in enumerate(watched_branches)]
     open_prs = [_pr_flat_json(pr, wb) for wb in wbs for pr in wb['prs'] if is_pr_author(user.gh_username, pr)]
     reviewer_prs = [_pr_flat_json(pr, wb) for wb in wbs for pr in wb['prs'] if is_pr_reviewer(user.gh_username, pr)]
@@ -1123,8 +1131,8 @@ async def api_developer_prs(request: web.Request, _: UserData) -> web.Response:
 
 @routes.get('/api/v1alpha/developers/{username}/prs/open')
 @auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
-async def api_developer_prs_open(request: web.Request, _: UserData) -> web.Response:
-    user = _lookup_developer(request.match_info['username'])
+async def api_developer_prs_open(request: web.Request, userdata: UserData) -> web.Response:
+    user = _lookup_developer(request.match_info['username'], userdata)
     wbs = [await watched_branch_config(request.app, wb, i) for i, wb in enumerate(watched_branches)]
     return json_response([
         _pr_flat_json(pr, wb) for wb in wbs for pr in wb['prs'] if is_pr_author(user.gh_username, pr)
@@ -1133,8 +1141,8 @@ async def api_developer_prs_open(request: web.Request, _: UserData) -> web.Respo
 
 @routes.get('/api/v1alpha/developers/{username}/prs/reviewer')
 @auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
-async def api_developer_prs_reviewer(request: web.Request, _: UserData) -> web.Response:
-    user = _lookup_developer(request.match_info['username'])
+async def api_developer_prs_reviewer(request: web.Request, userdata: UserData) -> web.Response:
+    user = _lookup_developer(request.match_info['username'], userdata)
     wbs = [await watched_branch_config(request.app, wb, i) for i, wb in enumerate(watched_branches)]
     return json_response([
         _pr_flat_json(pr, wb) for wb in wbs for pr in wb['prs'] if is_pr_reviewer(user.gh_username, pr)
@@ -1143,8 +1151,8 @@ async def api_developer_prs_reviewer(request: web.Request, _: UserData) -> web.R
 
 @routes.get('/api/v1alpha/developers/{username}/prs/action_required')
 @auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
-async def api_developer_prs_action_required(request: web.Request, _: UserData) -> web.Response:
-    user = _lookup_developer(request.match_info['username'])
+async def api_developer_prs_action_required(request: web.Request, userdata: UserData) -> web.Response:
+    user = _lookup_developer(request.match_info['username'], userdata)
     wbs = [await watched_branch_config(request.app, wb, i) for i, wb in enumerate(watched_branches)]
     return json_response([
         _pr_flat_json(pr, wb) for wb in wbs for pr in wb['prs'] if pr_requires_action(user.gh_username, pr)
@@ -1153,8 +1161,8 @@ async def api_developer_prs_action_required(request: web.Request, _: UserData) -
 
 @routes.get('/api/v1alpha/developers/{username}/dev_deploys')
 @auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
-async def api_developer_dev_deploys(request: web.Request, _: UserData) -> web.Response:
-    user = _lookup_developer(request.match_info['username'])
+async def api_developer_dev_deploys(request: web.Request, userdata: UserData) -> web.Response:
+    user = _lookup_developer(request.match_info['username'], userdata)
     batch_client = request.app[AppKeys.BATCH_CLIENT]
     dev_deploys_iter = batch_client.list_batches(f'user={user.hail_username} dev_deploy=1', limit=10)
     dev_deploys = sorted([b async for b in dev_deploys_iter], key=lambda b: b.id, reverse=True)

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -803,7 +803,7 @@ GROUP BY active_namespaces.namespace""",
         )
     ]
     for ns in namespaces:
-        ns['services'] = json.loads(ns['services']) or {}
+        ns['services'] = json.loads(ns['services'] or '{}') or {}
     return namespaces
 
 
@@ -1231,6 +1231,8 @@ async def api_retry_pr(request: web.Request, userdata: UserData) -> web.Response
 @auth.authenticated_users_with_permission(SystemPermission.MANAGE_CI, redirect=False)
 async def api_authorize_sha(request: web.Request, _) -> web.Response:
     params = await json_request(request)
+    if not isinstance(params, dict):
+        raise web.HTTPBadRequest(text='Request body must be a JSON object')
     sha = str(params.get('sha', '')).strip()
     if not sha:
         raise web.HTTPBadRequest(text='sha is required')
@@ -1309,6 +1311,8 @@ async def api_update_namespace_service(request: web.Request, _) -> web.Response:
     namespace = request.match_info['namespace']
     service = request.match_info['service']
     params = await json_request(request)
+    if not isinstance(params, dict):
+        raise web.HTTPBadRequest(text='Request body must be a JSON object')
     rate_limit_rps = params.get('rate_limit_rps')
     await db.execute_update(
         'UPDATE deployed_services SET rate_limit_rps = %s WHERE namespace = %s AND service = %s',

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -1078,11 +1078,12 @@ async def api_namespaces(request: web.Request, _) -> web.Response:
     return json_response(namespaces)
 
 
-@routes.get('/api/v1alpha/me')
+@routes.get('/api/v1alpha/developers/{username}')
 @auth.authenticated_users_with_permission(SystemPermission.READ_CI, redirect=False)
-async def api_me(request: web.Request, userdata: UserData) -> web.Response:
+async def api_developer(request: web.Request, _: UserData) -> web.Response:
+    username = request.match_info['username']
     user = next(
-        (u for u in AUTHORIZED_USERS if u.hail_username == userdata['username']),
+        (u for u in AUTHORIZED_USERS if u.hail_username == username),
         None,
     )
     if user is None:

--- a/ci/ci/templates/openapi.yaml
+++ b/ci/ci/templates/openapi.yaml
@@ -249,7 +249,7 @@ components:
         merge_candidate:
           type: string
           nullable: true
-          description: "Current merge candidate branch"
+          description: "Current merge candidate PR (eg pr-123)"
 
     WatchedBranchesResponse:
       type: object
@@ -271,6 +271,14 @@ components:
           type: string
         author:
           type: string
+        assignees:
+          type: array
+          items:
+            type: string
+        reviewers:
+          type: array
+          items:
+            type: string
         source_branch_name:
           type: string
         build_state:
@@ -503,7 +511,20 @@ paths:
               schema:
                 type: object
 
-  
+  /api/v1alpha/version:
+    get:
+      summary: Get service version
+      description: Returns the current version of the ci service as plain text. Available to unauthenticated users; sysadmins receive the full version string while others receive only the base version (prefix before the first '-').
+      tags: [Documentation]
+      responses:
+        '200':
+          description: Version string retrieved successfully
+          content:
+            text/plain:
+              schema:
+                type: string
+                description: Service version string
+
   /api/v1alpha/deploy_status:
     get:
       summary: Get deployment status
@@ -1266,8 +1287,8 @@ paths:
                       type: object
         '401':
           description: Unauthorized
-        '403':
-          description: Forbidden - user is not in AUTHORIZED_USERS
+        '404':
+          description: Not Found - user is not in AUTHORIZED_USERS in constants.py
 
   /api/v1alpha/authorized_shas:
     get:

--- a/ci/ci/templates/openapi.yaml
+++ b/ci/ci/templates/openapi.yaml
@@ -34,6 +34,54 @@ tags:
 
 components:
   schemas:
+    PRSummary:
+      type: object
+      properties:
+        number:
+          type: integer
+        title:
+          type: string
+        wb_index:
+          type: integer
+        wb_name:
+          type: string
+        build_state:
+          type: string
+          nullable: true
+        out_of_date:
+          type: boolean
+        gh_statuses:
+          type: object
+          additionalProperties:
+            type: string
+        labels:
+          type: array
+          items:
+            type: string
+        source_branch_name:
+          type: string
+        review_state:
+          type: string
+          nullable: true
+        author:
+          type: string
+
+    DeveloperPRs:
+      type: object
+      properties:
+        open:
+          type: array
+          items:
+            $ref: '#/components/schemas/PRSummary'
+        reviewer:
+          type: array
+          items:
+            $ref: '#/components/schemas/PRSummary'
+        action_required:
+          type: array
+          items:
+            $ref: '#/components/schemas/PRSummary'
+
     BuildStatus:
       type: object
       properties:
@@ -1256,11 +1304,9 @@ paths:
 
   /api/v1alpha/developers/{username}:
     get:
-      summary: Developer's CI dashboard data
-      description: >
-        Returns PRs authored by, under review by, and requiring action from the specified developer,
-        plus their recent dev deploys.
-      tags: [PRs]
+      summary: Developer identity
+      description: Returns the Hail and GitHub usernames for the specified developer.
+      tags: [Developers]
       parameters:
         - name: username
           in: path
@@ -1270,7 +1316,7 @@ paths:
           description: Hail username of the developer
       responses:
         '200':
-          description: User data retrieved successfully
+          description: Developer found
           content:
             application/json:
               schema:
@@ -1280,26 +1326,136 @@ paths:
                     type: string
                   gh_username:
                     type: string
-                  pr_wbs:
-                    type: array
-                    items:
-                      type: object
-                  review_wbs:
-                    type: array
-                    items:
-                      type: object
-                  actionable_wbs:
-                    type: array
-                    items:
-                      type: object
-                  dev_deploys:
-                    type: array
-                    items:
-                      type: object
         '401':
           description: Unauthorized
         '404':
           description: Not Found - user is not in AUTHORIZED_USERS in constants.py
+
+  /api/v1alpha/developers/{username}/prs:
+    get:
+      summary: Developer's PRs (all categories)
+      description: >
+        Returns all PRs relevant to the developer grouped into open (authored),
+        reviewer, and action_required lists. Each PR includes wb_index and wb_name
+        to correlate with the watched_branches endpoint.
+      tags: [Developers]
+      parameters:
+        - name: username
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: PR lists retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeveloperPRs'
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+
+  /api/v1alpha/developers/{username}/prs/open:
+    get:
+      summary: Developer's open PRs
+      description: PRs authored by the developer.
+      tags: [Developers]
+      parameters:
+        - name: username
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Open PRs retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PRSummary'
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+
+  /api/v1alpha/developers/{username}/prs/reviewer:
+    get:
+      summary: Developer's reviewer PRs
+      description: PRs where the developer is assigned as a reviewer.
+      tags: [Developers]
+      parameters:
+        - name: username
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Reviewer PRs retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PRSummary'
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+
+  /api/v1alpha/developers/{username}/prs/action_required:
+    get:
+      summary: Developer's action-required PRs
+      description: PRs that require action from the developer (build failure, changes requested, or pending review).
+      tags: [Developers]
+      parameters:
+        - name: username
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Action-required PRs retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PRSummary'
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
+
+  /api/v1alpha/developers/{username}/dev_deploys:
+    get:
+      summary: Developer's recent dev deploys
+      description: Returns the 10 most recent dev deploy batches for the developer.
+      tags: [Developers]
+      parameters:
+        - name: username
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Dev deploys retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        '401':
+          description: Unauthorized
+        '404':
+          description: Not Found
 
   /api/v1alpha/authorized_shas:
     get:

--- a/ci/ci/templates/openapi.yaml
+++ b/ci/ci/templates/openapi.yaml
@@ -45,6 +45,7 @@ components:
           type: integer
         wb_name:
           type: string
+          description: "Branch name (e.g. 'main'), usable directly as the {branch} path parameter in watched_branches endpoints"
         build_state:
           type: string
           nullable: true
@@ -1359,7 +1360,8 @@ paths:
       description: >
         Returns all PRs relevant to the developer grouped into open (authored),
         reviewer, and action_required lists. Each PR includes wb_index and wb_name
-        to correlate with the watched_branches endpoint.
+        to correlate with the watched_branches endpoint. wb_name is the branch name
+        (e.g. 'main') and can be used directly as the {branch} path parameter.
       tags: [Developers]
       parameters:
         - name: username

--- a/ci/ci/templates/openapi.yaml
+++ b/ci/ci/templates/openapi.yaml
@@ -1254,13 +1254,20 @@ paths:
         '403':
           description: Forbidden - requires MANAGE_CI
 
-  /api/v1alpha/me:
+  /api/v1alpha/developers/{username}:
     get:
-      summary: Current user's CI dashboard data
+      summary: Developer's CI dashboard data
       description: >
-        Returns PRs authored by, under review by, and requiring action from the current user,
+        Returns PRs authored by, under review by, and requiring action from the specified developer,
         plus their recent dev deploys.
       tags: [PRs]
+      parameters:
+        - name: username
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Hail username of the developer
       responses:
         '200':
           description: User data retrieved successfully

--- a/ci/ci/templates/openapi.yaml
+++ b/ci/ci/templates/openapi.yaml
@@ -1302,6 +1302,28 @@ paths:
         '403':
           description: Forbidden - requires MANAGE_CI
 
+  /api/v1alpha/developers:
+    get:
+      summary: List developers
+      description: Returns all authorized developers with their Hail and GitHub usernames.
+      tags: [Developers]
+      responses:
+        '200':
+          description: Developer list retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    hail_username:
+                      type: string
+                    gh_username:
+                      type: string
+        '401':
+          description: Unauthorized
+
   /api/v1alpha/developers/{username}:
     get:
       summary: Developer identity
@@ -1313,7 +1335,7 @@ paths:
           required: true
           schema:
             type: string
-          description: Hail username of the developer
+          description: Hail username of the developer, or the special value `me` for the authenticated caller
       responses:
         '200':
           description: Developer found

--- a/ci/ci/templates/openapi.yaml
+++ b/ci/ci/templates/openapi.yaml
@@ -1088,7 +1088,7 @@ paths:
   /api/v1alpha/namespaces/{namespace}:
     get:
       summary: Get a namespace
-      description: Returns the record for a single active namespace.
+      description: Returns the record for a single active namespace, including its deployed services map.
       tags: [Namespaces]
       parameters:
         - name: namespace
@@ -1099,6 +1099,10 @@ paths:
       responses:
         '200':
           description: Namespace retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NamespaceInfo'
         '401':
           description: Unauthorized
         '403':

--- a/ci/ci/templates/openapi.yaml
+++ b/ci/ci/templates/openapi.yaml
@@ -21,6 +21,8 @@ tags:
     description: "Endpoints for managing deployments"
   - name: Namespaces
     description: "Endpoints for managing namespaces and services"
+  - name: PRs
+    description: "Endpoints for pull request data"
   - name: GitHub Integration
     description: "Endpoints for GitHub webhook integration"
   - name: Documentation
@@ -217,11 +219,164 @@ components:
           type: boolean
           description: "Whether more rows exist beyond this page"
 
-  securitySchemes:
-    developerAuth:
-      type: http
-      scheme: bearer
-      description: Developer authentication token
+    WatchedBranchSummary:
+      type: object
+      properties:
+        branch:
+          type: string
+          description: "Branch name (e.g. main). Use this as the {branch} path parameter."
+        branch_fqn:
+          type: string
+          description: "Fully-qualified branch ref (e.g. hail-is/hail:main)."
+        repo:
+          type: string
+          description: "Repository (e.g. hail-is/hail)"
+        sha:
+          type: string
+          nullable: true
+          description: "Current HEAD SHA"
+        deploy_state:
+          type: string
+          nullable: true
+          description: "Latest deploy state"
+        deploy_batch_id:
+          type: integer
+          nullable: true
+          description: "Latest deploy batch ID"
+        n_prs:
+          type: integer
+          description: "Number of active PRs"
+        merge_candidate:
+          type: string
+          nullable: true
+          description: "Current merge candidate branch"
+
+    WatchedBranchesResponse:
+      type: object
+      properties:
+        branches:
+          type: array
+          items:
+            $ref: '#/components/schemas/WatchedBranchSummary'
+        frozen:
+          type: boolean
+          description: "Whether merges and deploys are frozen"
+
+    PRConfig:
+      type: object
+      properties:
+        number:
+          type: integer
+        title:
+          type: string
+        author:
+          type: string
+        source_branch_name:
+          type: string
+        build_state:
+          type: string
+          nullable: true
+        review_state:
+          type: string
+          nullable: true
+        labels:
+          type: array
+          items:
+            type: string
+        out_of_date:
+          type: boolean
+        gh_statuses:
+          type: object
+          additionalProperties:
+            type: string
+        batch_id:
+          type: integer
+          nullable: true
+
+    BatchSummary:
+      type: object
+      nullable: true
+      properties:
+        id:
+          type: integer
+        state:
+          type: string
+          nullable: true
+        cost:
+          type: number
+          nullable: true
+        artifacts_uri:
+          type: string
+
+    ActivePRDetail:
+      allOf:
+        - $ref: '#/components/schemas/PRConfig'
+        - type: object
+          properties:
+            review_approved:
+              type: boolean
+            checks_all_pass:
+              type: boolean
+            is_up_to_date:
+              type: boolean
+            blocking_labels:
+              type: array
+              items:
+                type: string
+            is_mergeable:
+              type: boolean
+            prs_ahead_in_queue:
+              type: array
+              items:
+                type: object
+                properties:
+                  number:
+                    type: integer
+                  title:
+                    type: string
+                  is_merge_candidate:
+                    type: boolean
+            is_merge_candidate:
+              type: boolean
+            blocking_deploy_batch_id:
+              type: integer
+              nullable: true
+            batch:
+              $ref: '#/components/schemas/BatchSummary'
+
+    HistoricalPRDetail:
+      type: object
+      properties:
+        number:
+          type: integer
+        title:
+          type: string
+        labels:
+          type: array
+          items:
+            type: string
+        merged:
+          type: boolean
+          nullable: true
+        merge_commit_sha:
+          type: string
+          nullable: true
+
+    TeamMember:
+      type: object
+      properties:
+        gh_username:
+          type: string
+        hail_username:
+          type: string
+          nullable: true
+
+    FreezeResponse:
+      type: object
+      properties:
+        frozen:
+          type: boolean
+
 
 paths:
   '/':
@@ -283,8 +438,6 @@ paths:
       summary: "Retry PR build"
       description: "Request a retry of the CI build for this PR"
       tags: [Deployments]
-      security:
-        - developerAuth: []
       parameters:
         - name: watched_branch_index
           in: path
@@ -356,8 +509,6 @@ paths:
       summary: Get deployment status
       description: Get status of all branch deployments
       tags: [Deployments]
-      security:
-        - developerAuth: []
       responses:
         '200':
           description: Deployment status retrieved successfully
@@ -377,8 +528,6 @@ paths:
       summary: Trigger update
       description: Trigger an update of all watched branches
       tags: [Deployments]
-      security:
-        - developerAuth: []
       responses:
         '200':
           description: Update triggered successfully
@@ -392,8 +541,6 @@ paths:
       summary: Deploy branch for development
       description: Create a development deployment for a specific branch
       tags: [Deployments]
-      security:
-        - developerAuth: []
       requestBody:
         required: true
         content:
@@ -434,8 +581,6 @@ paths:
       summary: List builds
       description: Get a list of CI builds
       tags: [Builds]
-      security:
-        - developerAuth: []
       parameters:
         - name: limit
           in: query
@@ -466,8 +611,6 @@ paths:
       summary: Get build details
       description: Get detailed information about a specific build
       tags: [Builds]
-      security:
-        - developerAuth: []
       parameters:
         - name: build_id
           in: path
@@ -502,8 +645,6 @@ paths:
       summary: Get Envoy configuration
       description: Get Envoy proxy configuration for gateway or internal-gateway
       tags: [Namespaces]
-      security:
-        - developerAuth: []
       parameters:
         - name: proxy
           in: path
@@ -538,8 +679,6 @@ paths:
       summary: Authorize source SHA
       description: Authorize a source SHA for deployment
       tags: [Builds]
-      security:
-        - developerAuth: []
       requestBody:
         required: true
         content:
@@ -563,8 +702,6 @@ paths:
       summary: Freeze merges and deploys
       description: Freeze all merges and deployments
       tags: [Deployments]
-      security:
-        - developerAuth: []
       responses:
         '200':
           description: Successfully froze merges and deploys
@@ -578,8 +715,6 @@ paths:
       summary: Unfreeze merges and deploys
       description: Unfreeze all merges and deployments
       tags: [Deployments]
-      security:
-        - developerAuth: []
       responses:
         '200':
           description: Successfully unfroze merges and deploys
@@ -593,8 +728,6 @@ paths:
       summary: "Namespaces (UI)"
       description: "Render the namespaces page, or (dev only) its supporting jinja context"
       tags: [UI Pages]
-      security:
-        - developerAuth: []
       parameters:
         - name: x-hail-return-jinja-context
           in: header
@@ -617,8 +750,6 @@ paths:
       summary: Add service to namespace
       description: Add a new service to a namespace
       tags: [Namespaces]
-      security:
-        - developerAuth: []
       parameters:
         - name: namespace
           in: path
@@ -649,8 +780,6 @@ paths:
       summary: Edit service in namespace
       description: Edit service configuration in a namespace
       tags: [Namespaces]
-      security:
-        - developerAuth: []
       parameters:
         - name: namespace
           in: path
@@ -688,8 +817,6 @@ paths:
       summary: Add namespace
       description: Add a new namespace
       tags: [Namespaces]
-      security:
-        - developerAuth: []
       requestBody:
         required: true
         content:
@@ -713,8 +840,6 @@ paths:
       summary: "Flaky Test Dashboard (UI)"
       description: "Render the flaky test leaderboard page"
       tags: [Flaky Tests, UI Pages]
-      security:
-        - developerAuth: []
       responses:
         '200':
           description: "Successfully rendered the flaky test dashboard"
@@ -731,8 +856,6 @@ paths:
         with cursor-based pagination and an optional date filter.
         The default window is the last 14 days.
       tags: [Flaky Tests]
-      security:
-        - developerAuth: []
       parameters:
         - name: after
           in: query
@@ -813,4 +936,434 @@ paths:
           content:
             application/json:
               schema:
-                type: object 
+                type: object
+
+  /api/v1alpha/watched_branches:
+    get:
+      summary: List watched branches
+      description: "Returns all branches CI is monitoring, plus the current freeze status."
+      tags: [PRs]
+      responses:
+        '200':
+          description: Watched branches retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WatchedBranchesResponse'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+
+  /api/v1alpha/watched_branches/{branch}/prs:
+    get:
+      summary: List PRs for a watched branch
+      description: Returns all active PRs for the given branch with build and review state.
+      tags: [PRs]
+      parameters:
+        - name: branch
+          in: path
+          required: true
+          schema:
+            type: string
+          description: "Branch name (e.g. main)"
+      responses:
+        '200':
+          description: PR list retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PRConfig'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Branch not found
+
+  /api/v1alpha/watched_branches/{branch}/prs/{number}:
+    get:
+      summary: Get PR details
+      description: >
+        Returns full details for a single PR. For active PRs (still open against this branch)
+        includes merge eligibility and queue position. For historical PRs fetches from GitHub.
+      tags: [PRs]
+      parameters:
+        - name: branch
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: number
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: PR details retrieved successfully
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ActivePRDetail'
+                  - $ref: '#/components/schemas/HistoricalPRDetail'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Branch or PR not found
+
+  /api/v1alpha/watched_branches/{branch}/prs/{number}/retry:
+    post:
+      summary: Retry PR build
+      description: Requests a CI retry for the PR. Invalidates the current batch and triggers a fresh run.
+      tags: [PRs]
+      parameters:
+        - name: branch
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: number
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Retry requested successfully
+        '400':
+          description: PR has no batch or had a merge failure
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - requires MANAGE_CI
+        '404':
+          description: Branch or PR not found
+
+  /api/v1alpha/namespaces:
+    get:
+      summary: List active namespaces
+      description: Returns all active dev namespaces with their deployed services and rate limits.
+      tags: [Namespaces]
+      responses:
+        '200':
+          description: Namespace list retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/NamespaceInfo'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+
+  /api/v1alpha/namespaces/{namespace}:
+    get:
+      summary: Get a namespace
+      description: Returns the record for a single active namespace.
+      tags: [Namespaces]
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Namespace retrieved successfully
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Namespace not found
+    put:
+      summary: Register a namespace (idempotent)
+      description: >
+        Ensures the namespace exists in active_namespaces. Creates it and returns
+        201 if new; returns 200 if it already existed. Safe to call repeatedly.
+      tags: [Namespaces]
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Namespace already existed
+        '201':
+          description: Namespace registered
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - requires MANAGE_CI
+    delete:
+      summary: Remove a namespace
+      description: Removes the namespace and all its deployed services from the active list.
+      tags: [Namespaces]
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Namespace removed
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - requires MANAGE_CI
+
+  /api/v1alpha/namespaces/{namespace}/services/{service}:
+    get:
+      summary: Get a namespace service
+      description: Returns the record for a single deployed service in a namespace.
+      tags: [Namespaces]
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: service
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Service retrieved successfully
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+        '404':
+          description: Service not found
+    put:
+      summary: Add service to namespace (idempotent)
+      description: >
+        Ensures the service is registered under the namespace. Creates it and
+        returns 201 if new; returns 200 if it already existed.
+      tags: [Namespaces]
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: service
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Service already existed
+        '201':
+          description: Service registered
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - requires MANAGE_CI
+    patch:
+      summary: Update service rate limit
+      description: Sets the rate_limit_rps for a deployed service. Pass null to remove the limit.
+      tags: [Namespaces]
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: service
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                rate_limit_rps:
+                  type: number
+                  nullable: true
+      responses:
+        '200':
+          description: Service updated
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - requires MANAGE_CI
+    delete:
+      summary: Remove a service from a namespace
+      description: Removes the service from the deployed_services table.
+      tags: [Namespaces]
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: service
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Service removed
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - requires MANAGE_CI
+
+  /api/v1alpha/me:
+    get:
+      summary: Current user's CI dashboard data
+      description: >
+        Returns PRs authored by, under review by, and requiring action from the current user,
+        plus their recent dev deploys.
+      tags: [PRs]
+      responses:
+        '200':
+          description: User data retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  hail_username:
+                    type: string
+                  gh_username:
+                    type: string
+                  pr_wbs:
+                    type: array
+                    items:
+                      type: object
+                  review_wbs:
+                    type: array
+                    items:
+                      type: object
+                  actionable_wbs:
+                    type: array
+                    items:
+                      type: object
+                  dev_deploys:
+                    type: array
+                    items:
+                      type: object
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - user is not in AUTHORIZED_USERS
+
+  /api/v1alpha/authorized_shas:
+    get:
+      summary: List authorized SHAs
+      description: Returns the list of SHAs that have been manually authorized for CI.
+      tags: [Builds]
+      responses:
+        '200':
+          description: Authorized SHAs retrieved
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+
+  /api/v1alpha/authorize_sha:
+    post:
+      summary: Authorize a SHA
+      description: Adds a SHA to the authorized_shas table.
+      tags: [Builds]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [sha]
+              properties:
+                sha:
+                  type: string
+      responses:
+        '201':
+          description: SHA authorized
+        '400':
+          description: Missing sha field
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - requires MANAGE_CI
+
+  /api/v1alpha/teams:
+    get:
+      summary: List teams and members
+      description: Returns the full team roster from AUTHORIZED_USERS grouped by team.
+      tags: [PRs]
+      responses:
+        '200':
+          description: Teams retrieved successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/TeamMember'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden
+
+  /api/v1alpha/freeze:
+    post:
+      summary: Freeze merges and deploys
+      description: Freezes all CI merges and deployments. Returns 409 if already frozen.
+      tags: [Deployments]
+      responses:
+        '200':
+          description: CI frozen
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FreezeResponse'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - requires MANAGE_CI
+        '409':
+          description: Already frozen
+
+  /api/v1alpha/unfreeze:
+    post:
+      summary: Unfreeze merges and deploys
+      description: Unfreezes CI merges and deployments. Returns 409 if already unfrozen.
+      tags: [Deployments]
+      responses:
+        '200':
+          description: CI unfrozen
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FreezeResponse'
+        '401':
+          description: Unauthorized
+        '403':
+          description: Forbidden - requires MANAGE_CI
+        '409':
+          description: Already unfrozen

--- a/monitoring/monitoring/templates/openapi.yaml
+++ b/monitoring/monitoring/templates/openapi.yaml
@@ -98,7 +98,7 @@ paths:
     get:
       summary: Get service version
       description: Returns the current version of the monitoring service as plain text. Available to unauthenticated users; sysadmins receive the full version string while others receive only the base version (prefix before the first '-').
-      tags: [Authentication]
+      tags: [Documentation]
       responses:
         '200':
           description: Version string retrieved successfully

--- a/monitoring/monitoring/templates/openapi.yaml
+++ b/monitoring/monitoring/templates/openapi.yaml
@@ -96,16 +96,17 @@ components:
 paths:
   /api/v1alpha/version:
     get:
-      summary: Get version
-      description: Get the current version of the monitoring service
-      tags: [Documentation]
+      summary: Get service version
+      description: Returns the current version of the monitoring service as plain text. Available to unauthenticated users; sysadmins receive the full version string while others receive only the base version (prefix before the first '-').
+      tags: [Authentication]
       responses:
         '200':
-          description: Version retrieved successfully
+          description: Version string retrieved successfully
           content:
             text/plain:
               schema:
                 type: string
+                description: Service version string
   /api/v1alpha/billing:
     get:
       summary: Get billing information


### PR DESCRIPTION
CI-only spin-off of #15514.

## Change Description

Completes the REST api endpoint set as a fully featured way to query the system, fetch data, and mutate state.

Motivation:
1. Allow hailctl (with future hailctl tool implementations, or via the hailctl curl fallback) to access all system state.
2. Allow full investigation of the deployed system state with command line commands and scripts.
3. Allow for local UI development against live APIs for rapid prototyping, development and testing without the current 40m build/deploy/test cycle. 
4. Supporting UI elements that combine data from multiple services (eg comparing actual charged billing data from batch with the cloud billing data in monitoring)

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a medium security impact

### Impact Description

One new functionality:

- Previously a developer could only poll for their own dev_deploys list and PRs assigned to them. We now have a general purpose API that can poll for the same information for them, or any other developer. All still auth'd behind the appropriate `READ_CI` permission.

I'm asserting that there is nothing else new that can be done here, since everything is currently possible via the html pages already. But the permissions on each API should be validated, and the refactors are increasing the surface area of the services even if the functionality is not new.

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
