### PR TITLE
[batch] fix incorrect reference to gcloud storage in the batch openapi doc

### DIFF
--- a/batch/batch/front_end/templates/openapi.yaml
+++ b/batch/batch/front_end/templates/openapi.yaml
@@ -650,7 +650,8 @@ paths:
       description: |
         Returns a time-limited GCS signed URL for direct download of a job's container log.
         The URL is valid for 15 minutes from the time of issue. Range requests are supported,
-        so parallel download tools such as `gcloud storage cp` work correctly.
+        so parallel download tools work correctly as long as all streams are initiated within
+        the validity window.
         Only available for completed jobs (or a specific past attempt via attempt_id).
         Only available for GCP deployments using GCS logs.
         The signed URL is returned without first verifying the log file exists in GCS;


### PR DESCRIPTION
## Change Description

Doc only fix. Removes an incorrect reference to `gcloud storage` in the signed url docs (download of the signed url would be via a standard tool like curl, but parallel download would still be supported)

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has no security impact

### Impact Description

Doc only change

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
