### PR TITLE
[query] Avoid Materialising Arrays + Structs

### DIFF
--- a/hail/hail/src/is/hail/expr/ir/IR.scala
+++ b/hail/hail/src/is/hail/expr/ir/IR.scala
@@ -142,6 +142,9 @@ class IROps(val ir: IR) extends AnyVal {
   def dropWhile(f: Atom => IR): IR =
     is.hail.expr.ir.dropWhile(ir)(f)
 
+  def enumerate(f: (Atom, Atom) => IR): IR =
+    zip(iota(0, 1), ArrayZipBehavior.TakeMinLength)(f)
+
   def streamFor(f: Atom => IR): IR =
     forIR(ir)(f)
 

--- a/hail/hail/src/is/hail/expr/ir/IRBuilder.scala
+++ b/hail/hail/src/is/hail/expr/ir/IRBuilder.scala
@@ -10,7 +10,9 @@ object IRBuilder {
   def scoped(f: IRBuilder => IR): IR = {
     val builder = new IRBuilder()
     val result = f(builder)
-    Block(builder.getBindings, result)
+    val bindings = builder.getBindings
+    if (bindings.nonEmpty) Block(bindings, result)
+    else result
   }
 }
 

--- a/hail/hail/src/is/hail/expr/ir/Interpret.scala
+++ b/hail/hail/src/is/hail/expr/ir/Interpret.scala
@@ -321,8 +321,17 @@ object Interpret extends Logging {
           null
         else
           aValue.asInstanceOf[IndexedSeq[Any]].length
-      case StreamIota(_, _, _) =>
-        throw new UnsupportedOperationException
+      case StreamIota(start_, step_, _) =>
+        // FIXME: `Stream` != `IndexedSeq`! Perhaps implement with `LazyList`?
+        interpret(start_, env, args) match {
+          case null => null
+          case start: Int =>
+            interpret(step_, env, args) match {
+              case null => null
+              case 0 => throw new UnsupportedOperationException("Iota step cannot be 0")
+              case step: Int => Range(start, if (step < 0) Int.MinValue else Int.MaxValue, step)
+            }
+        }
       case StreamRange(start, stop, step, _, errorID) =>
         val startValue = interpret(start, env, args)
         val stopValue = interpret(stop, env, args)

--- a/hail/hail/src/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/MatrixIR.scala
@@ -295,7 +295,7 @@ class MatrixNativeReader(
       val partFiles =
         colsRVDSpec.absolutePartPaths(spec.colsSpec.rowsComponent.absolutePath(colsPath))
 
-      def readCols(index: IR, path: IR): IR =
+      def readCols(path: IR, index: IR): IR =
         ReadPartition(
           makestruct("partitionIndex" -> index.toL, "partitionPath" -> path),
           requestedType.colType,
@@ -303,14 +303,8 @@ class MatrixNativeReader(
         )
 
       val cols =
-        if (partFiles.length == 1) readCols(0, Str(partFiles.head))
-        else flatten(
-          zip2(
-            iota(0, 1),
-            ToStream(Literal(TArray(TString), partFiles)),
-            ArrayZipBehavior.TakeMinLength,
-          )(readCols(_, _))
-        )
+        if (partFiles.length == 1) readCols(Str(partFiles.head), 0)
+        else flatten(Literal(TArray(TString), partFiles).stream.enumerate(readCols(_, _)))
 
       TableRead(tt, dropRows, trdr).mapGlobals(_.insert(colsFieldName -> ToArray(cols)))
     }

--- a/hail/hail/src/is/hail/expr/ir/TableIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableIR.scala
@@ -246,8 +246,9 @@ object LoweredTableReader extends Logging {
           )((context, _) => scanBody(context))
 
         sortedPartData <-
-          rangeIR(scanResult.len)
-            .streamMap(i => scanResult.at(i).insert("__idx" -> i))
+          scanResult
+            .stream
+            .enumerate((elem, i) => elem.insert("__idx" -> i))
             .filter(_.get("__min_key").len > 0)
             .streamMap(_.update("__min_key")(_.at(0)).update("__max_key")(_.at(0)))
             .sort((l, r) => l.select("__min_key", "__max_key") < r.select("__min_key", "__max_key"))

--- a/hail/hail/src/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/hail/src/is/hail/expr/ir/TypeCheck.scala
@@ -13,7 +13,7 @@ import is.hail.utils.StackSafe._
 import scala.collection.compat._
 import scala.reflect.ClassTag
 
-object TypeCheck {
+object TypeCheck extends Logging {
   def apply(ctx: ExecuteContext, ir: BaseIR): Unit =
     apply(ctx, ir, BindingEnv.empty)
 
@@ -23,10 +23,11 @@ object TypeCheck {
         check(ctx, ir, env).run()
       catch {
         case e: Throwable =>
-          fatal(
-            s"Error while typechecking IR:\n${Pretty(ctx, ir, preserveNames = true, allowUnboundRefs = true)}",
+          logger.fatal(
+            s"Error while typechecking IR: ${Pretty(ctx, ir, allowUnboundRefs = true)}",
             e,
           )
+          throw e
       }
     }
 
@@ -556,7 +557,10 @@ object TypeCheck {
             !t.colType.hasField(MatrixReader.colUIDFieldName),
           t,
         )
-        assert(children.forall(_.typ == t))
+        assert(
+          children.forall(_.typ == t),
+          "MatrixMultiWrite requires MatrixTable inputs of the same type",
+        )
       case x @ TableAggregate(_, query) =>
         assert(x.typ == query.typ)
       case x @ MatrixAggregate(_, query) =>

--- a/hail/hail/src/is/hail/expr/ir/functions/ArrayFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/ArrayFunctions.scala
@@ -171,16 +171,16 @@ object ArrayFunctions extends RegistryFunctions {
       }
     }
 
-    def argF(a: Atom, op: ComparisonOp[Boolean], errorID: Int): IR = {
+    def argF(a: Atom, op: ComparisonOp[Boolean]): IR = {
       val t = tcoerce[TArray](a.typ).elementType
       val tAccum = TTuple(t, TInt32)
 
       GetTupleElement(
-        foldIR(rangeIR(a.len), NA(tAccum)) { (accum, idx) =>
-          bindIRs(ArrayRef(a, idx, errorID), accum.get(0)) { case Seq(value, m) =>
+        foldIR(a.stream.zipWithIndex, NA(tAccum)) { (accum, elem) =>
+          bindIRs(elem.get("elt"), accum.get(0)) { case Seq(value, m) =>
             If(
               !IsNA(value) && (IsNA(m) || ApplyComparisonOp(op, value, m)),
-              maketuple(value, idx),
+              maketuple(value, elem.get("idx")),
               accum,
             )
           }
@@ -189,9 +189,9 @@ object ArrayFunctions extends RegistryFunctions {
       )
     }
 
-    registerIR1("argmin", TArray(tv("T")), TInt32)((_, a, errorID) => argF(a, LT, errorID))
+    registerIR1("argmin", TArray(tv("T")), TInt32)((_, a, _) => argF(a, LT))
 
-    registerIR1("argmax", TArray(tv("T")), TInt32)((_, a, errorID) => argF(a, GT, errorID))
+    registerIR1("argmax", TArray(tv("T")), TInt32)((_, a, _) => argF(a, GT))
 
     def uniqueIndex(a: Atom, op: ComparisonOp[Boolean], errorID: Int): IR = {
       val t = elementType(a.typ)

--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerMatrixIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerMatrixIR.scala
@@ -9,6 +9,7 @@ import is.hail.expr.ir.{Memoized => M, _}
 import is.hail.expr.ir.MatrixIR.{colName, entryName, globalName, rowName}
 import is.hail.expr.ir.Scope._
 import is.hail.expr.ir.defs._
+import is.hail.expr.ir.defs.ArrayZipBehavior._
 import is.hail.expr.ir.functions.{WrappedMatrixToTableFunction, WrappedMatrixToValueFunction}
 import is.hail.types.virtual._
 import is.hail.utils._
@@ -209,14 +210,12 @@ object LowerMatrixIR extends Logging {
 
       case MatrixAnnotateColsTable(child, table, root) =>
         lower(ctx, child, liftedRelationalLets).mapGlobals { global =>
-          bindIR(lower(ctx, table, liftedRelationalLets).collectAsDict) { annotations =>
+          lower(ctx, table, liftedRelationalLets).collectAsDict.bind { annotations =>
             global.update(colsFieldName) { cols =>
               mapArray(cols) { col =>
                 val key =
-                  MakeStruct(
-                    table.typ.key.zip(child.typ.colKey).map { case (tk, mck) =>
-                      tk -> col.get(mck)
-                    }
+                  col.select(child.typ.colKey).rename(
+                    _.rename(child.typ.colKey.zip(table.typ.key).toMap)
                   )
 
                 col.insert(root -> annotations.invoke("get", table.typ.valueType, key))
@@ -359,15 +358,19 @@ object LowerMatrixIR extends Logging {
 
               newRow <-
                 if (!ContainsAgg(body)) body
-                else rangeIR(entries.len).filter(!entries.at(_).isNA).streamAgg { i =>
-                  M.agg {
-                    M.sequence(
-                      colName -> cols.at(i),
-                      entryName -> entries.at(i),
-                      body,
-                    )
+                else cols
+                  .stream
+                  .zip(entries.stream)((c, e) => maybeIR(e)(maketuple(c, _)))
+                  .filter(!_.isNA)
+                  .streamAgg { elem =>
+                    M.agg {
+                      M.sequence(
+                        colName -> elem.get(0),
+                        entryName -> elem.get(1),
+                        body,
+                      )
+                    }
                   }
-                }
 
             } yield newRow.insert(entriesFieldName -> entries)
           }
@@ -536,7 +539,7 @@ object LowerMatrixIR extends Logging {
                                 _ <- colName -> aggCols.at(elem)
                                 g <- entryName -> entries.at(elem)
                                 _ <- M.lift[EVAL.type]((colName -> cols.at(idx)) >> M.unit)
-                              } yield AggFilter(!g.isNA, bindingsToStruct(aggs), false)
+                              } yield AggFilter(!g.isNA, bindingsToStruct(aggs), isScan = false)
                             }
                           },
                       )
@@ -595,18 +598,18 @@ object LowerMatrixIR extends Logging {
               _ <- setupOuterAggContext
               _ <- setupOuterScanContext
             } yield global.insert(
-              colsFieldName -> ToArray(StreamMap(
-                rangeIR(cols.len),
-                colIdx.name,
-                M.eval {
-                  M.sequence(
-                    colName -> cols.at(colIdx),
-                    setupInnerAggContext,
-                    setupInnerScanContext,
-                    b0,
-                  )
-                },
-              ))
+              colsFieldName ->
+                ToArray(cols.stream.enumerate { (col, idx) =>
+                  M.eval {
+                    M.sequence(
+                      colName -> col,
+                      colIdx.name -> idx,
+                      setupInnerAggContext,
+                      setupInnerScanContext,
+                      b0,
+                    )
+                  }
+                })
             )
           }
         }
@@ -623,11 +626,11 @@ object LowerMatrixIR extends Logging {
               _ <- rowName -> row.select(mtype.rowType.fieldNames)
             } yield row.insert(
               entriesFieldName ->
-                ToArray(rangeIR(cols.len).streamMap { i =>
+                ToArray(cols.stream.zip(entries.stream) { (col, entry) =>
                   M.eval {
                     for {
-                      _ <- colName -> cols.at(i)
-                      g <- entryName -> entries.at(i)
+                      _ <- colName -> col
+                      g <- entryName -> entry
                     } yield If(lower(ctx, pred, liftedRelationalLets), g, NA(mtype.entryType))
                   }
                 })
@@ -652,7 +655,7 @@ object LowerMatrixIR extends Logging {
                   def handleMissingEntriesArray(entries: String, cols: String): IR =
                     if (joinType == "inner") row.get(entries)
                     else row.get(entries).orElse {
-                      ToArray(rangeIR(global.get(cols).len).streamMap { _ =>
+                      ToArray(global.get(cols).stream.streamMap { _ =>
                         MakeStruct(right.typ.entryType.fields.map(f => f.name -> NA(f.typ)))
                       })
                     }
@@ -685,7 +688,7 @@ object LowerMatrixIR extends Logging {
                   FastSeq(ToStream(cols), ToStream(entries)),
                   FastSeq(colName, entryName),
                   lower(ctx, newEntries, liftedRelationalLets),
-                  ArrayZipBehavior.AssumeSameLength,
+                  AssumeSameLength,
                 ))
             )
           }
@@ -756,9 +759,11 @@ object LowerMatrixIR extends Logging {
                 lengths <- global.get("__lengths")
               } yield row.insert(
                 entriesFieldName ->
-                  ToArray(rangeIR(entries.len).streamFlatMap { idx =>
-                    rangeIR(lengths.at(idx)).streamMap(_ => entries.at(idx))
-                  })
+                  entries
+                    .stream
+                    .zip(lengths.stream)((entry, n) => rangeIR(n).streamMap(_ => entry))
+                    .streamFlatten
+                    .toArray
               )
             }
           }
@@ -800,8 +805,10 @@ object LowerMatrixIR extends Logging {
             bindIR(global.get(colsFieldName)) { cols =>
               global.insert(
                 "__new_col_idx" ->
-                  rangeIR(cols.len)
-                    .streamMap(i => maketuple(cols.at(i).select(child.typ.colKey), i))
+                  cols
+                    .stream
+                    .streamMap(_.select(child.typ.colKey))
+                    .zipWithIndex
                     .groupByKey
                     .stream
                     .toArray
@@ -812,7 +819,7 @@ object LowerMatrixIR extends Logging {
             row.update(entriesFieldName) { entries =>
               mapArray(global.get("__new_col_idx")) { kv =>
                 MakeStruct(child.typ.entryType.fieldNames.map { f =>
-                  f -> mapArray(kv.get("value"))(i => entries.at(i).get(f))
+                  f -> mapArray(kv.get("value"))(entries.at(_).get(f))
                 })
               }
             }
@@ -823,7 +830,7 @@ object LowerMatrixIR extends Logging {
                 InsertFields(
                   kv.get("key"),
                   child.typ.colValueStruct.fieldNames.map { f =>
-                    f -> mapArray(kv.get("value"))(i => cols.at(i).get(f))
+                    f -> mapArray(kv.get("value"))(cols.at(_).get(f))
                   },
                 )
               }
@@ -842,8 +849,10 @@ object LowerMatrixIR extends Logging {
             bindIR(global.get(colsFieldName)) { cols =>
               global.insert(
                 "__key_map" ->
-                  rangeIR(cols.len)
-                    .streamMap(idx => maketuple(cols.at(idx).select(child.typ.colKey), idx))
+                  cols
+                    .stream
+                    .streamMap(_.select(child.typ.colKey))
+                    .zipWithIndex
                     .groupByKey
                     .stream
                     .toArray
@@ -859,8 +868,8 @@ object LowerMatrixIR extends Logging {
                 entries <- row.get(entriesFieldName)
                 _ <- globalName -> global.select(child.typ.globalType.fieldNames)
                 _ <- rowName -> row.select(child.typ.rowType.fieldNames)
-                newEntries <- ToArray(rangeIR(keyMap.len).streamMap { idx =>
-                  keyMap.at(idx).get("value").stream.streamAgg { aggIdx =>
+                newEntries <- mapArray(keyMap) { kv =>
+                  kv.get("value").stream.streamAgg { aggIdx =>
                     M.agg {
                       for {
                         _ <- colName -> cols.at(aggIdx)
@@ -869,7 +878,7 @@ object LowerMatrixIR extends Logging {
                       } yield AggFilter(!g.isNA, aggEntries, isScan = false)
                     }
                   }
-                })
+                }
               } yield row.insert(entriesFieldName -> newEntries)
             }
           }
@@ -880,23 +889,20 @@ object LowerMatrixIR extends Logging {
                 keyMap <- global.get("__key_map")
                 global <- Name("__global_matrix_aggregate_cols_by_key") -> global
                 _ <- globalName -> global.select(child.typ.globalType.fieldNames)
-                newCols <- ToArray(rangeIR(keyMap.len)
-                  .streamMap { idx =>
-                    M.eval {
-                      for {
-                        elem <- keyMap.at(idx)
-                        key <- elem.get("key")
-                        value <- elem.get("value").stream.streamAgg { aggIdx =>
-                          M.agg {
-                            (colName -> cols.at(aggIdx)) >>
-                              lower(ctx, colExpr, liftedRelationalLets)
-                          }
-                        }
-                      } yield key.insert(
-                        value.typ.asInstanceOf[TStruct].fieldNames.map(f => f -> value.get(f))
-                      )
+                newCols <- ToArray(keyMap.stream.streamMap { elem =>
+                  val aggValue =
+                    elem.get("value").stream.streamAgg { aggIdx =>
+                      M.agg {
+                        (colName -> cols.at(aggIdx)) >> lower(ctx, colExpr, liftedRelationalLets)
+                      }
                     }
-                  })
+
+                  aggValue.bind { value =>
+                    elem.get("key").insert(
+                      value.typ.asInstanceOf[TStruct].fieldNames.map(f => f -> value.get(f))
+                    )
+                  }
+                })
               } yield global.insert(colsFieldName -> newCols).drop("__key_map")
             }
           }
@@ -906,8 +912,14 @@ object LowerMatrixIR extends Logging {
 
     if (!mir.typ.isCompatibleWith(lowered.typ))
       throw new RuntimeException(
-        s"Lowering changed type:\n  BEFORE: ${Pretty(ctx, mir)}\n    ${mir.typ}\n    ${mir.typ.canonicalTableType}\n  AFTER: ${Pretty(ctx, lowered)}\n    ${lowered.typ}"
+        s"Lowering changed type:" +
+          s"\n  BEFORE: ${Pretty(ctx, mir).strip}" +
+          s"\n    ${mir.typ}" +
+          s"\n    ${mir.typ.canonicalTableType}" +
+          s"\n  AFTER: ${Pretty(ctx, lowered).strip}" +
+          s"\n    ${lowered.typ}"
       )
+
     lowered
   }
 
@@ -928,11 +940,13 @@ object LowerMatrixIR extends Logging {
               bindIR(global.get(colsFieldName)) { cols =>
                 global.insert(
                   "__old_col_idx" ->
-                    rangeIR(cols.len)
-                      .streamMap(idx => maketuple(cols.at(idx).select(child.typ.colKey), idx))
+                    cols
+                      .stream
+                      .streamMap(_.select(child.typ.colKey))
+                      .zipWithIndex
                       .sort(ascending = true, onKey = true)
                       .stream
-                      .streamMap(_.get(1))
+                      .streamMap(_.get("idx"))
                       .toArray
                 )
               }
@@ -944,19 +958,33 @@ object LowerMatrixIR extends Logging {
               )
             }
             .mapRows { (global, row) =>
-              bindIR(global.get(colsFieldName)) { cols =>
+              bindIRs(global.get(colsFieldName), row.get("__values")) { case Seq(cols, values) =>
                 row.drop("__values").insert(
                   "__explode" ->
                     ToArray(global.get("__old_col_idx").stream.streamFlatMap { oldColIndex =>
                       bindIR(cols.at(oldColIndex)) { col =>
-                        row.get("__values").stream.streamFlatMap { v =>
+                        values.stream.streamFlatMap { v =>
                           bindIR(v.get(entriesFieldName).at(oldColIndex)) { entry =>
+                            val typ = child.typ
+                            val rfields = typ.rowValueStruct.fieldNames.map(f => f -> v.get(f))
+                            val cfields = typ.colType.fieldNames.map(f => f -> col.get(f))
+                            val efields = typ.entryType.fieldNames.map(f => f -> entry.get(f))
+
+                            val ordering =
+                              typ.rowValueStruct.fieldNames ++
+                                typ.colType.fieldNames ++
+                                typ.entryType.fieldNames
+
+                            val Rs = rfields.length
+                            val Cs = cfields.length
+                            val max = math.max(math.max(Rs, Cs), efields.length)
+
                             val newRow =
-                              MakeStruct(
-                                child.typ.rowValueStruct.fieldNames.map(f => f -> v.get(f)) ++
-                                  child.typ.colType.fieldNames.map(f => f -> col.get(f)) ++
-                                  child.typ.entryType.fieldNames.map(f => f -> entry.get(f))
-                              )
+                              if (max == Rs) v
+                                .select(typ.rowValueStruct.fieldNames)
+                                .insert(cfields ++ efields, Some(ordering))
+                              else if (max == Cs) col.insert(rfields ++ efields, Some(ordering))
+                              else entry.insert(rfields ++ cfields, Some(ordering))
 
                             If(IsNA(entry), MakeStream.empty(newRow.typ), MakeStream(newRow))
                           }
@@ -968,10 +996,22 @@ object LowerMatrixIR extends Logging {
             }
             .explode("__explode")
             .mapRows { (_, row) =>
-              bindIR(row.get("__explode")) { exploded =>
-                MakeStruct(x.typ.rowType.fieldNames.map { f =>
-                  f -> (if (child.typ.rowKey.contains(f)) row.get(f) else exploded.get(f))
-                })
+              row.get("__explode").bind { exploded =>
+                val fields = x.typ.rowType.fieldNames
+
+                val (rowNames, explodedNames) =
+                  fields.partition(child.typ.rowKey.contains)
+
+                if (rowNames.length > explodedNames.length)
+                  row.select(rowNames).insert(
+                    explodedNames.map(f => f -> exploded.get(f)),
+                    Some(fields),
+                  )
+                else
+                  exploded.select(explodedNames).insert(
+                    rowNames.map(f => f -> row.get(f)),
+                    Some(fields),
+                  )
               }
             }
             .mapGlobals(_.drop(colsFieldName, "__old_col_idx"))
@@ -1105,19 +1145,15 @@ object LowerMatrixIR extends Logging {
                 (globalName -> global.select(child.typ.globalType.fieldNames)) >>
                   M.unit
               }
-            } yield zip2(
-              ToStream(cols),
-              ToStream(entries),
-              ArrayZipBehavior.AssertSameLength,
-            ) {
-              (c, e) => maybeIR(e)(e => maketuple(c, e))
-            }
+            } yield cols
+              .stream
+              .zip(entries.stream)((c, e) => maybeIR(e)(e => maketuple(c, e)))
               .filter(!_.isNA)
               .aggExplode { explodedTuple =>
                 M.agg {
                   M.sequence(
-                    colName -> GetTupleElement(explodedTuple, 0),
-                    entryName -> GetTupleElement(explodedTuple, 1),
+                    colName -> explodedTuple.get(0),
+                    entryName -> explodedTuple.get(1),
                     query,
                   )
                 }
@@ -1134,6 +1170,9 @@ object LowerMatrixIR extends Logging {
   private def assertTypeUnchanged(original: BaseIR, lowered: BaseIR): Unit =
     if (lowered.typ != original.typ)
       fatal(
-        s"lowering changed type:\n  before: ${original.typ}\n after: ${lowered.typ}\n  ${original.getClass.getName} => ${lowered.getClass.getName}"
+        s"lowering changed type:" +
+          s"\n  before: ${original.typ}" +
+          s"\n  after: ${lowered.typ}" +
+          s"\n  ${original.getClass.getName} => ${lowered.getClass.getName}"
       )
 }

--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -125,7 +125,7 @@ class TableStage(
   val globals: Atom,
   val partitioner: RVDPartitioner,
   val dependency: TableStageDependency,
-  val contexts: IR,
+  val contexts: IR, // elements are required
   val ctxRefName: Name,
   val partitionIR: IR,
 ) extends Logging {
@@ -1437,7 +1437,7 @@ object LowerTableIR extends Logging {
                               aggsArray
                                 .stream
                                 .grouped(branchFactor)
-                                .zip(iota(0, 1), ArrayZipBehavior.TakeMinLength) { (group, idx) =>
+                                .enumerate { (group, idx) =>
                                   makestruct(
                                     "prev" -> last.at(idx),
                                     "partialSums" -> group.toArray,
@@ -1789,15 +1789,13 @@ object LowerTableIR extends Logging {
                   }
             ),
           contexts =
-            flatten(zip2(lc.contexts, iota(0, 1), ArrayZipBehavior.TakeMinLength) {
-              (elt, idx) =>
+            lc
+              .contexts
+              .enumerate { (elt, idx) =>
                 val `contains?` = invoke("contains", TBoolean, keepSetRef, idx)
-                If(
-                  if (keep) `contains?` else !`contains?`,
-                  MakeStream(elt),
-                  MakeStream.empty(elt.typ),
-                )
-            }),
+                If(if (keep) `contains?` else !`contains?`, elt, NA(elt.typ))
+              }
+              .filter(!_.isNA),
         )
 
       case TableToTableApply(

--- a/hail/hail/test/src/is/hail/expr/ir/MatrixIRSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/MatrixIRSuite.scala
@@ -422,11 +422,11 @@ class MatrixIRSuite {
     val range = rangeMatrix(10, 2, None)
     val path1 = ctx.createTmpPath("test1")
     val path2 = ctx.createTmpPath("test2")
-    intercept[HailException] {
+    interceptException[Throwable]("of the same type") {
       TypeCheck(
         ctx,
         MatrixMultiWrite(FastSeq(vcf, range), MatrixNativeMultiWriter(IndexedSeq(path1, path2))),
       )
-    }: Unit
+    }
   }
 }

--- a/hail/hail/test/src/is/hail/expr/ir/TableIRSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/TableIRSuite.scala
@@ -1565,13 +1565,12 @@ class TableIRSuite {
       ),
     )
 
-    val e = intercept[HailException](TypeCheck(
-      ctx,
-      collect(mapPartitions(table)((_, part) => flatMapIR(StreamRange(0, 2, 1))(_ => part))),
-    ))
-    assert(
-      "must iterate over the partition exactly once".r.findFirstIn(e.getCause.getMessage).isDefined
-    )
+    interceptException[Throwable]("must iterate over the partition exactly once") {
+      TypeCheck(
+        ctx,
+        mapPartitions(table)((_, part) => flatMapIR(StreamRange(0, 2, 1))(_ => part)).collect,
+      )
+    }
   }
 
   @Test def testRepartitionCostEstimate(implicit ctx: ExecuteContext): Unit = {

--- a/hail/hail/test/src/is/hail/expr/ir/table/TableGenSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/table/TableGenSuite.scala
@@ -37,7 +37,7 @@ class TableGenSuite {
 
   @Test
   def testWithInvalidGlobalsType(implicit ctx: ExecuteContext): Unit = {
-    val ex = intercept[HailException] {
+    val msg = intercept[Throwable] {
       TypeCheck(
         ctx,
         mkTableGen(
@@ -45,62 +45,58 @@ class TableGenSuite {
           body = Some((_, _) => MakeStream(IndexedSeq(), TStream(TStruct()))),
         ),
       )
-    }
-    ex.getCause.getMessage should include("globals")
-    ex.getCause.getMessage should include(s"Expected: ${classOf[TStruct].getName}")
-    ex.getCause.getMessage should include(s"Actual: ${TString.getClass.getName}")
+    }.getMessage
+    msg should include("globals")
+    msg should include(s"Expected: ${classOf[TStruct].getName}")
+    msg should include(s"Actual: ${TString.getClass.getName}")
   }
 
   @Test
   def testWithInvalidBodyType(implicit ctx: ExecuteContext): Unit = {
-    val ex = intercept[HailException] {
+    val msg = intercept[Throwable] {
       TypeCheck(ctx, mkTableGen(body = Some((_, _) => Str("oh noes :'("))))
-    }
-    ex.getCause.getMessage should include("body")
-    ex.getCause.getMessage should include(s"Expected: ${classOf[TStream].getName}")
-    ex.getCause.getMessage should include(s"Actual: ${TString.getClass.getName}")
+    }.getMessage
+    msg should include("body")
+    msg should include(s"Expected: ${classOf[TStream].getName}")
+    msg should include(s"Actual: ${TString.getClass.getName}")
   }
 
   @Test
   def testWithInvalidBodyElementType(implicit ctx: ExecuteContext): Unit = {
-    val ex = intercept[HailException] {
+    val msg = intercept[Throwable] {
       TypeCheck(
         ctx,
         mkTableGen(body =
           Some((_, _) => MakeStream(IndexedSeq(Str("oh noes :'(")), TStream(TString)))
         ),
       )
-    }
-    ex.getCause.getMessage should include("body.elementType")
-    ex.getCause.getMessage should include(s"Expected: ${classOf[TStruct].getName}")
-    ex.getCause.getMessage should include(s"Actual: ${TString.getClass.getName}")
+    }.getMessage
+    msg should include("body.elementType")
+    msg should include(s"Expected: ${classOf[TStruct].getName}")
+    msg should include(s"Actual: ${TString.getClass.getName}")
   }
 
   @Test
-  def testWithInvalidPartitionerKeyType(implicit ctx: ExecuteContext): Unit = {
-    val ex = intercept[HailException] {
+  def testWithInvalidPartitionerKeyType(implicit ctx: ExecuteContext): Unit =
+    intercept[Throwable] {
       TypeCheck(
         ctx,
         mkTableGen(partitioner =
           Some(RVDPartitioner.empty(ctx.stateManager, TStruct("does-not-exist" -> TInt32)))
         ),
       )
-    }
-    ex.getCause.getMessage should include("partitioner")
-  }
+    }.getMessage should include("partitioner")
 
   @Test
-  def testWithTooLongPartitionerKeyType(implicit ctx: ExecuteContext): Unit = {
-    val ex = intercept[HailException] {
+  def testWithTooLongPartitionerKeyType(implicit ctx: ExecuteContext): Unit =
+    intercept[Throwable] {
       TypeCheck(
         ctx,
         mkTableGen(partitioner =
           Some(RVDPartitioner.empty(ctx.stateManager, TStruct("does-not-exist" -> TInt32)))
         ),
       )
-    }
-    ex.getCause.getMessage should include("partitioner")
-  }
+    }.getMessage should include("partitioner")
 
   @Test
   def testRequiredness(implicit ctx: ExecuteContext): Unit = {

--- a/hail/python/test/hail/table/test_table.py
+++ b/hail/python/test/hail/table/test_table.py
@@ -2114,41 +2114,33 @@ def test_grouped_flatmap_streams():
     ht._force_count()
 
 
-def make_test(table_name: str, num_parts: int, counter: str, truncator, n: int):
-    # NOTE: we cannot use Hail during test parameter initialization
-    def test():
-        if table_name == 'rt':
-            table = hl.utils.range_table(10, n_partitions=num_parts)
-        elif table_name == 'par':
-            table = hl.Table.parallelize(
-                [hl.Struct(x=x) for x in range(10)], schema='struct{x: int32}', n_partitions=num_parts
-            )
-        elif table_name == 'rtcache':
-            table = hl.utils.range_table(10, n_partitions=num_parts).cache()
-        else:
-            assert table_name == 'chkpt'
-            table = hl.utils.range_table(10, n_partitions=num_parts).checkpoint(new_temp_file(extension='ht'))
-        assert counter(truncator(table, n)) == min(10, n)
-
-    return test
-
-
-head_tail_test_data = [
-    pytest.param(
-        make_test(table_name, num_parts, counter, truncator, n),
-        id='__'.join([table_name, str(num_parts), str(n), truncator_name, counter_name]),
-    )
+head_tail_test_ids = [
+    (table_name, num_parts, n, truncator_name, counter_name)
     for table_name in ['rt', 'par', 'rtcache', 'chkpt']
     for num_parts in [3, 11]
     for n in (10, 9, 11, 0, 7)
-    for truncator_name, truncator in (('head', hl.Table.head), ('tail', hl.Table.tail))
-    for counter_name, counter in (('count', hl.Table.count), ('_force_count', hl.Table._force_count))
+    for truncator_name in ('head', 'tail')
+    for counter_name in ('count', '_force_count')
 ]
 
 
-@pytest.mark.parametrize("test", head_tail_test_data)
-def test_table_head_and_tail(test):
-    test()
+@pytest.mark.parametrize('table_name,num_parts,n,truncator_name,counter_name', head_tail_test_ids)
+def test_table_head_and_tail(table_name, num_parts, n, truncator_name, counter_name):
+    if table_name == 'rt':
+        table = hl.utils.range_table(10, n_partitions=num_parts)
+    elif table_name == 'par':
+        table = hl.Table.parallelize(
+            [hl.Struct(x=x) for x in range(10)], schema='struct{x: int32}', n_partitions=num_parts
+        )
+    elif table_name == 'rtcache':
+        table = hl.utils.range_table(10, n_partitions=num_parts).cache()
+    else:
+        assert table_name == 'chkpt'
+        table = hl.utils.range_table(10, n_partitions=num_parts).checkpoint(new_temp_file(extension='ht'))
+
+    truncator = getattr(hl.Table, truncator_name)
+    counter = getattr(hl.Table, counter_name)
+    assert counter(truncator(table, n)) == min(10, n)
 
 
 def test_to_pandas():


### PR DESCRIPTION
I noticed while running gnomad workflows that `ArrayLen` was forcing entry array materilisation. Futhermore, we were doing lots of packing and unpacking of structs.

I changed some of the lowerings:
- that use `rangeIR(array.len)` to just `array.stream.streamMap`. This helps prevent materialisation.

- getfield + makestruct calls to use selectfields + insertfields to pervent materialising structs and doing lots of work to extract fields only to make a struct with them again.

This change does not affect the broad-managed batch service in gcp. 