### PR TITLE
[query] Remove `stageLocally`

### DIFF
--- a/hail/hail/ir-gen/src/Main.scala
+++ b/hail/hail/ir-gen/src/Main.scala
@@ -1189,7 +1189,6 @@ object Main {
       in("value", child),
       in("path", child),
       in("writer", att("ValueWriter")),
-      in("stagingFile", child.?).withDefault("None"),
     )
 
     r.result()

--- a/hail/hail/src/is/hail/expr/ir/BlockMatrixWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/BlockMatrixWriter.scala
@@ -55,12 +55,11 @@ case class BlockMatrixNativeWriter(
   path: String,
   overwrite: Boolean,
   forceRowMajor: Boolean,
-  stageLocally: Boolean,
 ) extends BlockMatrixWriter {
   override def pathOpt: Option[String] = Some(path)
 
   override def apply(ctx: ExecuteContext, bm: BlockMatrix): Unit =
-    bm.write(ctx, path, overwrite, forceRowMajor, stageLocally)
+    bm.write(ctx, path, overwrite, forceRowMajor)
 
   override def loweredTyp: Type = TVoid
 
@@ -81,23 +80,17 @@ case class BlockMatrixNativeWriter(
     val paths = s.collectBlocks(evalCtx, "block_matrix_native_writer") { (_, idx, block) =>
       val suffix = strConcat("parts/part-", idx, UUID4())
       val filepath = strConcat(s"$path/", suffix)
-      WriteValue(
-        block,
-        filepath,
-        writer,
-        if (stageLocally) Some(strConcat(s"${ctx.localTmpdir}/", suffix)) else None,
-      )
+      WriteValue(block, filepath, writer)
     }
     RelationalWriter.scoped(path, overwrite, None)(WriteMetadata(
       paths,
-      BlockMatrixNativeMetadataWriter(path, stageLocally, s.typ),
+      BlockMatrixNativeMetadataWriter(path, s.typ),
     ))
   }
 }
 
 case class BlockMatrixNativeMetadataWriter(
   path: String,
-  stageLocally: Boolean,
   typ: BlockMatrixType,
 ) extends MetadataWriter with Logging {
 

--- a/hail/hail/src/is/hail/expr/ir/Emit.scala
+++ b/hail/hail/src/is/hail/expr/ir/Emit.scala
@@ -2995,21 +2995,12 @@ class Emit[C](val ctx: EmitContext, val cb: EmitClassBuilder[C]) {
           decoded
         }
 
-      case WriteValue(value, path, writer, stagingFile) =>
+      case WriteValue(value, path, writer) =>
         emitI(path).flatMap(cb) { case pv: SStringValue =>
           emitI(value).map(cb) { v =>
-            val s = stagingFile.map(emitI(_).getOrAssert(cb).asString)
-            val os = cb.memoize(mb.createUnbuffered(s.getOrElse(pv).loadString(cb)))
+            val os = cb.memoize(mb.createUnbuffered(pv.loadString(cb)))
             writer.writeValue(cb, v, os)
             cb += os.invoke[Unit]("close")
-            s.foreach { stage =>
-              cb += mb.getFS.invoke[String, String, Boolean, Unit](
-                "copy",
-                stage.loadString(cb),
-                pv.loadString(cb),
-                const(true),
-              )
-            }
             pv
           }
         }

--- a/hail/hail/src/is/hail/expr/ir/MatrixValue.scala
+++ b/hail/hail/src/is/hail/expr/ir/MatrixValue.scala
@@ -329,7 +329,6 @@ object MatrixValue {
     mvs: IndexedSeq[MatrixValue],
     paths: IndexedSeq[String],
     overwrite: Boolean,
-    stageLocally: Boolean,
     bufferSpec: BufferSpec,
   ): Unit = {
     val first = mvs.head
@@ -348,7 +347,7 @@ object MatrixValue {
       fs.mkDir(path)
     }
 
-    val fileData = RVD.writeRowsSplitFiles(ctx, mvs.map(_.rvd), paths, bufferSpec, stageLocally)
+    val fileData = RVD.writeRowsSplitFiles(ctx, mvs.map(_.rvd), paths, bufferSpec)
     (mvs lazyZip paths lazyZip fileData).foreach { case (mv, path, fd) =>
       mv.finalizeWrite(ctx, path, bufferSpec, fd, consoleInfo = false)
     }

--- a/hail/hail/src/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/MatrixWriter.scala
@@ -35,8 +35,6 @@ import is.hail.utils.implicits.ByteTrackingOutputStream
 import is.hail.variant.{Call, ReferenceGenome}
 
 import java.io.{InputStream, OutputStream}
-import java.nio.file.{FileSystems, Path}
-import java.util.UUID
 
 import org.json4s.{DefaultFormats, Formats, ShortTypeHints}
 import org.json4s.jackson.JsonMethods
@@ -101,7 +99,6 @@ object MatrixNativeWriter {
     r: RTable,
     path: String,
     overwrite: Boolean = false,
-    stageLocally: Boolean = false,
     codecSpecJSONStr: String = null,
     partitions: String = null,
     partitionsTypeStr: String = null,
@@ -150,9 +147,6 @@ object MatrixNativeWriter {
       s"$path/entries/rows/parts/",
       pKey.virtualType.fieldNames,
       Some(s"$path/index/" -> pKey),
-      if (stageLocally)
-        Some(FileSystems.getDefault.getPath(ctx.localTmpdir, s"hail_stage_tmp_${UUID.randomUUID}"))
-      else None,
     )
 
     new MatrixWriterComponents {
@@ -200,20 +194,19 @@ object MatrixNativeWriter {
                 FastSeq(),
                 s"$path/globals/globals/parts/",
                 None,
-                None,
               ),
             )
 
             colInfo <- WritePartition(
               ToStream(GetField(globals, colsFieldName)),
               partFile,
-              PartitionNativeWriter(colSpec, FastSeq(), s"$path/cols/rows/parts/", None, None),
+              PartitionNativeWriter(colSpec, FastSeq(), s"$path/cols/rows/parts/", None),
             )
 
             writeGlobals <- WritePartition(
               MakeStream(SelectFields(globals, tm.globalType.fieldNames)),
               partFile,
-              PartitionNativeWriter(globalSpec, FastSeq(), s"$path/globals/rows/parts/", None, None),
+              PartitionNativeWriter(globalSpec, FastSeq(), s"$path/globals/rows/parts/", None),
             )
 
             _ <- WriteMetadata(
@@ -351,7 +344,6 @@ object MatrixNativeWriter {
 case class MatrixNativeWriter(
   path: String,
   overwrite: Boolean = false,
-  stageLocally: Boolean = false,
   codecSpecJSONStr: String = null,
   partitions: String = null,
   partitionsTypeStr: String = null,
@@ -368,7 +360,7 @@ case class MatrixNativeWriter(
 
     val components = MatrixNativeWriter.generateComponentFunctions(
       colsFieldName, entriesFieldName, colKey, ctx, tablestage, r,
-      path, overwrite, stageLocally, codecSpecJSONStr, partitions, partitionsTypeStr)
+      path, overwrite, codecSpecJSONStr, partitions, partitionsTypeStr)
 
     Begin(FastSeq(
       components.setup,
@@ -386,7 +378,6 @@ case class SplitPartitionNativeWriter(
   partPrefix2: String,
   keyFieldNames: IndexedSeq[String],
   index: Option[(String, PStruct)],
-  stageFolder: Option[Path],
 ) extends PartitionWriter {
 
   val keyType = spec1.encodedVirtualType.asInstanceOf[TStruct].select(keyFieldNames)._1
@@ -442,7 +433,7 @@ case class SplitPartitionNativeWriter(
 
     context.toI(cb).map(cb) { pctx =>
       val ctxValue = pctx.asString.loadString(cb)
-      val (filenames, stages, buffers) =
+      val buffers =
         FastSeq(partPrefix1, partPrefix2)
           .map(const)
           .zipWithIndex
@@ -450,26 +441,19 @@ case class SplitPartitionNativeWriter(
             val filename = mb.newLocal[String](s"filename$i")
             cb.assign(filename, prefix.concat(ctxValue))
 
-            val stagingFile = stageFolder.map { folder =>
-              val stage = mb.newLocal[String](s"stage$i")
-              cb.assign(stage, const(s"$folder/$i/").concat(ctxValue))
-              stage
-            }
-
             val ostream = mb.newLocal[ByteTrackingOutputStream](s"write_os$i")
             cb.assign(
               ostream,
               Code.newInstance[ByteTrackingOutputStream, OutputStream](
-                mb.createUnbuffered(stagingFile.getOrElse(filename).get)
+                mb.createUnbuffered(filename.get)
               ),
             )
 
             val buffer = mb.newLocal[OutputBuffer](s"write_ob$i")
             cb.assign(buffer, spec1.buildCodeOutputBuffer(Code.checkcast[OutputStream](ostream)))
 
-            (filename, stagingFile, buffer)
+            buffer
           }
-          .unzip3
 
       writeIndexInfo.foreach { case (name, _, writer) =>
         val indexFile = cb.newLocal[String]("indexFile")
@@ -585,15 +569,6 @@ case class SplitPartitionNativeWriter(
         cb += buff.writeByte(0.asInstanceOf[Byte])
         cb += buff.flush()
         cb += buff.close()
-      }
-
-      stages.flatten.zip(filenames).foreach { case (source, destination) =>
-        cb += mb.getFS.invoke[String, String, Boolean, Unit](
-          "copy",
-          source,
-          destination,
-          const(true),
-        )
       }
 
       lastSeenSettable.loadI(cb).consume(
@@ -2485,7 +2460,7 @@ case class MatrixBlockMatrixWriter(
     )
     RelationalWriter.scoped(path, overwrite, None)(WriteMetadata(
       flatPaths,
-      BlockMatrixNativeMetadataWriter(path, stageLocally = false, bmt),
+      BlockMatrixNativeMetadataWriter(path, bmt),
     ))
   }
 }
@@ -2500,13 +2475,12 @@ object MatrixNativeMultiWriter {
 case class MatrixNativeMultiWriter(
   paths: IndexedSeq[String],
   overwrite: Boolean = false,
-  stageLocally: Boolean = false,
   codecSpecJSONStr: String = null,
 ) {
   val bufferSpec: BufferSpec = BufferSpec.parseOrDefault(codecSpecJSONStr)
 
   def apply(ctx: ExecuteContext, mvs: IndexedSeq[MatrixValue]): Unit =
-    MatrixValue.writeMultiple(ctx, mvs, paths, overwrite, stageLocally, bufferSpec)
+    MatrixValue.writeMultiple(ctx, mvs, paths, overwrite, bufferSpec)
 
   def lower(
     ctx: ExecuteContext,
@@ -2515,7 +2489,7 @@ case class MatrixNativeMultiWriter(
     val components =
       paths.zip(tables).map { case (path, (colsFieldName, entriesFieldName, colKey, ts, rt)) =>
         MatrixNativeWriter.generateComponentFunctions(colsFieldName, entriesFieldName, colKey,
-          ctx, ts, rt, path, overwrite, stageLocally, codecSpecJSONStr)
+          ctx, ts, rt, path, overwrite, codecSpecJSONStr)
       }
 
     require(tables.map(_._4.tableType.keyType).distinct.length == 1)

--- a/hail/hail/src/is/hail/expr/ir/Parser.scala
+++ b/hail/hail/src/is/hail/expr/ir/Parser.scala
@@ -1504,9 +1504,8 @@ object IRParser {
       case "WriteValue" =>
         import ValueWriter.formats
         val writer = JsonMethods.parse(string_literal(it)).extract[ValueWriter]
-        ir_value_children(ctx)(it).map {
-          case Seq(value, path) => WriteValue(value, path, writer)
-          case Seq(value, path, stagingFile) => WriteValue(value, path, writer, Some(stagingFile))
+        ir_value_children(ctx)(it).map { case Seq(value, path) =>
+          WriteValue(value, path, writer)
         }
     }
   }

--- a/hail/hail/src/is/hail/expr/ir/Pretty.scala
+++ b/hail/hail/src/is/hail/expr/ir/Pretty.scala
@@ -641,7 +641,7 @@ class Pretty(
       single(prettyStringLiteral(JsonMethods.compact(writer.toJValue), elide = elideLiterals))
     case ReadValue(_, reader, reqType) =>
       FastSeq(prettyStringLiteral(JsonMethods.compact(reader.toJValue)), reqType.parsableString())
-    case WriteValue(_, _, writer, _) =>
+    case WriteValue(_, _, writer) =>
       single(prettyStringLiteral(JsonMethods.compact(writer.toJValue)))
     case MakeNDArray(_, _, _, errorId) => FastSeq(errorId.toString)
 

--- a/hail/hail/src/is/hail/expr/ir/TableWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableWriter.scala
@@ -32,9 +32,8 @@ import is.hail.utils.implicits.ByteTrackingOutputStream
 import is.hail.variant.ReferenceGenome
 
 import java.io.{BufferedOutputStream, OutputStream, OutputStreamWriter}
-import java.nio.file.{FileSystems, Path}
 import java.text.SimpleDateFormat
-import java.util.{Date, UUID}
+import java.util.Date
 
 import org.json4s.{DefaultFormats, Formats, JBool, JObject, ShortTypeHints}
 
@@ -67,7 +66,6 @@ object TableNativeWriter {
     ts: TableStage,
     path: String,
     overwrite: Boolean,
-    stageLocally: Boolean,
     rowSpec: TypedCodecSpec,
     globalSpec: TypedCodecSpec,
   ): IR = {
@@ -79,17 +77,10 @@ object TableNativeWriter {
       pKey.fieldNames,
       s"$path/rows/parts/",
       Some(s"$path/index/" -> pKey),
-      if (stageLocally) Some(FileSystems.getDefault.getPath(
-        ctx.localTmpdir,
-        s"hail_staging_tmp_${UUID.randomUUID()}",
-        "rows",
-        "parts",
-      ))
-      else None,
     )
 
     val globalWriter =
-      PartitionNativeWriter(globalSpec, IndexedSeq(), s"$path/globals/parts/", None, None)
+      PartitionNativeWriter(globalSpec, IndexedSeq(), s"$path/globals/parts/", None)
     RelationalWriter.scoped(path, overwrite, Some(ts.tableType))(
       ts.mapContexts { oldCtx =>
         val d = digitsNeeded(ts.numPartitions)
@@ -165,7 +156,6 @@ object TableNativeWriter {
 case class TableNativeWriter(
   path: String,
   overwrite: Boolean = true,
-  stageLocally: Boolean = false,
   codecSpecJSONStr: String = null,
 ) extends TableWriter {
 
@@ -179,7 +169,7 @@ case class TableNativeWriter(
       bufferSpec,
     )
 
-    TableNativeWriter.lower(ctx, ts, path, overwrite, stageLocally, rowSpec, globalSpec)
+    TableNativeWriter.lower(ctx, ts, path, overwrite, rowSpec, globalSpec)
   }
 }
 
@@ -206,7 +196,6 @@ case class PartitionNativeWriter(
   keyFields: IndexedSeq[String],
   partPrefix: String,
   index: Option[(String, PStruct)] = None,
-  stagingFolder: Option[Path] = None,
   trackTotalBytes: Boolean = false,
 ) extends PartitionWriter {
   val keyType = spec.encodedVirtualType.asInstanceOf[TStruct].select(keyFields)._1
@@ -247,7 +236,6 @@ case class PartitionNativeWriter(
     }
 
     private val filename = mb.newLocal[String]("filename")
-    private val stagingInfo = stagingFolder.map(folder => (folder, mb.newLocal[String]("stage")))
 
     private val ob = mb.newLocal[OutputBuffer]("write_ob")
     private val n = mb.newLocal[Long]("partition_count")
@@ -280,16 +268,11 @@ case class PartitionNativeWriter(
         writer.init(cb, indexFile, cb.memoize(mb.getObject[Map[String, Any]](Map.empty)))
       }
 
-      val stagingFile = stagingInfo.map { case (folder, fileRef) =>
-        cb.assign(fileRef, const(s"$folder/").concat(ctxValue))
-        fileRef
-      }
-
       val os = mb.newLocal[ByteTrackingOutputStream]("write_os")
       cb.assign(
         os,
         Code.newInstance[ByteTrackingOutputStream, OutputStream](
-          mb.create(stagingFile.getOrElse(filename).get)
+          mb.create(filename.get)
         ),
       )
       cb.assign(ob, spec.buildCodeOutputBuffer(Code.checkcast[OutputStream](os)))
@@ -371,10 +354,6 @@ case class PartitionNativeWriter(
       writeIndexInfo.foreach(_._3.close(cb))
       cb += ob.flush()
       cb += ob.close()
-
-      stagingInfo.foreach { case (_, source) =>
-        cb += mb.getFS.invoke[String, String, Boolean, Unit]("copy", source, filename, const(true))
-      }
 
       lastSeenSettable.loadI(cb).consume(
         cb,
@@ -946,7 +925,6 @@ case class TableNativeFanoutWriter(
   val path: String,
   val fields: IndexedSeq[String],
   overwrite: Boolean = true,
-  stageLocally: Boolean = false,
   codecSpecJSONStr: String = null,
 ) extends TableWriter {
 
@@ -981,16 +959,9 @@ case class TableNativeFanoutWriter(
           keyFields,
           s"$targetPath/rows/parts/",
           Some(s"$targetPath/index/" -> keyPType),
-          if (stageLocally) Some(FileSystems.getDefault.getPath(
-            ctx.localTmpdir,
-            s"hail_staging_tmp_${UUID.randomUUID()}",
-            "rows",
-            "parts",
-          ))
-          else None,
         )
         val globalWriter =
-          PartitionNativeWriter(globalSpec, IndexedSeq(), s"$targetPath/globals/parts/", None, None)
+          PartitionNativeWriter(globalSpec, IndexedSeq(), s"$targetPath/globals/parts/", None)
         new FanoutWriterTarget(field, targetPath, rowSpec, keyPType, tableType, rowWriter,
           globalWriter)
       }

--- a/hail/hail/src/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/hail/src/is/hail/expr/ir/TypeCheck.scala
@@ -598,9 +598,8 @@ object TypeCheck {
             assert(reader.spec.encodedType.decodedPType(requestedType).virtualType == requestedType)
           case _ => // do nothing, we can't in general typecheck an arbitrary value reader
         }
-      case WriteValue(_, path, _, stagingFile) =>
+      case WriteValue(_, path, _) =>
         assert(path.typ == TString)
-        assert(stagingFile.forall(_.typ == TString))
       case Consume(_) =>
 
       case TableAggregateByKey(child, _) =>

--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerDistributedSort.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerDistributedSort.scala
@@ -53,7 +53,6 @@ object LowerDistributedSort extends Logging {
       keyToSortBy.fieldNames,
       initialTmpPath,
       None,
-      None,
       trackTotalBytes = true,
     )
 

--- a/hail/hail/src/is/hail/linalg/BlockMatrix.scala
+++ b/hail/hail/src/is/hail/linalg/BlockMatrix.scala
@@ -409,7 +409,6 @@ object BlockMatrix {
 
     def blockMatrixURI(matrixIdx: Int): String = prefix + "_" + matrixIdx
     val fs = ctx.fs
-    val tmpdir = ctx.localTmpdir
 
     bms.zipWithIndex.foreach { case (_, bIdx) =>
       val uri = blockMatrixURI(bIdx)
@@ -474,9 +473,7 @@ object BlockMatrix {
         fileName,
         null,
         (_, _, _) => null,
-        false,
         fs,
-        tmpdir,
         trueIt,
         writeBlock,
       )
@@ -998,7 +995,6 @@ class BlockMatrix(
     uri: String,
     overwrite: Boolean = false,
     forceRowMajor: Boolean = false,
-    stageLocally: Boolean = false,
   ): Unit = {
     val fs = ctx.fs
     if (overwrite)
@@ -1021,7 +1017,7 @@ class BlockMatrix(
       (1L, bytesWritten)
     }
 
-    val fileData = blocks.writePartitions(ctx, uri, stageLocally, writeBlock)
+    val fileData = blocks.writePartitions(ctx, uri, writeBlock)
 
     using(new DataOutputStream(fs.create(uri + metadataRelativePath))) { os =>
       implicit val formats = DefaultFormats

--- a/hail/hail/src/is/hail/rvd/RVD.scala
+++ b/hail/hail/src/is/hail/rvd/RVD.scala
@@ -845,10 +845,9 @@ class RVD(
     ctx: ExecuteContext,
     path: String,
     idxRelPath: String,
-    stageLocally: Boolean,
     codecSpec: AbstractTypedCodecSpec,
   ): IndexedSeq[FileWriteMetadata] = {
-    val fileData = crdd.writeRows(ctx, path, idxRelPath, typ, stageLocally, codecSpec)
+    val fileData = crdd.writeRows(ctx, path, idxRelPath, typ, codecSpec)
     val spec = MakeRVDSpec(
       codecSpec,
       fileData.map(_.path),
@@ -1375,7 +1374,6 @@ object RVD extends Logging {
     rvds: IndexedSeq[RVD],
     paths: IndexedSeq[String],
     bufferSpec: BufferSpec,
-    stageLocally: Boolean,
   ): IndexedSeq[IndexedSeq[FileWriteMetadata]] = {
     val first = rvds.head
     rvds.foreach { rvd =>
@@ -1388,7 +1386,6 @@ object RVD extends Logging {
     }
 
     val sc = SparkBackend.sparkContext
-    val localTmpdir = execCtx.localTmpdir
     val fs = execCtx.fs
 
     val nRVDs = rvds.length
@@ -1428,7 +1425,6 @@ object RVD extends Logging {
         ContextRDD.inCtx { (hcl, ctx) =>
           val fullPath = paths(originIdx)
           val fileData = RichContextRDDRegionValue.writeSplitRegion(
-            localTmpdir,
             fsBc.value,
             fullPath,
             localTyp,
@@ -1437,7 +1433,6 @@ object RVD extends Logging {
             hcl,
             ctx,
             partDigits,
-            stageLocally,
             makeIndexWriter,
             os => makeRowsEnc(os, hcl),
             os => makeEntriesEnc(os, hcl),

--- a/hail/hail/src/is/hail/sparkextras/implicits/RichContextRDD.scala
+++ b/hail/hail/src/is/hail/sparkextras/implicits/RichContextRDD.scala
@@ -25,40 +25,19 @@ object RichContextRDD {
     f: String,
     idxRelPath: String,
     mkIdxWriter: (String, HailClassLoader, RegionPool) => IndexWriter,
-    stageLocally: Boolean,
     fs: FS,
-    localTmpdir: String,
     it: Iterator[T],
     write: (HailClassLoader, RVDContext, Iterator[T], OutputStream, IndexWriter) => (Long, Long),
   ): Iterator[FileWriteMetadata] = {
-    val finalFilename = rootPath + "/parts/" + f
-    val finalIdxFilename =
+    val filename = rootPath + "/parts/" + f
+    val idxFilename =
       if (idxRelPath != null) rootPath + "/" + idxRelPath + "/" + f + ".idx" else null
-    val (filename, idxFilename) =
-      if (stageLocally) {
-        val context = TaskContext.get()
-        val partPath = ExecuteContext.createTmpPathNoCleanup(localTmpdir, "write-partitions-part")
-        val idxPath = partPath + ".idx"
-        context.addTaskCompletionListener[Unit] { (context: TaskContext) =>
-          fs.delete(partPath, recursive = false)
-          fs.delete(idxPath, recursive = true)
-        }: Unit
-        partPath -> idxPath
-      } else
-        finalFilename -> finalIdxFilename
     val os = fs.create(filename)
     val iw = mkIdxWriter(idxFilename, hcl, ctx.r.pool)
 
     // write must close `os` and `iw`
     val (rowCount, bytesWritten) = write(hcl, ctx, it, os, iw)
 
-    if (stageLocally) {
-      fs.copy(filename, finalFilename)
-      if (iw != null) {
-        fs.copy(idxFilename + "/index", finalIdxFilename + "/index")
-        fs.copy(idxFilename + "/metadata.json.gz", finalIdxFilename + "/metadata.json.gz")
-      }
-    }
     ctx.region.clear()
     Iterator.single(FileWriteMetadata(f, rowCount, bytesWritten))
   }
@@ -96,11 +75,9 @@ class RichContextRDD[T](val crdd: ContextRDD[T]) extends AnyVal {
     ctx: ExecuteContext,
     path: String,
     idxRelPath: String,
-    stageLocally: Boolean,
     mkIdxWriter: (String, HailClassLoader, RegionPool) => IndexWriter,
     write: (HailClassLoader, RVDContext, Iterator[T], OutputStream, IndexWriter) => (Long, Long),
   ): IndexedSeq[FileWriteMetadata] = {
-    val localTmpdir = ctx.localTmpdir
     val fs = ctx.fs
 
     fs.mkDir(path + "/parts")
@@ -113,8 +90,7 @@ class RichContextRDD[T](val crdd: ContextRDD[T]) extends AnyVal {
 
     val fileData = crdd.cmapPartitionsWithIndex { (i, hcl, ctx, it) =>
       val f = partFile(d, i, TaskContext.get())
-      RichContextRDD.writeParts(hcl, ctx, path, f, idxRelPath, mkIdxWriter, stageLocally, fs,
-        localTmpdir, it, write)
+      RichContextRDD.writeParts(hcl, ctx, path, f, idxRelPath, mkIdxWriter, fs, it, write)
     }
       .collect()
 

--- a/hail/hail/src/is/hail/sparkextras/implicits/RichContextRDDRegionValue.scala
+++ b/hail/hail/src/is/hail/sparkextras/implicits/RichContextRDDRegionValue.scala
@@ -77,7 +77,6 @@ object RichContextRDDRegionValue {
   }
 
   def writeSplitRegion(
-    localTmpdir: String,
     fs: FS,
     path: String,
     t: RVDType,
@@ -86,7 +85,6 @@ object RichContextRDDRegionValue {
     hcl: HailClassLoader,
     ctx: RVDContext,
     partDigits: Int,
-    stageLocally: Boolean,
     makeIndexWriter: (String, HailClassLoader, RegionPool) => IndexWriter,
     makeRowsEnc: (OutputStream) => Encoder,
     makeEntriesEnc: (OutputStream) => Encoder,
@@ -96,24 +94,9 @@ object RichContextRDDRegionValue {
     val context = TaskContext.get()
     val f = partFile(partDigits, idx, context)
     val outputMetrics = context.taskMetrics().outputMetrics
-    val finalRowsPartPath = path + "/rows/rows/parts/" + f
-    val finalEntriesPartPath = path + "/entries/rows/parts/" + f
-    val finalIdxPath = path + "/index/" + f + ".idx"
-    val (rowsPartPath, entriesPartPath, idxPath) =
-      if (stageLocally) {
-        val rowsPartPath =
-          ExecuteContext.createTmpPathNoCleanup(localTmpdir, "write-split-staged-rows-part")
-        val entriesPartPath =
-          ExecuteContext.createTmpPathNoCleanup(localTmpdir, "write-split-staged-entries-part")
-        val idxPath = rowsPartPath + ".idx"
-        context.addTaskCompletionListener[Unit] { (context: TaskContext) =>
-          fs.delete(rowsPartPath, recursive = false)
-          fs.delete(entriesPartPath, recursive = false)
-          fs.delete(idxPath, recursive = true)
-        }: Unit
-        (rowsPartPath, entriesPartPath, idxPath)
-      } else
-        (finalRowsPartPath, finalEntriesPartPath, finalIdxPath)
+    val rowsPartPath = path + "/rows/rows/parts/" + f
+    val entriesPartPath = path + "/entries/rows/parts/" + f
+    val idxPath = path + "/index/" + f + ".idx"
 
     val (rowCount, totalBytesWritten) = using(fs.create(rowsPartPath)) { rowsOS =>
       val trackedRowsOS = new ByteTrackingOutputStream(rowsOS)
@@ -162,13 +145,6 @@ object RichContextRDDRegionValue {
           }
         }
       }
-    }
-
-    if (stageLocally) {
-      fs.copy(rowsPartPath, finalRowsPartPath)
-      fs.copy(entriesPartPath, finalEntriesPartPath)
-      fs.copy(idxPath + "/index", finalIdxPath + "/index")
-      fs.copy(idxPath + "/metadata.json.gz", finalIdxPath + "/metadata.json.gz")
     }
 
     FileWriteMetadata(f, rowCount, totalBytesWritten)
@@ -234,14 +210,12 @@ class RichContextRDDLong(val crdd: ContextRDD[Long]) extends AnyVal {
     path: String,
     idxRelPath: String,
     t: RVDType,
-    stageLocally: Boolean,
     encoding: AbstractTypedCodecSpec,
   ): IndexedSeq[FileWriteMetadata] = {
     crdd.writePartitions(
       ctx,
       path,
-      idxRelPath,
-      stageLocally, {
+      idxRelPath, {
         val f1 = IndexWriter.builder(ctx, t.kType, +PCanonicalStruct())
         f1(_, _, SparkTaskContext.get(), _)
       },

--- a/hail/hail/src/is/hail/sparkextras/implicits/RichRDD.scala
+++ b/hail/hail/src/is/hail/sparkextras/implicits/RichRDD.scala
@@ -225,7 +225,6 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
   def writePartitions(
     ctx: ExecuteContext,
     path: String,
-    stageLocally: Boolean,
     write: (Iterator[T], OutputStream) => (Long, Long),
   )(implicit T: ClassTag[T]
   ): IndexedSeq[FileWriteMetadata] =
@@ -233,7 +232,6 @@ class RichRDD[T](val r: RDD[T]) extends AnyVal {
       ctx,
       path,
       null,
-      stageLocally,
       (_, _, _) => null,
       (_, _, it, os, _) => write(it, os),
     )

--- a/hail/hail/test/src/is/hail/expr/ir/BlockMatrixIRSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/BlockMatrixIRSuite.scala
@@ -186,7 +186,7 @@ class BlockMatrixIRSuite {
     val tempPath = ctx.createTmpPath("test-blockmatrix-write-read", "bm")
     Interpret[Unit](
       ctx,
-      BlockMatrixWrite(ones, BlockMatrixNativeWriter(tempPath, false, false, false)),
+      BlockMatrixWrite(ones, BlockMatrixNativeWriter(tempPath, false, false)),
     )
 
     assertBMEvalsTo(
@@ -418,7 +418,7 @@ class BlockMatrixIRSuite {
     assertEvalsTo(
       BlockMatrixWrite(
         BlockMatrixRead(BlockMatrixNativeReader(ctx.fs, original)),
-        BlockMatrixNativeWriter(path, overwrite = true, forceRowMajor = false, stageLocally = false),
+        BlockMatrixNativeWriter(path, overwrite = true, forceRowMajor = false),
       ),
       (),
     )

--- a/hail/hail/test/src/is/hail/expr/ir/IRSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/IRSuite.scala
@@ -3423,7 +3423,7 @@ class IRSuite {
 
     val blockMatrix =
       BlockMatrixRead(BlockMatrixNativeReader(fs, getTestResource("blockmatrix_example/0")))
-    val blockMatrixWriter = BlockMatrixNativeWriter("/path/to/file.bm", false, false, false)
+    val blockMatrixWriter = BlockMatrixNativeWriter("/path/to/file.bm", false, false)
     val blockMatrixMultiWriter = BlockMatrixBinaryMultiWriter("/path/to/prefix", false)
     val nd = MakeNDArray(
       MakeArray(FastSeq(I32(-1), I32(1)), TArray(TInt32)),
@@ -3657,7 +3657,6 @@ class IRSuite {
           IndexedSeq(),
           "path",
           None,
-          None,
         ),
       ),
       WriteMetadata(
@@ -3677,12 +3676,6 @@ class IRSuite {
         I32(1),
         Str("foo"),
         ETypeValueWriter(TypedCodecSpec(ctx, PInt32(), BufferSpec.default)),
-      ),
-      WriteValue(
-        I32(1),
-        Str("foo"),
-        ETypeValueWriter(TypedCodecSpec(ctx, PInt32(), BufferSpec.default)),
-        Some(Str("/tmp/uid/part")),
       ),
       relationalBindIR(I32(0))(_ => I32(0)), {
         val y = freshName()

--- a/hail/python/hail/experimental/write_multiple.py
+++ b/hail/python/hail/experimental/write_multiple.py
@@ -20,7 +20,7 @@ def write_matrix_tables(
 ):
     length = len(str(len(mts) - 1))
     paths = [f"{prefix}{str(i).rjust(length, '0')}.mt" for i in range(len(mts))]
-    writer = MatrixNativeMultiWriter(paths, overwrite, stage_locally, codec_spec)
+    writer = MatrixNativeMultiWriter(paths, overwrite, codec_spec)
     Env.backend().execute(MatrixMultiWrite([mt._mir for mt in mts], writer))
 
     return paths
@@ -82,8 +82,8 @@ def write_block_matrices(
         to row-major format before writing.
         If ``False``, write blocks in their current format.
     :param stage_locally: :obj:`bool`
-        If ``True``, major output will be written to temporary local storage
-        before being copied to ``output``.
+        Deprecated and ignored. Retained for backwards compatibility; has no
+        effect.
     """
-    writer = BlockMatrixNativeMultiWriter(path_prefix, overwrite, force_row_major, stage_locally)
+    writer = BlockMatrixNativeMultiWriter(path_prefix, overwrite, force_row_major)
     Env.backend().execute(BlockMatrixMultiWrite([bm._bmir for bm in bms], writer))

--- a/hail/python/hail/ir/blockmatrix_writer.py
+++ b/hail/python/hail/ir/blockmatrix_writer.py
@@ -21,12 +21,11 @@ class BlockMatrixWriter(object):
 
 
 class BlockMatrixNativeWriter(BlockMatrixWriter):
-    @typecheck_method(path=str, overwrite=bool, force_row_major=bool, stage_locally=bool)
-    def __init__(self, path, overwrite, force_row_major, stage_locally):
+    @typecheck_method(path=str, overwrite=bool, force_row_major=bool)
+    def __init__(self, path, overwrite, force_row_major):
         self.path = path
         self.overwrite = overwrite
         self.force_row_major = force_row_major
-        self.stage_locally = stage_locally
 
     def render(self):
         writer = {
@@ -34,7 +33,6 @@ class BlockMatrixNativeWriter(BlockMatrixWriter):
             'path': self.path,
             'overwrite': self.overwrite,
             'forceRowMajor': self.force_row_major,
-            'stageLocally': self.stage_locally,
         }
         return escape_str(json.dumps(writer))
 
@@ -47,7 +45,6 @@ class BlockMatrixNativeWriter(BlockMatrixWriter):
             and self.path == other.path
             and self.overwrite == other.overwrite
             and self.force_row_major == other.force_row_major
-            and self.stage_locally == other.stage_locally
         )
 
 
@@ -202,12 +199,11 @@ class BlockMatrixPersistWriter(BlockMatrixWriter):
 
 
 class BlockMatrixNativeMultiWriter(BlockMatrixMultiWriter):
-    @typecheck_method(prefix=str, overwrite=bool, force_row_major=bool, stage_locally=bool)
-    def __init__(self, prefix, overwrite, force_row_major, stage_locally):
+    @typecheck_method(prefix=str, overwrite=bool, force_row_major=bool)
+    def __init__(self, prefix, overwrite, force_row_major):
         self.prefix = prefix
         self.overwrite = overwrite
         self.force_row_major = force_row_major
-        self.stage_locally = stage_locally
 
     def render(self):
         writer = {
@@ -215,7 +211,6 @@ class BlockMatrixNativeMultiWriter(BlockMatrixMultiWriter):
             'prefix': self.prefix,
             'overwrite': self.overwrite,
             'forceRowMajor': self.force_row_major,
-            'stageLocally': self.stage_locally,
         }
         return escape_str(json.dumps(writer))
 
@@ -228,5 +223,4 @@ class BlockMatrixNativeMultiWriter(BlockMatrixMultiWriter):
             and self.prefix == other.prefix
             and self.overwrite == other.overwrite
             and self.force_row_major == other.force_row_major
-            and self.stage_locally == other.stage_locally
         )

--- a/hail/python/hail/ir/matrix_writer.py
+++ b/hail/python/hail/ir/matrix_writer.py
@@ -22,15 +22,13 @@ class MatrixNativeWriter(MatrixWriter):
     @typecheck_method(
         path=str,
         overwrite=bool,
-        stage_locally=bool,
         codec_spec=nullable(str),
         partitions=nullable(str),
         partitions_type=nullable(hail_type),
     )
-    def __init__(self, path, overwrite, stage_locally, codec_spec, partitions, partitions_type):
+    def __init__(self, path, overwrite, codec_spec, partitions, partitions_type):
         self.path = path
         self.overwrite = overwrite
-        self.stage_locally = stage_locally
         self.codec_spec = codec_spec
         self.partitions = partitions
         self.partitions_type = partitions_type
@@ -40,7 +38,6 @@ class MatrixNativeWriter(MatrixWriter):
             'name': 'MatrixNativeWriter',
             'path': self.path,
             'overwrite': self.overwrite,
-            'stageLocally': self.stage_locally,
             'codecSpecJSONStr': self.codec_spec,
             'partitions': self.partitions,
             'partitionsTypeStr': self.partitions_type._parsable_string() if self.partitions_type is not None else None,
@@ -52,7 +49,6 @@ class MatrixNativeWriter(MatrixWriter):
             isinstance(other, MatrixNativeWriter)
             and other.path == self.path
             and other.overwrite == self.overwrite
-            and other.stage_locally == self.stage_locally
             and other.codec_spec == self.codec_spec
             and other.partitions == self.partitions
             and other.partitions_type == self.partitions_type
@@ -177,11 +173,10 @@ class MatrixBlockMatrixWriter(MatrixWriter):
 
 
 class MatrixNativeMultiWriter(object):
-    @typecheck_method(paths=sequenceof(str), overwrite=bool, stage_locally=bool, codec_spec=nullable(str))
-    def __init__(self, paths, overwrite, stage_locally, codec_spec):
+    @typecheck_method(paths=sequenceof(str), overwrite=bool, codec_spec=nullable(str))
+    def __init__(self, paths, overwrite, codec_spec):
         self.paths = paths
         self.overwrite = overwrite
-        self.stage_locally = stage_locally
         self.codec_spec = codec_spec
 
     def render(self):
@@ -189,7 +184,6 @@ class MatrixNativeMultiWriter(object):
             'name': 'MatrixNativeMultiWriter',
             'paths': list(self.paths),
             'overwrite': self.overwrite,
-            'stageLocally': self.stage_locally,
             'codecSpecJSONStr': self.codec_spec,
         }
         return escape_str(json.dumps(writer))
@@ -199,6 +193,5 @@ class MatrixNativeMultiWriter(object):
             isinstance(other, MatrixNativeMultiWriter)
             and other.paths == self.paths
             and other.overwrite == self.overwrite
-            and other.stage_locally == self.stage_locally
             and other.codec_spec == self.codec_spec
         )

--- a/hail/python/hail/ir/table_writer.py
+++ b/hail/python/hail/ir/table_writer.py
@@ -17,12 +17,11 @@ class TableWriter(object):
 
 
 class TableNativeWriter(TableWriter):
-    @typecheck_method(path=str, overwrite=bool, stage_locally=bool, codec_spec=nullable(str))
-    def __init__(self, path, overwrite, stage_locally, codec_spec):
+    @typecheck_method(path=str, overwrite=bool, codec_spec=nullable(str))
+    def __init__(self, path, overwrite, codec_spec):
         super(TableNativeWriter, self).__init__()
         self.path = path
         self.overwrite = overwrite
-        self.stage_locally = stage_locally
         self.codec_spec = codec_spec
 
     def render(self):
@@ -30,7 +29,6 @@ class TableNativeWriter(TableWriter):
             'name': 'TableNativeWriter',
             'path': self.path,
             'overwrite': self.overwrite,
-            'stageLocally': self.stage_locally,
             'codecSpecJSONStr': self.codec_spec,
         }
         return escape_str(json.dumps(writer))
@@ -40,7 +38,6 @@ class TableNativeWriter(TableWriter):
             isinstance(other, TableNativeWriter)
             and other.path == self.path
             and other.overwrite == self.overwrite
-            and other.stage_locally == self.stage_locally
             and other.codec_spec == self.codec_spec
         )
 
@@ -78,13 +75,12 @@ class TableTextWriter(TableWriter):
 
 
 class TableNativeFanoutWriter(TableWriter):
-    @typecheck_method(path=str, fields=sequenceof(str), overwrite=bool, stage_locally=bool, codec_spec=nullable(str))
-    def __init__(self, path, fields, overwrite, stage_locally, codec_spec):
+    @typecheck_method(path=str, fields=sequenceof(str), overwrite=bool, codec_spec=nullable(str))
+    def __init__(self, path, fields, overwrite, codec_spec):
         super(TableNativeFanoutWriter, self).__init__()
         self.path = path
         self.fields = fields
         self.overwrite = overwrite
-        self.stage_locally = stage_locally
         self.codec_spec = codec_spec
 
     def render(self):
@@ -93,7 +89,6 @@ class TableNativeFanoutWriter(TableWriter):
             'path': self.path,
             'fields': self.fields,
             'overwrite': self.overwrite,
-            'stageLocally': self.stage_locally,
             'codecSpecJSONStr': self.codec_spec,
         }
         return escape_str(json.dumps(writer))
@@ -104,6 +99,5 @@ class TableNativeFanoutWriter(TableWriter):
             and other.path == self.path
             and other.fields == self.fields
             and other.overwrite == self.overwrite
-            and other.stage_locally == self.stage_locally
             and other.codec_spec == self.codec_spec
         )

--- a/hail/python/hail/linalg/blockmatrix.py
+++ b/hail/python/hail/linalg/blockmatrix.py
@@ -647,12 +647,12 @@ class BlockMatrix:
             to row-major format before writing.
             If ``False``, write blocks in their current format.
         stage_locally: :obj:`bool`
-            If ``True``, major output will be written to temporary local storage
-            before being copied to ``output``.
+            Deprecated and ignored. Retained for backwards compatibility; has no
+            effect.
         """
         hl.current_backend().validate_file(path)
 
-        writer = BlockMatrixNativeWriter(path, overwrite, force_row_major, stage_locally)
+        writer = BlockMatrixNativeWriter(path, overwrite, force_row_major)
         Env.backend().execute(BlockMatrixWrite(self._bmir, writer))
 
     @typecheck_method(path=str, overwrite=bool, force_row_major=bool, stage_locally=bool)
@@ -672,11 +672,11 @@ class BlockMatrix:
             to row-major format before checkpointing.
             If ``False``, checkpoint blocks in their current format.
         stage_locally: :obj:`bool`
-            If ``True``, major output will be written to temporary local storage
-            before being copied to ``output``.
+            Deprecated and ignored. Retained for backwards compatibility; has no
+            effect.
         """
         hl.current_backend().validate_file(path)
-        self.write(path, overwrite, force_row_major, stage_locally)
+        self.write(path, overwrite, force_row_major)
         return BlockMatrix.read(path, _assert_type=self._bmir._type)
 
     @staticmethod

--- a/hail/python/hail/matrixtable.py
+++ b/hail/python/hail/matrixtable.py
@@ -2719,8 +2719,8 @@ class MatrixTable(BaseTable):
         output : str
             Path at which to write.
         stage_locally: bool
-            If ``True``, major output will be written to temporary local storage
-            before being copied to ``output``
+            Deprecated and ignored. Retained for backwards compatibility; has no
+            effect.
         overwrite : bool
             If ``True``, overwrite an existing file at the destination.
 
@@ -2746,7 +2746,7 @@ class MatrixTable(BaseTable):
         hl.current_backend().validate_file(output)
 
         if not _read_if_exists or not hl.hadoop_exists(f'{output}/_SUCCESS'):
-            self.write(output=output, overwrite=overwrite, stage_locally=stage_locally, _codec_spec=_codec_spec)
+            self.write(output=output, overwrite=overwrite, _codec_spec=_codec_spec)
             _assert_type = self._type
             _load_refs = False
         else:
@@ -2791,8 +2791,8 @@ class MatrixTable(BaseTable):
         output : str
             Path at which to write.
         stage_locally: bool
-            If ``True``, major output will be written to temporary local storage
-            before being copied to ``output``
+            Deprecated and ignored. Retained for backwards compatibility; has no
+            effect.
         overwrite : bool
             If ``True``, overwrite an existing file at the destination.
         """
@@ -2804,7 +2804,7 @@ class MatrixTable(BaseTable):
         else:
             _partitions_type = None
 
-        writer = ir.MatrixNativeWriter(output, overwrite, stage_locally, _codec_spec, _partitions, _partitions_type)
+        writer = ir.MatrixNativeWriter(output, overwrite, _codec_spec, _partitions, _partitions_type)
         Env.backend().execute(ir.MatrixWrite(self._mir, writer))
 
     class _Show:

--- a/hail/python/hail/table.py
+++ b/hail/python/hail/table.py
@@ -1938,8 +1938,8 @@ class Table(BaseTable):
         output : str
             Path at which to write.
         stage_locally: bool
-            If ``True``, major output will be written to temporary local storage
-            before being copied to ``output``
+            Deprecated and ignored. Retained for backwards compatibility; has no
+            effect.
         overwrite : bool
             If ``True``, overwrite an existing file at the destination.
 
@@ -1963,7 +1963,7 @@ class Table(BaseTable):
         hl.current_backend().validate_file(output)
 
         if not _read_if_exists or not hl.hadoop_exists(f'{output}/_SUCCESS'):
-            self.write(output=output, overwrite=overwrite, stage_locally=stage_locally, _codec_spec=_codec_spec)
+            self.write(output=output, overwrite=overwrite, _codec_spec=_codec_spec)
             _assert_type = self._type
             _load_refs = False
         else:
@@ -1997,17 +1997,15 @@ class Table(BaseTable):
         output : str
             Path at which to write.
         stage_locally: bool
-            If ``True``, major output will be written to temporary local storage
-            before being copied to ``output``.
+            Deprecated and ignored. Retained for backwards compatibility; has no
+            effect.
         overwrite : bool
             If ``True``, overwrite an existing file at the destination.
         """
 
         hl.current_backend().validate_file(output)
 
-        Env.backend().execute(
-            ir.TableWrite(self._tir, ir.TableNativeWriter(output, overwrite, stage_locally, _codec_spec))
-        )
+        Env.backend().execute(ir.TableWrite(self._tir, ir.TableNativeWriter(output, overwrite, _codec_spec)))
 
     @typecheck_method(output=str, fields=sequenceof(str), overwrite=bool, stage_locally=bool, _codec_spec=nullable(str))
     def write_many(
@@ -2125,8 +2123,8 @@ class Table(BaseTable):
         fields : list of str
             The fields to write.
         stage_locally: bool
-            If ``True``, major output will be written to temporary local storage
-            before being copied to ``output``.
+            Deprecated and ignored. Retained for backwards compatibility; has no
+            effect.
         overwrite : bool
             If ``True``, overwrite an existing file at the destination.
         """
@@ -2134,7 +2132,7 @@ class Table(BaseTable):
         hl.current_backend().validate_file(output)
 
         Env.backend().execute(
-            ir.TableWrite(self._tir, ir.TableNativeFanoutWriter(output, fields, overwrite, stage_locally, _codec_spec))
+            ir.TableWrite(self._tir, ir.TableNativeFanoutWriter(output, fields, overwrite, _codec_spec))
         )
 
     def _show(self, n, width, truncate, types):

--- a/hail/python/hail/vds/methods.py
+++ b/hail/python/hail/vds/methods.py
@@ -11,10 +11,8 @@ from hail.vds.variant_dataset import VariantDataset
 
 def write_variant_datasets(vdss, paths, *, overwrite=False, stage_locally=False, codec_spec=None):
     """Write many `vdses` to their corresponding path in `paths`."""
-    ref_writer = ir.MatrixNativeMultiWriter(
-        [f"{p}/reference_data" for p in paths], overwrite, stage_locally, codec_spec
-    )
-    var_writer = ir.MatrixNativeMultiWriter([f"{p}/variant_data" for p in paths], overwrite, stage_locally, codec_spec)
+    ref_writer = ir.MatrixNativeMultiWriter([f"{p}/reference_data" for p in paths], overwrite, codec_spec)
+    var_writer = ir.MatrixNativeMultiWriter([f"{p}/variant_data" for p in paths], overwrite, codec_spec)
     Env.backend().execute(ir.MatrixMultiWrite([vds.reference_data._mir for vds in vdss], ref_writer))
     Env.backend().execute(ir.MatrixMultiWrite([vds.variant_data._mir for vds in vdss], var_writer))
 

--- a/hail/python/test/hail/test_ir.py
+++ b/hail/python/test/hail/test_ir.py
@@ -153,15 +153,14 @@ def value_irs():
         ir.TableToValueApply(table, {'name': 'ForceCountTable'}),
         ir.MatrixToValueApply(matrix_read, {'name': 'ForceCountMatrixTable'}),
         ir.TableAggregate(table, ir.MakeStruct([('foo', ir.ApplyAggOp('Collect', [], [ir.I32(0)]))])),
-        ir.TableWrite(table, ir.TableNativeWriter(new_temp_file(), False, True, "fake_codec_spec$$")),
+        ir.TableWrite(table, ir.TableNativeWriter(new_temp_file(), False, "fake_codec_spec$$")),
         ir.TableWrite(table, ir.TableTextWriter(new_temp_file(), None, True, "concatenated", ",")),
         ir.MatrixAggregate(matrix_read, ir.MakeStruct([('foo', ir.ApplyAggOp('Collect', [], [ir.I32(0)]))])),
-        ir.MatrixWrite(matrix_read, ir.MatrixNativeWriter(new_temp_file(), False, False, "", None, None)),
+        ir.MatrixWrite(matrix_read, ir.MatrixNativeWriter(new_temp_file(), False, "", None, None)),
         ir.MatrixWrite(
             matrix_read,
             ir.MatrixNativeWriter(
                 new_temp_file(),
-                False,
                 False,
                 "",
                 '[{"start":{"row_idx":0},"end":{"row_idx": 10},"includeStart":true,"includeEnd":false}]',
@@ -173,9 +172,9 @@ def value_irs():
         ir.MatrixWrite(matrix_read, ir.MatrixPLINKWriter(new_temp_file())),
         ir.MatrixMultiWrite(
             [matrix_read, matrix_read],
-            ir.MatrixNativeMultiWriter([new_temp_file(), new_temp_file()], False, False, None),
+            ir.MatrixNativeMultiWriter([new_temp_file(), new_temp_file()], False, None),
         ),
-        ir.BlockMatrixWrite(block_matrix_read, ir.BlockMatrixNativeWriter('fake.bm', False, False, False)),
+        ir.BlockMatrixWrite(block_matrix_read, ir.BlockMatrixNativeWriter('fake.bm', False, False)),
         ir.BlockMatrixWrite(block_matrix_read, ir.BlockMatrixPersistWriter('x', 'MEMORY_ONLY')),
     ]
 


### PR DESCRIPTION
It is kept as a no-op in python for backwards compatibility.

The ability to 'stage locally' was added to try and fix an observed behavior of cloud storage libraries failing with long running open connections. I've noticed that in lowered execution, we do not stage index writing locally and hold the index open for as long as the partition is, indicating that this is no longer an issue and that cloud storage client libraries or our own retry logic has become sufficiently advanced to no longer need the additional complexity of this parameter.

## Security Assessment
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP