### PR TITLE
[query] Remove PartitionNativeWriter

### DIFF
--- a/hail/hail/src/is/hail/expr/ir/AggOp.scala
+++ b/hail/hail/src/is/hail/expr/ir/AggOp.scala
@@ -3,6 +3,8 @@ package is.hail.expr.ir
 import is.hail.collection.FastSeq
 import is.hail.expr.ir.agg._
 import is.hail.types.virtual._
+import is.hail.types.physical.PStruct
+import is.hail.io.TypedCodecSpec
 
 sealed trait AggOp {}
 final case class ApproxCDF() extends AggOp
@@ -28,7 +30,7 @@ final case class ImputeType() extends AggOp
 final case class NDArraySum() extends AggOp
 final case class NDArrayMultiplyAdd() extends AggOp
 final case class Fold() extends AggOp
-final case class WriteTBD(codec: is.hail.io.TypedCodecSpec) extends AggOp
+final case class WriteTBD(codec: TypedCodecSpec, indexKey: Option[PStruct]) extends AggOp
 
 // exists === map(p).sum, needs short-circuiting aggs
 // forall === map(p).product, needs short-circuiting aggs
@@ -56,7 +58,7 @@ object AggOp {
     case (Downsample(), Seq(_, _, _)) => DownsampleAggregator.resultType
     case (NDArraySum(), Seq(t)) => t
     case (NDArrayMultiplyAdd(), Seq(a: TNDArray, _)) => a
-    case (WriteTBD(_), _) => TString
+    case (WriteTBD(_, _), _) => TString
     case _ => throw new UnsupportedExtraction(this.toString)
   }
 

--- a/hail/hail/src/is/hail/expr/ir/AggOp.scala
+++ b/hail/hail/src/is/hail/expr/ir/AggOp.scala
@@ -28,6 +28,7 @@ final case class ImputeType() extends AggOp
 final case class NDArraySum() extends AggOp
 final case class NDArrayMultiplyAdd() extends AggOp
 final case class Fold() extends AggOp
+final case class WriteTBD(codec: is.hail.io.TypedCodecSpec) extends AggOp
 
 // exists === map(p).sum, needs short-circuiting aggs
 // forall === map(p).product, needs short-circuiting aggs
@@ -55,6 +56,7 @@ object AggOp {
     case (Downsample(), Seq(_, _, _)) => DownsampleAggregator.resultType
     case (NDArraySum(), Seq(t)) => t
     case (NDArrayMultiplyAdd(), Seq(a: TNDArray, _)) => a
+    case (WriteTBD(_), _) => TString
     case _ => throw new UnsupportedExtraction(this.toString)
   }
 

--- a/hail/hail/src/is/hail/expr/ir/AggOp.scala
+++ b/hail/hail/src/is/hail/expr/ir/AggOp.scala
@@ -30,7 +30,7 @@ final case class ImputeType() extends AggOp
 final case class NDArraySum() extends AggOp
 final case class NDArrayMultiplyAdd() extends AggOp
 final case class Fold() extends AggOp
-final case class WriteTBD(codec: TypedCodecSpec, indexKey: Option[PStruct]) extends AggOp
+final case class WriteRows(codec: TypedCodecSpec, indexKey: Option[PStruct]) extends AggOp
 
 // exists === map(p).sum, needs short-circuiting aggs
 // forall === map(p).product, needs short-circuiting aggs
@@ -58,7 +58,7 @@ object AggOp {
     case (Downsample(), Seq(_, _, _)) => DownsampleAggregator.resultType
     case (NDArraySum(), Seq(t)) => t
     case (NDArrayMultiplyAdd(), Seq(a: TNDArray, _)) => a
-    case (WriteTBD(_, _), _) => TString
+    case (WriteRows(_, _), _) => TString
     case _ => throw new UnsupportedExtraction(this.toString)
   }
 

--- a/hail/hail/src/is/hail/expr/ir/AggOp.scala
+++ b/hail/hail/src/is/hail/expr/ir/AggOp.scala
@@ -32,6 +32,9 @@ final case class NDArrayMultiplyAdd() extends AggOp
 final case class Fold() extends AggOp
 final case class WriteRows(codec: TypedCodecSpec, indexKey: Option[PStruct]) extends AggOp
 
+// TODO
+// final case class WriteSplitRows(codec, indexKey, entries)
+
 // exists === map(p).sum, needs short-circuiting aggs
 // forall === map(p).product, needs short-circuiting aggs
 

--- a/hail/hail/src/is/hail/expr/ir/AggOp.scala
+++ b/hail/hail/src/is/hail/expr/ir/AggOp.scala
@@ -2,9 +2,9 @@ package is.hail.expr.ir
 
 import is.hail.collection.FastSeq
 import is.hail.expr.ir.agg._
-import is.hail.types.virtual._
-import is.hail.types.physical.PStruct
 import is.hail.io.TypedCodecSpec
+import is.hail.types.physical.PStruct
+import is.hail.types.virtual._
 
 sealed trait AggOp {}
 final case class ApproxCDF() extends AggOp

--- a/hail/hail/src/is/hail/expr/ir/AggOp.scala
+++ b/hail/hail/src/is/hail/expr/ir/AggOp.scala
@@ -32,8 +32,13 @@ final case class NDArrayMultiplyAdd() extends AggOp
 final case class Fold() extends AggOp
 final case class WriteRows(codec: TypedCodecSpec, indexKey: Option[PStruct]) extends AggOp
 
-// TODO
-// final case class WriteSplitRows(codec, indexKey, entries)
+// FIXME full row type not needed, just pass rows/entries separately
+final case class WriteSplitRows(
+  fullRowType: TStruct,
+  rowsCodec: TypedCodecSpec,
+  entriesCodec: TypedCodecSpec,
+  indexKey: PStruct,
+) extends AggOp
 
 // exists === map(p).sum, needs short-circuiting aggs
 // forall === map(p).product, needs short-circuiting aggs
@@ -61,7 +66,7 @@ object AggOp {
     case (Downsample(), Seq(_, _, _)) => DownsampleAggregator.resultType
     case (NDArraySum(), Seq(t)) => t
     case (NDArrayMultiplyAdd(), Seq(a: TNDArray, _)) => a
-    case (WriteRows(_, _), _) => TString
+    case (WriteRows(_, _), _) | (WriteSplitRows(_, _, _, _), _) => TString
     case _ => throw new UnsupportedExtraction(this.toString)
   }
 

--- a/hail/hail/src/is/hail/expr/ir/IR.scala
+++ b/hail/hail/src/is/hail/expr/ir/IR.scala
@@ -441,7 +441,6 @@ package defs {
       new DefaultFormats() {
         override val typeHints = ShortTypeHints(
           List(
-            classOf[PartitionNativeWriter],
             classOf[TableTextPartitionWriter],
             classOf[VCFPartitionWriter],
             classOf[GenSampleWriter],

--- a/hail/hail/src/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/MatrixWriter.scala
@@ -2,7 +2,6 @@ package is.hail.expr.ir
 
 import is.hail.annotations.{Region, RowSeq}
 import is.hail.asm4s._
-import is.hail.asm4s.implicits.{valueToRichCodeOutputBuffer, valueToRichCodeRegion}
 import is.hail.backend.ExecuteContext
 import is.hail.collection.{ByteArrayBuilder, FastSeq}
 import is.hail.collection.compat.immutable.ArraySeq
@@ -15,7 +14,6 @@ import is.hail.io._
 import is.hail.io.bgen.BgenSettings
 import is.hail.io.fs.FS
 import is.hail.io.gen.{BgenWriter, ExportGen}
-import is.hail.io.index.StagedIndexWriter
 import is.hail.io.plink.{BitPacker, ExportPlink}
 import is.hail.io.vcf.{ExportVCF, TabixVCF}
 import is.hail.linalg.{BlockMatrix, MatrixSparsity}
@@ -23,7 +21,7 @@ import is.hail.rvd.{IndexSpec, RVDPartitioner, RVDSpecMaker}
 import is.hail.types._
 import is.hail.types.encoded.{EBaseStruct, EBlockMatrixNDArray, EType}
 import is.hail.types.physical._
-import is.hail.types.physical.stypes.{EmitType, SValue}
+import is.hail.types.physical.stypes.SValue
 import is.hail.types.physical.stypes.concrete.{
   SJavaArrayString, SJavaArrayStringValue, SJavaString, SStackStruct,
 }
@@ -31,7 +29,6 @@ import is.hail.types.physical.stypes.interfaces._
 import is.hail.types.physical.stypes.primitives._
 import is.hail.types.virtual._
 import is.hail.utils._
-import is.hail.utils.implicits.ByteTrackingOutputStream
 import is.hail.variant.{Call, ReferenceGenome}
 
 import java.io.{InputStream, OutputStream}
@@ -140,15 +137,6 @@ object MatrixNativeWriter {
     val partitioner = lowered.partitioner
     val pKey: PStruct = tcoerce[PStruct](rowSpec.decodedPType(partitioner.kType))
 
-    val rowWriter = SplitPartitionNativeWriter(
-      rowSpec,
-      s"$path/rows/rows/parts/",
-      entrySpec,
-      s"$path/entries/rows/parts/",
-      pKey.virtualType.fieldNames,
-      Some(s"$path/index/" -> pKey),
-    )
-
     new MatrixWriterComponents {
 
       override val stage: TableStage =
@@ -175,11 +163,53 @@ object MatrixNativeWriter {
           WriteMetadata(Void(), RelationalSetup(s"$path/entries", overwrite = false, None)),
         ))
 
-      override def writePartitionType: Type =
-        rowWriter.returnType
+      override def writePartitionType: Type = TStruct(
+        "filePath" -> TString,
+        "partitionCounts" -> TInt64,
+        "distinctlyKeyed" -> TBoolean,
+        "firstKey" -> pKey.virtualType,
+        "lastKey" -> pKey.virtualType,
+      )
 
-      override def writePartition(rows: Atom, ctx: Atom): IR =
-        WritePartition(rows, GetField(ctx, "writeCtx") + UUID4(), rowWriter)
+      override def writePartition(rows: Atom, ctx: Atom): IR = M.eval {
+        for {
+          partFile <- GetField(ctx, "writeCtx") + UUID4()
+          partResult <- streamAggIR(rows) { row =>
+            assert(row.typ.isInstanceOf[TStruct])
+            val rowPartsRoot = Str(s"$path/rows/rows/parts/")
+            val entryPartsRoot = Str(s"$path/entries/rows/parts/")
+            val indexRoot = Str(s"$path/index/")
+            val initOpArgs: Seq[IR] = Seq(partFile, rowPartsRoot, entryPartsRoot, indexRoot)
+            val zero = makestruct(
+              "distinct" -> !pKey.fieldNames.isEmpty,
+              "firstKey" -> NA(pKey.virtualType),
+              "lastKey" -> NA(pKey.virtualType),
+            )
+            makestruct(
+              "partpath" -> ApplyAggOp(
+                WriteSplitRows(tablestage.rowType, rowSpec, entrySpec, pKey),
+                initOpArgs: _*
+              )(row),
+              "partitionCounts" -> ApplyAggOp(Count())(),
+              "keyMeta" -> aggFoldIR(zero) { accum =>
+                bindIRs(SelectFields(row, pKey.fieldNames), GetField(accum, "lastKey")) {
+                  case Seq(key, prev) =>
+                    makestruct(
+                      "distinct" -> (GetField(accum, "distinct") && Coalesce(FastSeq(
+                        prev.cne(key),
+                        True(),
+                      ))),
+                      "firstKey" -> Coalesce(FastSeq(GetField(accum, "firstKey"), key)),
+                      "lastKey" -> Coalesce(FastSeq(key, prev)),
+                    )
+                }
+              } { (accum1, accum2) =>
+                Die("unreachable: calling combop on writer fold makes no sense", zero.typ)
+              },
+            )
+          }
+        } yield TableWriter.resultHelper(partResult)
+      }
 
       override def finalizeWrite(parts: Atom, globals: Atom): IR =
         M.eval {
@@ -366,231 +396,6 @@ case class MatrixNativeWriter(
         components.writePartition
       )(components.finalizeWrite),
     ))
-  }
-}
-
-case class SplitPartitionNativeWriter(
-  spec1: AbstractTypedCodecSpec,
-  partPrefix1: String,
-  spec2: AbstractTypedCodecSpec,
-  partPrefix2: String,
-  keyFieldNames: IndexedSeq[String],
-  index: Option[(String, PStruct)],
-) extends PartitionWriter {
-
-  val keyType = spec1.encodedVirtualType.asInstanceOf[TStruct].select(keyFieldNames)._1
-
-  override def ctxType: Type = TString
-
-  override def returnType: Type = TStruct(
-    "filePath" -> TString,
-    "partitionCounts" -> TInt64,
-    "distinctlyKeyed" -> TBoolean,
-    "firstKey" -> keyType,
-    "lastKey" -> keyType,
-  )
-
-  override def unionTypeRequiredness(
-    r: TypeWithRequiredness,
-    ctxType: TypeWithRequiredness,
-    streamType: RIterable,
-  ): Unit = {
-    val rs = r.asInstanceOf[RStruct]
-    val rKeyType = streamType.elementType.asInstanceOf[RStruct].select(keyFieldNames)
-    rs.field("firstKey").union(false)
-    rs.field("firstKey").unionFrom(rKeyType)
-    rs.field("lastKey").union(false)
-    rs.field("lastKey").unionFrom(rKeyType)
-    r.union(ctxType.required)
-    r.union(streamType.required)
-  }
-
-  override def consumeStream(
-    ctx: ExecuteContext,
-    cb: EmitCodeBuilder,
-    stream: StreamProducer,
-    context: EmitCode,
-    region: Value[Region],
-  ): IEmitCode = {
-    val iAnnotationType = PCanonicalStruct(required = true, "entries_offset" -> PInt64())
-    val mb = cb.emb
-
-    val writeIndexInfo = index.map { case (name, ktype) =>
-      val bfactor = Option(mb.ctx.getFlag("index_branching_factor")).map(_.toInt).getOrElse(4096)
-      (
-        name,
-        ktype,
-        StagedIndexWriter.withDefaults(
-          ktype,
-          mb.ecb,
-          annotationType = iAnnotationType,
-          branchingFactor = bfactor,
-        ),
-      )
-    }
-
-    context.toI(cb).map(cb) { pctx =>
-      val ctxValue = pctx.asString.loadString(cb)
-      val buffers =
-        FastSeq(partPrefix1, partPrefix2)
-          .map(const)
-          .zipWithIndex
-          .map { case (prefix, i) =>
-            val filename = mb.newLocal[String](s"filename$i")
-            cb.assign(filename, prefix.concat(ctxValue))
-
-            val ostream = mb.newLocal[ByteTrackingOutputStream](s"write_os$i")
-            cb.assign(
-              ostream,
-              Code.newInstance[ByteTrackingOutputStream, OutputStream](
-                mb.createUnbuffered(filename.get)
-              ),
-            )
-
-            val buffer = mb.newLocal[OutputBuffer](s"write_ob$i")
-            cb.assign(buffer, spec1.buildCodeOutputBuffer(Code.checkcast[OutputStream](ostream)))
-
-            buffer
-          }
-
-      writeIndexInfo.foreach { case (name, _, writer) =>
-        val indexFile = cb.newLocal[String]("indexFile")
-        cb.assign(indexFile, const(name).concat(ctxValue).concat(".idx"))
-        writer.init(cb, indexFile, cb.memoize(mb.getObject[Map[String, Any]](Map.empty)))
-      }
-
-      val pCount = mb.newLocal[Long]("partition_count")
-      cb.assign(pCount, 0L)
-
-      // True until proven otherwise, if there's a key to care about all.
-      val distinctlyKeyed = mb.newLocal[Boolean]("distinctlyKeyed")
-      cb.assign(distinctlyKeyed, keyFieldNames.nonEmpty)
-
-      val keyEmitType = EmitType(spec1.decodedPType(keyType).sType, false)
-
-      val firstSeenSettable = mb.newEmitLocal("pnw_firstSeen", keyEmitType)
-      val lastSeenSettable = mb.newEmitLocal("pnw_lastSeen", keyEmitType)
-      val lastSeenRegion = cb.newLocal[Region]("last_seen_region")
-
-      // Start off missing, we will use this to determine if we haven't processed any rows yet.
-      cb.assign(firstSeenSettable, EmitCode.missing(cb.emb, keyEmitType.st))
-      cb.assign(lastSeenSettable, EmitCode.missing(cb.emb, keyEmitType.st))
-      cb.assign(lastSeenRegion, Region.stagedCreate(Region.TINY, region.getPool()))
-
-      val specs = FastSeq(spec1, spec2)
-      stream.memoryManagedConsume(region, cb) { cb =>
-        val row = stream.element.toI(cb).getOrFatal(cb, "row can't be missing").asBaseStruct
-
-        writeIndexInfo.foreach { case (_, keyType, writer) =>
-          writer.add(
-            cb, {
-              IEmitCode.present(
-                cb,
-                keyType.asInstanceOf[PCanonicalBaseStruct]
-                  .constructFromFields(
-                    cb,
-                    stream.elementRegion,
-                    keyType.fields.map { f =>
-                      EmitCode.fromI(cb.emb)(cb => row.loadField(cb, f.name))
-                    },
-                    deepCopy = false,
-                  ),
-              )
-            },
-            buffers(0).invoke[Long]("indexOffset"), {
-              IEmitCode.present(
-                cb,
-                iAnnotationType.constructFromFields(
-                  cb,
-                  stream.elementRegion,
-                  FastSeq(EmitCode.present(
-                    cb.emb,
-                    primitive(cb.memoize(buffers(1).invoke[Long]("indexOffset"))),
-                  )),
-                  deepCopy = false,
-                ),
-              )
-            },
-          )
-        }
-
-        val key = SStackStruct.constructFromArgs(
-          cb,
-          stream.elementRegion,
-          keyType,
-          keyType.fields.map(f => EmitCode.fromI(cb.emb)(cb => row.loadField(cb, f.name))): _*
-        )
-
-        if (keyFieldNames.nonEmpty) {
-          cb.if_(
-            distinctlyKeyed, {
-              lastSeenSettable.loadI(cb).consume(
-                cb,
-                // If there's no last seen, we are in the first row.
-                cb.assign(
-                  firstSeenSettable,
-                  EmitValue.present(key.copyToRegion(cb, region, firstSeenSettable.st)),
-                ),
-                { _ =>
-                  val comparator = EQ.codeOrdering(
-                    cb.emb.ecb,
-                    lastSeenSettable.st,
-                    key.st,
-                  )
-                  val equalToLast = comparator(cb, lastSeenSettable, EmitValue.present(key))
-                  cb.if_(
-                    equalToLast.asInstanceOf[Value[Boolean]],
-                    cb.assign(distinctlyKeyed, false),
-                  )
-                },
-              )
-            },
-          )
-          cb += lastSeenRegion.clearRegion()
-          cb.assign(
-            lastSeenSettable,
-            IEmitCode.present(cb, key.copyToRegion(cb, lastSeenRegion, lastSeenSettable.st)),
-          )
-        }
-
-        buffers.zip(specs).foreach { case (buff, spec) =>
-          cb += buff.writeByte(1.asInstanceOf[Byte])
-          spec.encodedType.buildEncoder(row.st, cb.emb.ecb).apply(cb, row, buff)
-        }
-
-        cb.assign(pCount, pCount + 1L)
-      }
-
-      writeIndexInfo.foreach(_._3.close(cb))
-
-      buffers.foreach { buff =>
-        cb += buff.writeByte(0.asInstanceOf[Byte])
-        cb += buff.flush()
-        cb += buff.close()
-      }
-
-      lastSeenSettable.loadI(cb).consume(
-        cb,
-        { /* do nothing */ },
-        lastSeen =>
-          cb.assign(
-            lastSeenSettable,
-            IEmitCode.present(cb, lastSeen.copyToRegion(cb, region, lastSeenSettable.st)),
-          ),
-      )
-      cb += lastSeenRegion.invalidate()
-
-      SStackStruct.constructFromArgs(
-        cb,
-        region,
-        returnType.asInstanceOf[TBaseStruct],
-        EmitCode.present(mb, pctx),
-        EmitCode.present(mb, new SInt64Value(pCount)),
-        EmitCode.present(mb, new SBooleanValue(distinctlyKeyed)),
-        firstSeenSettable,
-        lastSeenSettable,
-      )
-    }
   }
 }
 

--- a/hail/hail/src/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/MatrixWriter.scala
@@ -186,27 +186,25 @@ object MatrixNativeWriter {
           for {
             partFile <- Str(partFile(1, 0))
             // parts is array<struct> of partition results
-            writeEmpty <- WritePartition(
+            writeEmpty <- TableWriter.writerHelper(
+              emptySpec,
               MakeStream(makestruct()),
               partFile,
-              PartitionNativeWriter(
-                emptySpec,
-                FastSeq(),
-                s"$path/globals/globals/parts/",
-                None,
-              ),
+              Str(s"$path/globals/globals/parts/"),
             )
 
-            colInfo <- WritePartition(
+            colInfo <- TableWriter.writerHelper(
+              colSpec,
               ToStream(GetField(globals, colsFieldName)),
               partFile,
-              PartitionNativeWriter(colSpec, FastSeq(), s"$path/cols/rows/parts/", None),
+              Str(s"$path/cols/rows/parts/"),
             )
 
-            writeGlobals <- WritePartition(
+            writeGlobals <- TableWriter.writerHelper(
+              globalSpec,
               MakeStream(SelectFields(globals, tm.globalType.fieldNames)),
               partFile,
-              PartitionNativeWriter(globalSpec, FastSeq(), s"$path/globals/rows/parts/", None),
+              Str(s"$path/globals/rows/parts/"),
             )
 
             _ <- WriteMetadata(

--- a/hail/hail/src/is/hail/expr/ir/TableWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableWriter.scala
@@ -1035,7 +1035,7 @@ case class TableNativeFanoutWriter(
       bindIR(GetField(ctxRef, "writeCtx") + UUID4()) { partFile =>
         val partResult = streamAggIR(rows) { row =>
           maketuple(targets.map { target =>
-            bindIR(SelectFields(row, target.tableType.rowType.fieldNames)) { targetRow =>
+            aggBindIR(SelectFields(row, target.tableType.rowType.fieldNames)) { targetRow =>
               val partRoot = Str(s"${target.path}/rows/parts/")
               val indexRoot = Str(s"${target.path}/index/")
               TableWriter.rowWriterHelper(
@@ -1048,9 +1048,11 @@ case class TableNativeFanoutWriter(
             }
           }: _*)
         }
-        maketuple((0 until targets.length).map { i =>
-          bindIR(GetTupleElement(partResult, i))(TableWriter.resultHelper(_))
-        }: _*)
+        bindIR(partResult) { partResult =>
+          maketuple((0 until targets.length).map { i =>
+            bindIR(GetTupleElement(partResult, i))(TableWriter.resultHelper(_))
+          }: _*)
+        }
       }
     } { (parts, globals) =>
       bindIR(parts) { fileCountAndDistinct =>

--- a/hail/hail/src/is/hail/expr/ir/TableWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableWriter.scala
@@ -47,12 +47,26 @@ object TableWriter {
 
   def writerHelper(
     rowSpec: TypedCodecSpec,
-    pKey: PStruct,
+    rows: IR,
+    partFile: IR,
+    partRoot: IR,
+    indexInfo: Option[(PStruct, IR)] = None,
+  ): IR = {
+    val partResult = streamAggIR(rows) { row =>
+      TableWriter.writerHelper(rowSpec, row, partFile, partRoot, indexInfo)
+    }
+    bindIR(partResult)(TableWriter.resultHelper(_))
+  }
+
+  def rowWriterHelper(
+    rowSpec: TypedCodecSpec,
     row: Atom,
     partFile: IR,
     partRoot: IR,
-    indexRoot: IR,
+    indexInfo: Option[(PStruct, IR)] = None,
   ): IR = {
+    val pKey = indexInfo.map(_._1).getOrElse(PCanonicalStruct())
+    val initOpArgs = Seq(partFile, partRoot) ++ indexInfo.map(_._2)
     val zero = makestruct(
       "distinct" -> !pKey.fieldNames.isEmpty,
       "firstKey" -> NA(pKey.virtualType),
@@ -60,10 +74,8 @@ object TableWriter {
     )
     makestruct(
       "partpath" -> ApplyAggOp(
-        WriteTBD(rowSpec, Some(pKey)),
-        partFile,
-        partRoot,
-        indexRoot,
+        WriteTBD(rowSpec, indexInfo.map(_._1)),
+        initOpArgs: _*
       )(row),
       "partitionCounts" -> ApplyAggOp(Count())(),
       "keyMeta" -> aggFoldIR(zero) { accum =>
@@ -124,8 +136,6 @@ object TableNativeWriter {
     val partitioner = ts.partitioner
     val pKey: PStruct = tcoerce[PStruct](rowSpec.decodedPType(partitioner.kType))
 
-    val globalWriter =
-      PartitionNativeWriter(globalSpec, IndexedSeq(), s"$path/globals/parts/", None)
     RelationalWriter.scoped(path, overwrite, Some(ts.tableType))(
       ts.mapContexts { oldCtx =>
         val d = digitsNeeded(ts.numPartitions)
@@ -145,16 +155,14 @@ object TableNativeWriter {
           bindIR(GetField(ctxRef, "writeCtx") + UUID4()) { partFile =>
             val partRoot = Str(s"$path/rows/parts/")
             val indexRoot = Str(s"$path/index/")
-            val partResult = streamAggIR(rows) { row =>
-              TableWriter.writerHelper(rowSpec, pKey, row, partFile, partRoot, indexRoot)
-            }
-            bindIR(partResult)(TableWriter.resultHelper(_))
+            TableWriter.writerHelper(rowSpec, rows, partFile, partRoot, Some(pKey -> indexRoot))
           }
       } { (parts, globals) =>
-        val writeGlobals = WritePartition(
+        val writeGlobals = TableWriter.writerHelper(
+          globalSpec,
           MakeStream(globals),
           Str(partFile(1, 0)),
-          globalWriter,
+          Str(s"$path/globals/parts/"),
         )
 
         bindIR(parts) { fileCountAndDistinct =>

--- a/hail/hail/src/is/hail/expr/ir/TableWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableWriter.scala
@@ -3,7 +3,6 @@ package is.hail.expr.ir
 import is.hail.PrettyVersion
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.asm4s.implicits.{valueToRichCodeOutputBuffer, valueToRichCodeRegion}
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
 import is.hail.collection.compat.immutable.ArraySeq
@@ -12,23 +11,19 @@ import is.hail.expr.TableAnnotationImpex
 import is.hail.expr.ir.defs._
 import is.hail.expr.ir.functions.StringFunctions
 import is.hail.expr.ir.lowering.TableStage
-import is.hail.expr.ir.streams.StreamProducer
-import is.hail.io.{AbstractTypedCodecSpec, BufferSpec, OutputBuffer, TypedCodecSpec}
+import is.hail.io.{BufferSpec, TypedCodecSpec}
 import is.hail.io.fs.FS
-import is.hail.io.index.StagedIndexWriter
 import is.hail.rvd.{AbstractRVDSpec, IndexSpec, RVDPartitioner, RVDSpecMaker}
 import is.hail.types._
 import is.hail.types.encoded.EType
 import is.hail.types.physical._
-import is.hail.types.physical.stypes.{EmitType, SCode, SValue}
+import is.hail.types.physical.stypes.EmitType
 import is.hail.types.physical.stypes.concrete.{
-  SJavaArrayString, SJavaArrayStringValue, SStackStruct,
+  SJavaArrayString, SJavaArrayStringValue,
 }
 import is.hail.types.physical.stypes.interfaces._
-import is.hail.types.physical.stypes.primitives.{SBooleanValue, SInt64, SInt64Value}
 import is.hail.types.virtual._
 import is.hail.utils._
-import is.hail.utils.implicits.ByteTrackingOutputStream
 import is.hail.variant.ReferenceGenome
 
 import java.io.{BufferedOutputStream, OutputStream, OutputStreamWriter}
@@ -51,10 +46,11 @@ object TableWriter {
     partFile: IR,
     partRoot: IR,
     indexInfo: Option[(PStruct, IR)] = None,
+    trackTotalBytes: Boolean = false
   ): IR = {
     val partResult = streamAggIR(rows) { row =>
       assert(row.typ.isInstanceOf[TStruct])
-      TableWriter.rowWriterHelper(rowSpec, row, partFile, partRoot, indexInfo)
+      TableWriter.rowWriterHelper(rowSpec, row, partFile, partRoot, indexInfo, trackTotalBytes)
     }
     bindIR(partResult)(TableWriter.resultHelper(_))
   }
@@ -65,6 +61,7 @@ object TableWriter {
     partFile: IR,
     partRoot: IR,
     indexInfo: Option[(PStruct, IR)] = None,
+    trackTotalBytes: Boolean = false,
   ): IR = {
     val pKey = indexInfo.map(_._1).getOrElse(PCanonicalStruct())
     val initOpArgs = Seq(partFile, partRoot) ++ indexInfo.map(_._2)
@@ -73,7 +70,7 @@ object TableWriter {
       "firstKey" -> NA(pKey.virtualType),
       "lastKey" -> NA(pKey.virtualType),
     )
-    makestruct(
+    val args = Seq(
       "partpath" -> ApplyAggOp(
         WriteRows(rowSpec, indexInfo.map(_._1)),
         initOpArgs: _*
@@ -93,19 +90,25 @@ object TableWriter {
         }
       } { (accum1, accum2) =>
         Die("unreachable: calling combop on writer fold makes no sense", zero.typ)
-      },
-    )
+      }) ++ Some("partitionByteSize" -> ApplyAggOp(Sum())(invoke("sizeofValue", TInt64, row))).filter(_ => trackTotalBytes)
+    makestruct(args: _*)
   }
 
   def resultHelper(result: Atom): IR = {
     bindIR(GetField(result, "keyMeta")) { keymeta =>
-      makestruct(
+      val args = Seq(
         "filePath" -> GetField(result, "partpath"),
         "partitionCounts" -> GetField(result, "partitionCounts"),
         "distinctlyKeyed" -> GetField(keymeta, "distinct"),
         "firstKey" -> GetField(keymeta, "firstKey"),
         "lastKey" -> GetField(keymeta, "lastKey"),
-      )
+      ) ++ {
+        if (tcoerce[TStruct](result.typ).hasField("partitionByteSize"))
+          Some("partitionByteSize" -> GetField(result, "partitionByteSize"))
+        else
+          None
+      }
+      makestruct(args: _*)
     }
   }
 }
@@ -230,228 +233,6 @@ case class TableNativeWriter(
     )
 
     TableNativeWriter.lower(ctx, ts, path, overwrite, rowSpec, globalSpec)
-  }
-}
-
-object PartitionNativeWriter {
-  val ctxType = TString
-
-  def fullReturnType(keyType: TStruct): TStruct = TStruct(
-    "filePath" -> TString,
-    "partitionCounts" -> TInt64,
-    "distinctlyKeyed" -> TBoolean,
-    "firstKey" -> keyType,
-    "lastKey" -> keyType,
-    "partitionByteSize" -> TInt64,
-  )
-
-  def returnType(keyType: TStruct, trackTotalBytes: Boolean): TStruct = {
-    val t = PartitionNativeWriter.fullReturnType(keyType)
-    if (trackTotalBytes) t else t.filterSet(Set("partitionByteSize"), include = false)._1
-  }
-}
-
-case class PartitionNativeWriter(
-  spec: AbstractTypedCodecSpec,
-  keyFields: IndexedSeq[String],
-  partPrefix: String,
-  index: Option[(String, PStruct)] = None,
-  trackTotalBytes: Boolean = false,
-) extends PartitionWriter {
-  val keyType = spec.encodedVirtualType.asInstanceOf[TStruct].select(keyFields)._1
-
-  override def ctxType = PartitionNativeWriter.ctxType
-  val returnType = PartitionNativeWriter.returnType(keyType, trackTotalBytes)
-
-  override def unionTypeRequiredness(
-    r: TypeWithRequiredness,
-    ctxType: TypeWithRequiredness,
-    streamType: RIterable,
-  ): Unit = {
-    val rs = r.asInstanceOf[RStruct]
-    val rKeyType = streamType.elementType.asInstanceOf[RStruct].select(keyFields)
-    rs.field("firstKey").union(false)
-    rs.field("firstKey").unionFrom(rKeyType)
-    rs.field("lastKey").union(false)
-    rs.field("lastKey").unionFrom(rKeyType)
-    r.union(ctxType.required)
-    r.union(streamType.required)
-  }
-
-  class StreamConsumer(
-    ctx: SValue,
-    private val cb: EmitCodeBuilder,
-    private val region: Value[Region],
-  ) {
-    private val mb = cb.emb
-
-    private val writeIndexInfo = index.map { case (name, ktype) =>
-      val branchingFactor =
-        Option(mb.ctx.getFlag("index_branching_factor")).map(_.toInt).getOrElse(4096)
-      (
-        name,
-        ktype,
-        StagedIndexWriter.withDefaults(ktype, mb.ecb, branchingFactor = branchingFactor),
-      )
-    }
-
-    private val filename = mb.newLocal[String]("filename")
-
-    private val ob = mb.newLocal[OutputBuffer]("write_ob")
-    private val n = mb.newLocal[Long]("partition_count")
-
-    private val byteCount =
-      if (trackTotalBytes) Some(mb.newPLocal("partition_byte_count", SInt64)) else None
-
-    private val distinctlyKeyed = mb.newLocal[Boolean]("distinctlyKeyed")
-    private val keyEmitType = EmitType(spec.decodedPType(keyType).sType, false)
-    private val firstSeenSettable = mb.newEmitLocal("pnw_firstSeen", keyEmitType)
-    private val lastSeenSettable = mb.newEmitLocal("pnw_lastSeen", keyEmitType)
-    private val lastSeenRegion = mb.newLocal[Region]("last_key_region")
-
-    def setup(): Unit = {
-      cb.assign(
-        distinctlyKeyed,
-        !keyFields.isEmpty,
-      ) // True until proven otherwise, if there's a key to care about at all.
-      // Start off missing, we will use this to determine if we haven't processed any rows yet.
-      cb.assign(firstSeenSettable, EmitCode.missing(cb.emb, keyEmitType.st))
-      cb.assign(lastSeenSettable, EmitCode.missing(cb.emb, keyEmitType.st))
-      cb.assign(lastSeenRegion, Region.stagedCreate(Region.TINY, region.getPool()))
-
-      val ctxValue = ctx.asString.loadString(cb)
-
-      cb.assign(filename, const(partPrefix).concat(ctxValue))
-      writeIndexInfo.foreach { case (indexName, _, writer) =>
-        val indexFile = cb.newLocal[String]("indexFile")
-        cb.assign(indexFile, const(indexName).concat(ctxValue).concat(".idx"))
-        writer.init(cb, indexFile, cb.memoize(mb.getObject[Map[String, Any]](Map.empty)))
-      }
-
-      val os = mb.newLocal[ByteTrackingOutputStream]("write_os")
-      cb.assign(
-        os,
-        Code.newInstance[ByteTrackingOutputStream, OutputStream](
-          mb.create(filename.get)
-        ),
-      )
-      cb.assign(ob, spec.buildCodeOutputBuffer(Code.checkcast[OutputStream](os)))
-      cb.assign(n, 0L)
-    }
-
-    def consumeElement(cb: EmitCodeBuilder, codeRow: SValue, elementRegion: Settable[Region])
-      : Unit = {
-      val row = codeRow.asBaseStruct
-
-      writeIndexInfo.foreach { case (_, indexKeyType, writer) =>
-        writer.add(
-          cb, {
-            IEmitCode.present(
-              cb,
-              indexKeyType.asInstanceOf[PCanonicalBaseStruct]
-                .constructFromFields(
-                  cb,
-                  elementRegion,
-                  indexKeyType.fields.map { f =>
-                    EmitCode.fromI(cb.emb)(cb => row.loadField(cb, f.name))
-                  },
-                  deepCopy = true,
-                ),
-            )
-          },
-          ob.invoke[Long]("indexOffset"),
-          IEmitCode.present(cb, PCanonicalStruct().loadCheapSCode(cb, 0L)),
-        )
-      }
-
-      val key = SStackStruct.constructFromArgs(
-        cb,
-        elementRegion,
-        keyType,
-        keyType.fields.map(f => EmitCode.fromI(cb.emb)(cb => row.loadField(cb, f.name))): _*
-      )
-
-      if (!keyFields.isEmpty) {
-        cb.if_(
-          distinctlyKeyed, {
-            lastSeenSettable.loadI(cb).consume(
-              cb,
-              // If there's no last seen, we are in the first row.
-              cb.assign(
-                firstSeenSettable,
-                EmitValue.present(key.copyToRegion(cb, region, firstSeenSettable.st)),
-              ),
-              { _ =>
-                val comparator = EQ.codeOrdering(
-                  cb.emb.ecb,
-                  lastSeenSettable.st,
-                  key.st,
-                )
-                val equalToLast = comparator(cb, lastSeenSettable, EmitValue.present(key))
-                cb.if_(equalToLast.asInstanceOf[Value[Boolean]], cb.assign(distinctlyKeyed, false))
-              },
-            )
-          },
-        )
-        cb += lastSeenRegion.clearRegion()
-        cb.assign(
-          lastSeenSettable,
-          IEmitCode.present(cb, key.copyToRegion(cb, lastSeenRegion, lastSeenSettable.st)),
-        )
-      }
-
-      cb += ob.writeByte(1.asInstanceOf[Byte])
-
-      spec.encodedType.buildEncoder(row.st, cb.emb.ecb)
-        .apply(cb, row, ob)
-
-      cb.assign(n, n + 1L)
-      byteCount.foreach(bc => cb.assign(bc, SCode.add(cb, bc, row.sizeToStoreInBytes(cb), true)))
-    }
-
-    def result(): SValue = {
-      cb += ob.writeByte(0.asInstanceOf[Byte])
-      writeIndexInfo.foreach(_._3.close(cb))
-      cb += ob.flush()
-      cb += ob.close()
-
-      lastSeenSettable.loadI(cb).consume(
-        cb,
-        { /* do nothing */ },
-        lastSeen =>
-          cb.assign(
-            lastSeenSettable,
-            IEmitCode.present(cb, lastSeen.copyToRegion(cb, region, lastSeenSettable.st)),
-          ),
-      )
-      cb += lastSeenRegion.invalidate()
-      val values = Seq[EmitCode](
-        EmitCode.present(mb, ctx),
-        EmitCode.present(mb, new SInt64Value(n)),
-        EmitCode.present(mb, new SBooleanValue(distinctlyKeyed)),
-        firstSeenSettable,
-        lastSeenSettable,
-      ) ++ byteCount.map(EmitCode.present(mb, _))
-
-      SStackStruct.constructFromArgs(cb, region, returnType.asInstanceOf[TBaseStruct], values: _*)
-    }
-  }
-
-  override def consumeStream(
-    ctx: ExecuteContext,
-    cb: EmitCodeBuilder,
-    stream: StreamProducer,
-    context: EmitCode,
-    region: Value[Region],
-  ): IEmitCode = {
-    val ctx = context.toI(cb).getOrAssert(cb)
-    val consumer = new StreamConsumer(ctx, cb, region)
-    consumer.setup()
-    stream.memoryManagedConsume(region, cb) { cb =>
-      val element = stream.element.toI(cb).getOrFatal(cb, "row can't be missing")
-      consumer.consumeElement(cb, element, stream.elementRegion)
-    }
-    IEmitCode.present(cb, consumer.result())
   }
 }
 

--- a/hail/hail/src/is/hail/expr/ir/TableWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableWriter.scala
@@ -1045,7 +1045,13 @@ case class TableNativeFanoutWriter(
             bindIR(SelectFields(row, target.tableType.rowType.fieldNames)) { targetRow =>
               val partRoot = Str(s"${target.path}/rows/parts/")
               val indexRoot = Str(s"${target.path}/index/")
-              TableWriter.rowWriterHelper(target.rowSpec, targetRow, partFile, partRoot, Some(target.keyPType -> indexRoot))
+              TableWriter.rowWriterHelper(
+                target.rowSpec,
+                targetRow,
+                partFile,
+                partRoot,
+                Some(target.keyPType -> indexRoot),
+              )
             }
           }: _*)
         }

--- a/hail/hail/src/is/hail/expr/ir/TableWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableWriter.scala
@@ -53,7 +53,8 @@ object TableWriter {
     indexInfo: Option[(PStruct, IR)] = None,
   ): IR = {
     val partResult = streamAggIR(rows) { row =>
-      TableWriter.writerHelper(rowSpec, row, partFile, partRoot, indexInfo)
+      assert(row.typ.isInstanceOf[TStruct])
+      TableWriter.rowWriterHelper(rowSpec, row, partFile, partRoot, indexInfo)
     }
     bindIR(partResult)(TableWriter.resultHelper(_))
   }

--- a/hail/hail/src/is/hail/expr/ir/TableWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableWriter.scala
@@ -74,7 +74,7 @@ object TableWriter {
     )
     makestruct(
       "partpath" -> ApplyAggOp(
-        WriteTBD(rowSpec, indexInfo.map(_._1)),
+        WriteRows(rowSpec, indexInfo.map(_._1)),
         initOpArgs: _*
       )(row),
       "partitionCounts" -> ApplyAggOp(Count())(),

--- a/hail/hail/src/is/hail/expr/ir/TableWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableWriter.scala
@@ -977,7 +977,6 @@ class FanoutWriterTarget(
   val rowSpec: TypedCodecSpec,
   val keyPType: PStruct,
   val tableType: TableType,
-  val rowWriter: PartitionNativeWriter,
 )
 
 case class TableNativeFanoutWriter(
@@ -1013,13 +1012,7 @@ case class TableNativeFanoutWriter(
         )
         val keyPType = tcoerce[PStruct](rowSpec.decodedPType(keyType))
         val tableType = TableType(targetRowType, keyFields, ts.globalType)
-        val rowWriter = PartitionNativeWriter(
-          rowSpec,
-          keyFields,
-          s"$targetPath/rows/parts/",
-          Some(s"$targetPath/index/" -> keyPType),
-        )
-        new FanoutWriterTarget(field, targetPath, rowSpec, keyPType, tableType, rowWriter)
+        new FanoutWriterTarget(field, targetPath, rowSpec, keyPType, tableType)
       }
     }
 

--- a/hail/hail/src/is/hail/expr/ir/TableWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableWriter.scala
@@ -72,12 +72,12 @@ object TableNativeWriter {
     // write out partitioner key, which may be stricter than table key
     val partitioner = ts.partitioner
     val pKey: PStruct = tcoerce[PStruct](rowSpec.decodedPType(partitioner.kType))
-    val rowWriter = PartitionNativeWriter(
-      rowSpec,
-      pKey.fieldNames,
-      s"$path/rows/parts/",
-      Some(s"$path/index/" -> pKey),
-    )
+    // val _@rowWriter = PartitionNativeWriter(
+    //  rowSpec,
+    //  pKey.fieldNames,
+    //  s"$path/rows/parts/",
+    //  Some(s"$path/index/" -> pKey),
+    // )
 
     val globalWriter =
       PartitionNativeWriter(globalSpec, IndexedSeq(), s"$path/globals/parts/", None)
@@ -97,8 +97,62 @@ object TableNativeWriter {
         }
       }(GetField(_, "oldCtx")).mapCollectWithContextsAndGlobals("table_native_writer") {
         (rows, ctxRef) =>
-          val file = GetField(ctxRef, "writeCtx")
-          WritePartition(rows, file + UUID4(), rowWriter)
+          bindIR(GetField(ctxRef, "writeCtx") + UUID4()) { file =>
+            val root = s"$path/rows/parts/"
+            val partPath = Str(root) + file + UUID4()
+
+            val zero = makestruct(
+              "distinct" -> !pKey.fieldNames.isEmpty,
+              "firstKey" -> NA(pKey.virtualType),
+              "lastKey" -> NA(pKey.virtualType),
+            )
+            val partResult = streamAggIR(rows) { row =>
+              makestruct(
+                "fullpartpath" -> ApplyAggOp(WriteTBD(rowSpec), partPath)(row),
+                "partitionCounts" -> ApplyAggOp(Count())(),
+                "keyMeta" -> aggFoldIR(zero) { accum =>
+                  bindIRs(SelectFields(row, pKey.fieldNames), GetField(accum, "lastKey")) {
+                    case Seq(key, prev) =>
+                      makestruct(
+                        "distinct" -> (GetField(accum, "distinct") && Coalesce(FastSeq(
+                          prev.cne(key),
+                          True(),
+                        ))),
+                        "firstKey" -> Coalesce(FastSeq(GetField(accum, "firstKey"), key)),
+                        "lastKey" -> Coalesce(FastSeq(key, prev)),
+                      )
+                  }
+                } { (accum1, accum2) =>
+                  Die("unreachable: calling combop on writer fold makes no sense", zero.typ)
+                  /* val stillDistinct = GetField(accum1, "distinct") && GetField( accum2,
+                   * "distinct", ) && Coalesce(FastSeq( GetField(accum1,
+                   * "lastKey").cne(GetField(accum2, "firstKey")), True(), )) val first =
+                   * Coalesce(FastSeq(GetField(accum1, "firstKey"), GetField(accum2, "firstKey")))
+                   * val last =
+                   * Coalesce(FastSeq(GetField(accum2, "lastKey"), GetField(accum1, "lastKey")))
+                   * makestruct( "distinct" -> stillDistinct, "firstKey" -> first, "lastKey" ->
+                   * last, ) */
+                },
+              )
+            }
+            bindIR(partResult) { result =>
+              bindIR(GetField(result, "keyMeta")) { keymeta =>
+                makestruct(
+                  "filePath" -> invoke(
+                    "slice",
+                    TString,
+                    GetField(result, "fullpartpath"),
+                    I32(root.length()),
+                    I32(Int.MaxValue),
+                  ),
+                  "partitionCounts" -> GetField(result, "partitionCounts"),
+                  "distinctlyKeyed" -> GetField(keymeta, "distinct"),
+                  "firstKey" -> GetField(keymeta, "firstKey"),
+                  "lastKey" -> GetField(keymeta, "lastKey"),
+                )
+              }
+            }
+          }
       } { (parts, globals) =>
         val writeGlobals = WritePartition(
           MakeStream(globals),

--- a/hail/hail/src/is/hail/expr/ir/TableWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableWriter.scala
@@ -978,7 +978,6 @@ class FanoutWriterTarget(
   val keyPType: PStruct,
   val tableType: TableType,
   val rowWriter: PartitionNativeWriter,
-  val globalWriter: PartitionNativeWriter,
 )
 
 case class TableNativeFanoutWriter(
@@ -1020,10 +1019,7 @@ case class TableNativeFanoutWriter(
           s"$targetPath/rows/parts/",
           Some(s"$targetPath/index/" -> keyPType),
         )
-        val globalWriter =
-          PartitionNativeWriter(globalSpec, IndexedSeq(), s"$targetPath/globals/parts/", None)
-        new FanoutWriterTarget(field, targetPath, rowSpec, keyPType, tableType, rowWriter,
-          globalWriter)
+        new FanoutWriterTarget(field, targetPath, rowSpec, keyPType, tableType, rowWriter)
       }
     }
 
@@ -1043,23 +1039,32 @@ case class TableNativeFanoutWriter(
     }(
       GetField(_, "oldCtx")
     ).mapCollectWithContextsAndGlobals("table_native_fanout_writer") { (rows, ctxRef) =>
-      val file = GetField(ctxRef, "writeCtx")
-      WritePartition(rows, file + UUID4(), new PartitionNativeFanoutWriter(targets))
+      bindIR(GetField(ctxRef, "writeCtx") + UUID4()) { partFile =>
+        val partResult = streamAggIR(rows) { row =>
+          maketuple(targets.map { target =>
+            bindIR(SelectFields(row, target.tableType.rowType.fieldNames)) { targetRow =>
+              val partRoot = Str(s"${target.path}/rows/parts/")
+              val indexRoot = Str(s"${target.path}/index/")
+              TableWriter.rowWriterHelper(target.rowSpec, targetRow, partFile, partRoot, Some(target.keyPType -> indexRoot))
+            }
+          }: _*)
+        }
+        maketuple((0 until targets.length).map { i =>
+          bindIR(GetTupleElement(partResult, i))(TableWriter.resultHelper(_))
+        }: _*)
+      }
     } { (parts, globals) =>
       bindIR(parts) { fileCountAndDistinct =>
         Begin(targets.zipWithIndex.map { case (target, index) =>
+          val writeGlobals = TableWriter.writerHelper(
+            globalSpec,
+            MakeStream(globals),
+            Str(partFile(1, 0)),
+            Str(s"${target.path}/globals/parts/"),
+          )
           Begin(FastSeq(
             WriteMetadata(
-              MakeArray(
-                GetField(
-                  WritePartition(
-                    MakeStream(globals),
-                    Str(partFile(1, 0)),
-                    target.globalWriter,
-                  ),
-                  "filePath",
-                )
-              ),
+              MakeArray(GetField(writeGlobals, "filePath")),
               RVDSpecWriter(
                 s"${target.path}/globals",
                 RVDSpecMaker(globalSpec, RVDPartitioner.unkeyed(ctx.stateManager, 1)),
@@ -1107,60 +1112,6 @@ case class TableNativeFanoutWriter(
       )(
         rest
       )
-    }
-  }
-}
-
-class PartitionNativeFanoutWriter(
-  targets: IndexedSeq[FanoutWriterTarget]
-) extends PartitionWriter {
-  override def consumeStream(
-    ctx: ExecuteContext,
-    cb: EmitCodeBuilder,
-    stream: StreamProducer,
-    context: EmitCode,
-    region: Value[Region],
-  ): IEmitCode = {
-    val ctx = context.toI(cb).getOrAssert(cb)
-    val consumers = targets.map(target => new target.rowWriter.StreamConsumer(ctx, cb, region))
-
-    consumers.foreach(_.setup())
-    stream.memoryManagedConsume(region, cb) { cb =>
-      val row = stream.element.toI(cb).getOrFatal(cb, "row can't be missing")
-
-      (consumers zip targets).foreach { case (consumer, target) =>
-        consumer.consumeElement(
-          cb,
-          row.asBaseStruct.subset((target.keyPType.fieldNames :+ target.field): _*),
-          stream.elementRegion,
-        )
-      }
-    }
-    IEmitCode.present(
-      cb,
-      SStackStruct.constructFromArgs(
-        cb,
-        region,
-        returnType,
-        consumers.map(consumer => EmitCode.present(cb.emb, consumer.result())): _*
-      ),
-    )
-  }
-
-  override def ctxType = TString
-
-  override def returnType: TTuple =
-    TTuple(targets.map(target => target.rowWriter.returnType): _*)
-
-  override def unionTypeRequiredness(
-    returnType: TypeWithRequiredness,
-    ctxType: TypeWithRequiredness,
-    streamType: RIterable,
-  ): Unit = {
-    val targetReturnTypes = returnType.asInstanceOf[RTuple].fields.map(_.typ)
-
-    ((targetReturnTypes) zip targets).foreach { case (returnType, target) =>
-      target.rowWriter.unionTypeRequiredness(returnType, ctxType, streamType)
     }
   }
 }

--- a/hail/hail/src/is/hail/expr/ir/TableWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableWriter.scala
@@ -108,7 +108,12 @@ object TableNativeWriter {
             )
             val partResult = streamAggIR(rows) { row =>
               makestruct(
-                "partpath" -> ApplyAggOp(WriteTBD(rowSpec, Some(pKey)), partPath, Str(root), Str(s"$path/index/"))(row),
+                "partpath" -> ApplyAggOp(
+                  WriteTBD(rowSpec, Some(pKey)),
+                  partPath,
+                  Str(root),
+                  Str(s"$path/index/"),
+                )(row),
                 "partitionCounts" -> ApplyAggOp(Count())(),
                 "keyMeta" -> aggFoldIR(zero) { accum =>
                   bindIRs(SelectFields(row, pKey.fieldNames), GetField(accum, "lastKey")) {

--- a/hail/hail/src/is/hail/expr/ir/TableWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableWriter.scala
@@ -99,7 +99,7 @@ object TableNativeWriter {
         (rows, ctxRef) =>
           bindIR(GetField(ctxRef, "writeCtx") + UUID4()) { file =>
             val root = s"$path/rows/parts/"
-            val partPath = Str(root) + file + UUID4()
+            val partPath = file + UUID4()
 
             val zero = makestruct(
               "distinct" -> !pKey.fieldNames.isEmpty,
@@ -108,7 +108,7 @@ object TableNativeWriter {
             )
             val partResult = streamAggIR(rows) { row =>
               makestruct(
-                "fullpartpath" -> ApplyAggOp(WriteTBD(rowSpec), partPath)(row),
+                "partpath" -> ApplyAggOp(WriteTBD(rowSpec, Some(pKey)), partPath, Str(root), Str(s"$path/index/"))(row),
                 "partitionCounts" -> ApplyAggOp(Count())(),
                 "keyMeta" -> aggFoldIR(zero) { accum =>
                   bindIRs(SelectFields(row, pKey.fieldNames), GetField(accum, "lastKey")) {
@@ -138,13 +138,7 @@ object TableNativeWriter {
             bindIR(partResult) { result =>
               bindIR(GetField(result, "keyMeta")) { keymeta =>
                 makestruct(
-                  "filePath" -> invoke(
-                    "slice",
-                    TString,
-                    GetField(result, "fullpartpath"),
-                    I32(root.length()),
-                    I32(Int.MaxValue),
-                  ),
+                  "filePath" -> GetField(result, "partpath"),
                   "partitionCounts" -> GetField(result, "partitionCounts"),
                   "distinctlyKeyed" -> GetField(keymeta, "distinct"),
                   "firstKey" -> GetField(keymeta, "firstKey"),

--- a/hail/hail/src/is/hail/expr/ir/TableWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableWriter.scala
@@ -44,6 +44,57 @@ object TableWriter {
       typeHintFieldName = "name",
     )
   }
+
+  def writerHelper(
+    rowSpec: TypedCodecSpec,
+    pKey: PStruct,
+    row: Atom,
+    partFile: IR,
+    partRoot: IR,
+    indexRoot: IR,
+  ): IR = {
+    val zero = makestruct(
+      "distinct" -> !pKey.fieldNames.isEmpty,
+      "firstKey" -> NA(pKey.virtualType),
+      "lastKey" -> NA(pKey.virtualType),
+    )
+    makestruct(
+      "partpath" -> ApplyAggOp(
+        WriteTBD(rowSpec, Some(pKey)),
+        partFile,
+        partRoot,
+        indexRoot,
+      )(row),
+      "partitionCounts" -> ApplyAggOp(Count())(),
+      "keyMeta" -> aggFoldIR(zero) { accum =>
+        bindIRs(SelectFields(row, pKey.fieldNames), GetField(accum, "lastKey")) {
+          case Seq(key, prev) =>
+            makestruct(
+              "distinct" -> (GetField(accum, "distinct") && Coalesce(FastSeq(
+                prev.cne(key),
+                True(),
+              ))),
+              "firstKey" -> Coalesce(FastSeq(GetField(accum, "firstKey"), key)),
+              "lastKey" -> Coalesce(FastSeq(key, prev)),
+            )
+        }
+      } { (accum1, accum2) =>
+        Die("unreachable: calling combop on writer fold makes no sense", zero.typ)
+      },
+    )
+  }
+
+  def resultHelper(result: Atom): IR = {
+    bindIR(GetField(result, "keyMeta")) { keymeta =>
+      makestruct(
+        "filePath" -> GetField(result, "partpath"),
+        "partitionCounts" -> GetField(result, "partitionCounts"),
+        "distinctlyKeyed" -> GetField(keymeta, "distinct"),
+        "firstKey" -> GetField(keymeta, "firstKey"),
+        "lastKey" -> GetField(keymeta, "lastKey"),
+      )
+    }
+  }
 }
 
 abstract class TableWriter {
@@ -91,52 +142,13 @@ object TableNativeWriter {
         }
       }(GetField(_, "oldCtx")).mapCollectWithContextsAndGlobals("table_native_writer") {
         (rows, ctxRef) =>
-          bindIR(GetField(ctxRef, "writeCtx") + UUID4()) { file =>
-            val root = s"$path/rows/parts/"
-            val partPath = file + UUID4()
-
-            val zero = makestruct(
-              "distinct" -> !pKey.fieldNames.isEmpty,
-              "firstKey" -> NA(pKey.virtualType),
-              "lastKey" -> NA(pKey.virtualType),
-            )
+          bindIR(GetField(ctxRef, "writeCtx") + UUID4()) { partFile =>
+            val partRoot = Str(s"$path/rows/parts/")
+            val indexRoot = Str(s"$path/index/")
             val partResult = streamAggIR(rows) { row =>
-              makestruct(
-                "partpath" -> ApplyAggOp(
-                  WriteTBD(rowSpec, Some(pKey)),
-                  partPath,
-                  Str(root),
-                  Str(s"$path/index/"),
-                )(row),
-                "partitionCounts" -> ApplyAggOp(Count())(),
-                "keyMeta" -> aggFoldIR(zero) { accum =>
-                  bindIRs(SelectFields(row, pKey.fieldNames), GetField(accum, "lastKey")) {
-                    case Seq(key, prev) =>
-                      makestruct(
-                        "distinct" -> (GetField(accum, "distinct") && Coalesce(FastSeq(
-                          prev.cne(key),
-                          True(),
-                        ))),
-                        "firstKey" -> Coalesce(FastSeq(GetField(accum, "firstKey"), key)),
-                        "lastKey" -> Coalesce(FastSeq(key, prev)),
-                      )
-                  }
-                } { (accum1, accum2) =>
-                  Die("unreachable: calling combop on writer fold makes no sense", zero.typ)
-                },
-              )
+              TableWriter.writerHelper(rowSpec, pKey, row, partFile, partRoot, indexRoot)
             }
-            bindIR(partResult) { result =>
-              bindIR(GetField(result, "keyMeta")) { keymeta =>
-                makestruct(
-                  "filePath" -> GetField(result, "partpath"),
-                  "partitionCounts" -> GetField(result, "partitionCounts"),
-                  "distinctlyKeyed" -> GetField(keymeta, "distinct"),
-                  "firstKey" -> GetField(keymeta, "firstKey"),
-                  "lastKey" -> GetField(keymeta, "lastKey"),
-                )
-              }
-            }
+            bindIR(partResult)(TableWriter.resultHelper(_))
           }
       } { (parts, globals) =>
         val writeGlobals = WritePartition(

--- a/hail/hail/src/is/hail/expr/ir/TableWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableWriter.scala
@@ -72,12 +72,6 @@ object TableNativeWriter {
     // write out partitioner key, which may be stricter than table key
     val partitioner = ts.partitioner
     val pKey: PStruct = tcoerce[PStruct](rowSpec.decodedPType(partitioner.kType))
-    // val _@rowWriter = PartitionNativeWriter(
-    //  rowSpec,
-    //  pKey.fieldNames,
-    //  s"$path/rows/parts/",
-    //  Some(s"$path/index/" -> pKey),
-    // )
 
     val globalWriter =
       PartitionNativeWriter(globalSpec, IndexedSeq(), s"$path/globals/parts/", None)
@@ -129,14 +123,6 @@ object TableNativeWriter {
                   }
                 } { (accum1, accum2) =>
                   Die("unreachable: calling combop on writer fold makes no sense", zero.typ)
-                  /* val stillDistinct = GetField(accum1, "distinct") && GetField( accum2,
-                   * "distinct", ) && Coalesce(FastSeq( GetField(accum1,
-                   * "lastKey").cne(GetField(accum2, "firstKey")), True(), )) val first =
-                   * Coalesce(FastSeq(GetField(accum1, "firstKey"), GetField(accum2, "firstKey")))
-                   * val last =
-                   * Coalesce(FastSeq(GetField(accum2, "lastKey"), GetField(accum1, "lastKey")))
-                   * makestruct( "distinct" -> stillDistinct, "firstKey" -> first, "lastKey" ->
-                   * last, ) */
                 },
               )
             }

--- a/hail/hail/src/is/hail/expr/ir/TypeCheck.scala
+++ b/hail/hail/src/is/hail/expr/ir/TypeCheck.scala
@@ -490,7 +490,10 @@ object TypeCheck {
           s"${args.map(_.typ)} !=  ${aggSig.initOpTypes}",
         )
       case SeqOp(_, args, aggSig) =>
-        assert(args.map(_.typ) == aggSig.seqOpTypes)
+        assert(
+          args.map(_.typ) == aggSig.seqOpTypes,
+          s"${args.map(_.typ)} !=  ${aggSig.seqOpTypes}\n$aggSig",
+        )
       case _: CombOp =>
       case _: ResultOp =>
       case AggStateValue(_, _) =>

--- a/hail/hail/src/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/Extract.scala
@@ -60,7 +60,7 @@ object AggStateSig {
           seqVTypes.head.setRequired(false)
         ) // set required to false to handle empty aggs
       case NDArrayMultiplyAdd() => NDArrayMultiplyAddStateSig(seqVTypes.head.setRequired(false))
-      case WriteTBD(codecSpec, key) =>
+      case WriteRows(codecSpec, key) =>
         assert(codecSpec.encodedVirtualType == seqVTypes.head.t)
         WriteSig(seqVTypes.head, key)
       case _ => throw new UnsupportedExtraction(op.toString)
@@ -475,7 +475,7 @@ object Extract {
       new NDArrayMultiplyAddAggregator(nda)
     case PhysicalAggSig(Fold(), FoldStateSig(res, accumName, otherAccumName, combOpIR)) =>
       new FoldAggregator(res, accumName, otherAccumName, combOpIR)
-    case PhysicalAggSig(WriteTBD(codec, indexKey), WriteSig(_, _)) =>
+    case PhysicalAggSig(WriteRows(codec, indexKey), WriteSig(_, _)) =>
       new StreamWriterAggregator(codec, indexKey.isDefined)
   }
 

--- a/hail/hail/src/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/Extract.scala
@@ -63,6 +63,9 @@ object AggStateSig {
       case WriteRows(codecSpec, key) =>
         assert(codecSpec.encodedVirtualType == seqVTypes.head.t)
         WriteSig(seqVTypes.head, key)
+      case WriteSplitRows(fullRowType, _, _, key) =>
+        assert(fullRowType == seqVTypes.head.t)
+        WriteSplitSig(seqVTypes.head, key)
       case _ => throw new UnsupportedExtraction(op.toString)
     }
   }
@@ -97,6 +100,7 @@ object AggStateSig {
       new TypedRegionBackedAggState(vWithReq, cb)
     case LinearRegressionStateSig() => new LinearRegressionAggregatorState(cb)
     case WriteSig(_, key) => new StreamWriterState(cb, key)
+    case WriteSplitSig(_, key) => new StreamSplitWriterState(cb, key)
   }
 }
 
@@ -149,6 +153,9 @@ case class FoldStateSig(
 
 case class WriteSig(rowType: VirtualTypeWithReq, indexKey: Option[PStruct])
     extends AggStateSig(ArraySeq(rowType), None)
+
+case class WriteSplitSig(fullRowType: VirtualTypeWithReq, indexKey: PStruct)
+    extends AggStateSig(ArraySeq(fullRowType), None)
 
 object PhysicalAggSig {
   def apply(op: AggOp, state: AggStateSig): PhysicalAggSig = BasicPhysicalAggSig(op, state)
@@ -477,6 +484,8 @@ object Extract {
       new FoldAggregator(res, accumName, otherAccumName, combOpIR)
     case PhysicalAggSig(WriteRows(codec, indexKey), WriteSig(_, _)) =>
       new StreamWriterAggregator(codec, indexKey.isDefined)
+    case PhysicalAggSig(WriteSplitRows(fullType, rowCodec, entryCodec, _), WriteSplitSig(_, _)) =>
+      new StreamSplitWriterAggregator(fullType, rowCodec, entryCodec)
   }
 
   def apply(ctx: ExecuteContext, ir: IR, r: RequirednessAnalysis, isScan: Boolean = false)

--- a/hail/hail/src/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/Extract.scala
@@ -12,6 +12,7 @@ import is.hail.expr.ir._
 import is.hail.expr.ir.defs._
 import is.hail.io.BufferSpec
 import is.hail.types.{tcoerce, TypeWithRequiredness, VirtualTypeWithReq}
+import is.hail.types.physical.PStruct
 import is.hail.types.physical.stypes.EmitType
 import is.hail.types.virtual._
 
@@ -59,9 +60,9 @@ object AggStateSig {
           seqVTypes.head.setRequired(false)
         ) // set required to false to handle empty aggs
       case NDArrayMultiplyAdd() => NDArrayMultiplyAddStateSig(seqVTypes.head.setRequired(false))
-      case WriteTBD(codecSpec) =>
+      case WriteTBD(codecSpec, key) =>
         assert(codecSpec.encodedVirtualType == seqVTypes.head.t)
-        WriteSig(seqVTypes.head)
+        WriteSig(seqVTypes.head, key)
       case _ => throw new UnsupportedExtraction(op.toString)
     }
   }
@@ -95,7 +96,7 @@ object AggStateSig {
       val vWithReq = resultEmitType.typeWithRequiredness
       new TypedRegionBackedAggState(vWithReq, cb)
     case LinearRegressionStateSig() => new LinearRegressionAggregatorState(cb)
-    case WriteSig(_) => new StreamWriterState(cb)
+    case WriteSig(_, key) => new StreamWriterState(cb, key)
   }
 }
 
@@ -146,7 +147,7 @@ case class FoldStateSig(
   combOpIR: IR,
 ) extends AggStateSig(ArraySeq(resultEmitType.typeWithRequiredness), None)
 
-case class WriteSig(rowType: VirtualTypeWithReq) extends AggStateSig(ArraySeq(rowType), None)
+case class WriteSig(rowType: VirtualTypeWithReq, indexKey: Option[PStruct]) extends AggStateSig(ArraySeq(rowType), None)
 
 object PhysicalAggSig {
   def apply(op: AggOp, state: AggStateSig): PhysicalAggSig = BasicPhysicalAggSig(op, state)
@@ -473,8 +474,8 @@ object Extract {
       new NDArrayMultiplyAddAggregator(nda)
     case PhysicalAggSig(Fold(), FoldStateSig(res, accumName, otherAccumName, combOpIR)) =>
       new FoldAggregator(res, accumName, otherAccumName, combOpIR)
-    case PhysicalAggSig(WriteTBD(codec), WriteSig(_)) =>
-      new StreamWriterAggregator(codec)
+    case PhysicalAggSig(WriteTBD(codec, indexKey), WriteSig(_, _)) =>
+      new StreamWriterAggregator(codec, indexKey.isDefined)
   }
 
   def apply(ctx: ExecuteContext, ir: IR, r: RequirednessAnalysis, isScan: Boolean = false)

--- a/hail/hail/src/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/Extract.scala
@@ -147,7 +147,8 @@ case class FoldStateSig(
   combOpIR: IR,
 ) extends AggStateSig(ArraySeq(resultEmitType.typeWithRequiredness), None)
 
-case class WriteSig(rowType: VirtualTypeWithReq, indexKey: Option[PStruct]) extends AggStateSig(ArraySeq(rowType), None)
+case class WriteSig(rowType: VirtualTypeWithReq, indexKey: Option[PStruct])
+    extends AggStateSig(ArraySeq(rowType), None)
 
 object PhysicalAggSig {
   def apply(op: AggOp, state: AggStateSig): PhysicalAggSig = BasicPhysicalAggSig(op, state)

--- a/hail/hail/src/is/hail/expr/ir/agg/Extract.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/Extract.scala
@@ -59,6 +59,9 @@ object AggStateSig {
           seqVTypes.head.setRequired(false)
         ) // set required to false to handle empty aggs
       case NDArrayMultiplyAdd() => NDArrayMultiplyAddStateSig(seqVTypes.head.setRequired(false))
+      case WriteTBD(codecSpec) =>
+        assert(codecSpec.encodedVirtualType == seqVTypes.head.t)
+        WriteSig(seqVTypes.head)
       case _ => throw new UnsupportedExtraction(op.toString)
     }
   }
@@ -92,6 +95,7 @@ object AggStateSig {
       val vWithReq = resultEmitType.typeWithRequiredness
       new TypedRegionBackedAggState(vWithReq, cb)
     case LinearRegressionStateSig() => new LinearRegressionAggregatorState(cb)
+    case WriteSig(_) => new StreamWriterState(cb)
   }
 }
 
@@ -141,6 +145,8 @@ case class FoldStateSig(
   otherAccumName: Name,
   combOpIR: IR,
 ) extends AggStateSig(ArraySeq(resultEmitType.typeWithRequiredness), None)
+
+case class WriteSig(rowType: VirtualTypeWithReq) extends AggStateSig(ArraySeq(rowType), None)
 
 object PhysicalAggSig {
   def apply(op: AggOp, state: AggStateSig): PhysicalAggSig = BasicPhysicalAggSig(op, state)
@@ -467,6 +473,8 @@ object Extract {
       new NDArrayMultiplyAddAggregator(nda)
     case PhysicalAggSig(Fold(), FoldStateSig(res, accumName, otherAccumName, combOpIR)) =>
       new FoldAggregator(res, accumName, otherAccumName, combOpIR)
+    case PhysicalAggSig(WriteTBD(codec), WriteSig(_)) =>
+      new StreamWriterAggregator(codec)
   }
 
   def apply(ctx: ExecuteContext, ir: IR, r: RequirednessAnalysis, isScan: Boolean = false)

--- a/hail/hail/src/is/hail/expr/ir/agg/StreamSplitWriterAggregator.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/StreamSplitWriterAggregator.scala
@@ -1,0 +1,158 @@
+package is.hail.expr.ir.agg
+
+import is.hail.annotations.Region
+import is.hail.asm4s._
+import is.hail.asm4s.implicits.valueToRichCodeOutputBuffer
+import is.hail.backend.ExecuteContext
+import is.hail.collection.compat.immutable.ArraySeq
+import is.hail.expr.ir._
+import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer, TypedCodecSpec}
+import is.hail.io.index.StagedIndexWriter
+import is.hail.types.physical._
+import is.hail.types.physical.stypes.{EmitType, SValue}
+import is.hail.types.physical.stypes.concrete.{SJavaString, SJavaStringValue, SStackStruct}
+import is.hail.types.physical.stypes.interfaces.primitive
+import is.hail.types.virtual._
+import is.hail.utils.fatal
+
+class StreamSplitWriterState(override val kb: EmitClassBuilder[_], indexKey: PStruct)
+    extends AggregatorState {
+  val outbRows: Settable[OutputBuffer] = kb.genFieldThisRef[OutputBuffer]()
+  val outbEntries: Settable[OutputBuffer] = kb.genFieldThisRef[OutputBuffer]()
+  val part: Settable[String] = kb.genFieldThisRef[String]()
+  private val iAnnotationType = PCanonicalStruct(required = true, "entries_offset" -> PInt64())
+
+  val indexWriter = {
+    val branchingFactor =
+      Option(kb.ctx.getFlag("index_branching_factor")).map(_.toInt).getOrElse(4096)
+    StagedIndexWriter.withDefaults(
+      indexKey,
+      kb,
+      annotationType = iAnnotationType,
+      branchingFactor = branchingFactor,
+    )
+  }
+
+  override def storageType = PCanonicalStringRequired
+
+  override def createState(cb: EmitCodeBuilder): Unit = {}
+
+  override def newState(cb: EmitCodeBuilder, off: Value[Long]): Unit = {}
+
+  override def load(
+    cb: EmitCodeBuilder,
+    regionLoader: (EmitCodeBuilder, Value[Region]) => Unit,
+    src: Value[Long],
+  ): Unit = fatal("makes no sense to load a writer's state")
+
+  override def store(
+    cb: EmitCodeBuilder,
+    regionStorer: (EmitCodeBuilder, Value[Region]) => Unit,
+    dest: Value[Long],
+  ): Unit = {}
+
+  override def copyFrom(cb: EmitCodeBuilder, src: Value[Long]): Unit =
+    fatal("writer cannot be copied from address")
+
+  override def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit =
+    fatal("writer cannot be serialized")
+
+  override def deserialize(codec: BufferSpec): (EmitCodeBuilder, Value[InputBuffer]) => Unit =
+    fatal("writer cannot be deserialized")
+
+  private[agg] def addToIndex(cb: EmitCodeBuilder, codeRow: SValue): Unit = {
+    val row = codeRow.asBaseStruct
+    val rowKey = row.subset(indexKey.fieldNames: _*)
+    indexWriter.add(
+      cb,
+      IEmitCode.present(cb, rowKey),
+      outbRows.invoke[Long]("indexOffset"),
+      IEmitCode.present(
+        cb,
+        SStackStruct.constructFromArgs(
+          cb,
+          /*region=*/ null,
+          iAnnotationType.virtualType,
+          EmitCode.present(
+            cb.emb,
+            primitive(cb.memoize(outbEntries.invoke[Long]("indexOffset"))),
+          ),
+        ),
+      ),
+    )
+  }
+}
+
+// FIXME fullRowType not needed, pass rows/entries separately
+class StreamSplitWriterAggregator(
+  fullRowType: TStruct,
+  rowSpec: TypedCodecSpec,
+  entrySpec: TypedCodecSpec,
+) extends StagedAggregator {
+  type State = StreamSplitWriterState
+
+  val initOpTypes: IndexedSeq[Type] = ArraySeq(
+    TString, // partfile base name,
+    TString, // rows path root _with_  'directory' separator
+    TString, // entries path root _with_  'directory' separator
+    TString, // index path root _with_ 'directory' separator
+  )
+
+  // FIXME separate args for rows/entries.
+  val seqOpTypes: IndexedSeq[Type] = ArraySeq(fullRowType)
+  val resultEmitType = EmitType(SJavaString, true)
+
+  override protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
+    val Array(partEC, rowRootEC, entryRootEC, ixrootEC) = init
+
+    val part = partEC.toI(cb).getOrFatal(cb, "part name cannot be missing").asString.loadString(cb)
+    val rowRoot =
+      rowRootEC.toI(cb).getOrFatal(cb, "rows path cannot be missing").asString.loadString(cb)
+    val entryRoot =
+      entryRootEC.toI(cb).getOrFatal(cb, "entries path cannot be missing").asString.loadString(cb)
+    val rowOs = cb.emb.createUnbuffered(rowRoot.concat(part))
+    val entryOs = cb.emb.createUnbuffered(entryRoot.concat(part))
+
+    val indexRoot =
+      ixrootEC.toI(cb).getOrFatal(cb, "index path cannot be missing").asString.loadString(cb)
+    val indexPath = cb.memoize(indexRoot.concat(part).concat(".idx"))
+    state.indexWriter.init(cb, indexPath, cb.memoize(cb.emb.getObject[Map[String, Any]](Map.empty)))
+
+    cb.assign(state.part, part)
+    cb.assign(state.outbRows, rowSpec.buildCodeOutputBuffer(rowOs))
+    cb.assign(state.outbEntries, entrySpec.buildCodeOutputBuffer(entryOs))
+  }
+
+  override protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
+    val Array(fullRowEC) = seq
+    val fullRow = fullRowEC.toI(cb).getOrFatal(cb, "row cannot be missing")
+    val rowsEncoder = rowSpec.encodedType.buildEncoder(fullRow.st, cb.emb.ecb)
+    val entriesEncoder = entrySpec.encodedType.buildEncoder(fullRow.st, cb.emb.ecb)
+
+    state.addToIndex(cb, fullRow)
+    cb += state.outbRows.writeByte(1.asInstanceOf[Byte])
+    cb += state.outbEntries.writeByte(1.asInstanceOf[Byte])
+    rowsEncoder.apply(cb, fullRow, state.outbRows)
+    entriesEncoder.apply(cb, fullRow, state.outbEntries)
+  }
+
+  override protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region])
+    : IEmitCode = {
+    cb += state.outbRows.writeByte(0.asInstanceOf[Byte])
+    cb += state.outbRows.flush()
+    cb += state.outbRows.close()
+    cb += state.outbEntries.writeByte(0.asInstanceOf[Byte])
+    cb += state.outbEntries.flush()
+    cb += state.outbEntries.close()
+    state.indexWriter.close(cb)
+    IEmitCode.present(cb, new SJavaStringValue(state.part))
+  }
+
+  override protected def _combOp(
+    ctx: ExecuteContext,
+    cb: EmitCodeBuilder,
+    region: Value[Region],
+    state: State,
+    other: State,
+  ): Unit = fatal("makes no sense to call a combop on the writer")
+}

--- a/hail/hail/src/is/hail/expr/ir/agg/StreamWriterAggregator.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/StreamWriterAggregator.scala
@@ -2,20 +2,25 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.asm4s.implicits.{valueToRichCodeOutputBuffer, valueToRichCodeRegion}
+import is.hail.asm4s.implicits.{valueToRichCodeOutputBuffer}
 import is.hail.backend.ExecuteContext
 import is.hail.collection.compat.immutable.ArraySeq
 import is.hail.expr.ir._
 import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer, TypedCodecSpec}
+import is.hail.io.index.StagedIndexWriter
 import is.hail.types.physical._
-import is.hail.types.physical.stypes.EmitType
+import is.hail.types.physical.stypes.{EmitType, SValue}
 import is.hail.types.physical.stypes.concrete.{SJavaString, SJavaStringValue}
 import is.hail.types.virtual._
 import is.hail.utils.fatal
 
-class StreamWriterState(override val kb: EmitClassBuilder[_]) extends AggregatorState {
+class StreamWriterState(override val kb: EmitClassBuilder[_], indexKey: Option[PStruct]) extends AggregatorState {
   val outb: Settable[OutputBuffer] = kb.genFieldThisRef[OutputBuffer]()
-  val path: Settable[String] = kb.genFieldThisRef[String]()
+  val part: Settable[String] = kb.genFieldThisRef[String]()
+  val indexWriter = indexKey.map { key =>
+    val branchingFactor = Option(kb.ctx.getFlag("index_branching_factor")).map(_.toInt).getOrElse(4096)
+    StagedIndexWriter.withDefaults(key, kb, branchingFactor = branchingFactor)
+  }
 
   override def storageType = PCanonicalStringRequired
 
@@ -40,20 +45,46 @@ class StreamWriterState(override val kb: EmitClassBuilder[_]) extends Aggregator
   override def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit = ???
 
   override def deserialize(codec: BufferSpec): (EmitCodeBuilder, Value[InputBuffer]) => Unit = ???
+
+  private[agg] def addToIndex(cb: EmitCodeBuilder, codeRow: SValue): Unit = indexWriter.foreach { iw =>
+    val row = codeRow.asBaseStruct
+    val rowKey = row.subset(indexKey.get.fieldNames: _*)
+    iw.add(cb, IEmitCode.present(cb, rowKey), outb.invoke[Long]("indexOffset"),
+          IEmitCode.present(cb, PCanonicalStruct().loadCheapSCode(cb, 0L)))
+  }
 }
 
-class StreamWriterAggregator(spec: TypedCodecSpec) extends StagedAggregator {
+class StreamWriterAggregator(spec: TypedCodecSpec, indexed: Boolean) extends StagedAggregator {
   type State = StreamWriterState
 
-  val initOpTypes: IndexedSeq[Type] = ArraySeq(TString)
+  val initOpTypes: IndexedSeq[Type] = ArraySeq(
+    TString, // partfile base name
+    TString, // path root _with_  'directory' separator
+  ) ++ (if (indexed) Some(TString) else None) // if indexed, index root path _with_ 'directory' separator
   val seqOpTypes: IndexedSeq[Type] = ArraySeq(spec.encodedVirtualType)
   val resultEmitType = EmitType(SJavaString, true)
 
   override protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
-    val Array(pathEC) = init
-    val path = pathEC.toI(cb).getOrFatal(cb, "path cannot be missing").asString.loadString(cb)
-    val os = cb.emb.createUnbuffered(path)
-    cb.assign(state.path, path)
+    val (partEC, rootEC, ixrootEC) = init match {
+      case Array(root, part) =>
+        require(!indexed)
+        (root, part, None)
+      case Array(root, part, ixroot) =>
+        require(indexed)
+        (root, part, Some(ixroot))
+    }
+
+    val root = rootEC.toI(cb).getOrFatal(cb, "path cannot be missing").asString.loadString(cb)
+    val part = partEC.toI(cb).getOrFatal(cb, "part cannot be missing").asString.loadString(cb)
+    val os = cb.emb.createUnbuffered(root.concat(part))
+
+    state.indexWriter.foreach { iw =>
+      val root = ixrootEC.get.toI(cb).getOrFatal(cb, "index path cannot be missing").asString.loadString(cb)
+      val path = cb.memoize(root.concat(part).concat(".idx"))
+      iw.init(cb, path, cb.memoize(cb.emb.getObject[Map[String, Any]](Map.empty)))
+    }
+
+    cb.assign(state.part, part)
     cb.assign(state.outb, spec.buildCodeOutputBuffer(os))
   }
 
@@ -61,16 +92,20 @@ class StreamWriterAggregator(spec: TypedCodecSpec) extends StagedAggregator {
     val Array(rowEC) = seq
     val row = rowEC.toI(cb).getOrFatal(cb, "row cannot be missing")
     val encoder = spec.encodedType.buildEncoder(row.st, cb.emb.ecb)
+
+    state.addToIndex(cb, row)
     cb += state.outb.writeByte(1.asInstanceOf[Byte])
     encoder.apply(cb, row, state.outb)
   }
+
 
   override protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region])
     : IEmitCode = {
     cb += state.outb.writeByte(0.asInstanceOf[Byte])
     cb += state.outb.flush()
     cb += state.outb.close()
-    IEmitCode.present(cb, new SJavaStringValue(state.path))
+    state.indexWriter.foreach(_.close(cb))
+    IEmitCode.present(cb, new SJavaStringValue(state.part))
   }
 
   override protected def _combOp(

--- a/hail/hail/src/is/hail/expr/ir/agg/StreamWriterAggregator.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/StreamWriterAggregator.scala
@@ -41,13 +41,16 @@ class StreamWriterState(override val kb: EmitClassBuilder[_], indexKey: Option[P
     cb: EmitCodeBuilder,
     regionStorer: (EmitCodeBuilder, Value[Region]) => Unit,
     dest: Value[Long],
-  ): Unit = {}
+  ): Unit = fatal("makes no sense to store a writer's state")
 
-  override def copyFrom(cb: EmitCodeBuilder, src: Value[Long]): Unit = ???
+  override def copyFrom(cb: EmitCodeBuilder, src: Value[Long]): Unit =
+    fatal("writer cannot be copied from address")
 
-  override def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit = ???
+  override def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit =
+    fatal("writer cannot be serialized")
 
-  override def deserialize(codec: BufferSpec): (EmitCodeBuilder, Value[InputBuffer]) => Unit = ???
+  override def deserialize(codec: BufferSpec): (EmitCodeBuilder, Value[InputBuffer]) => Unit =
+    fatal("writer cannot be deserialized")
 
   private[agg] def addToIndex(cb: EmitCodeBuilder, codeRow: SValue): Unit =
     indexWriter.foreach { iw =>

--- a/hail/hail/src/is/hail/expr/ir/agg/StreamWriterAggregator.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/StreamWriterAggregator.scala
@@ -41,7 +41,7 @@ class StreamWriterState(override val kb: EmitClassBuilder[_], indexKey: Option[P
     cb: EmitCodeBuilder,
     regionStorer: (EmitCodeBuilder, Value[Region]) => Unit,
     dest: Value[Long],
-  ): Unit = fatal("makes no sense to store a writer's state")
+  ): Unit = {}
 
   override def copyFrom(cb: EmitCodeBuilder, src: Value[Long]): Unit =
     fatal("writer cannot be copied from address")

--- a/hail/hail/src/is/hail/expr/ir/agg/StreamWriterAggregator.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/StreamWriterAggregator.scala
@@ -2,7 +2,7 @@ package is.hail.expr.ir.agg
 
 import is.hail.annotations.Region
 import is.hail.asm4s._
-import is.hail.asm4s.implicits.{valueToRichCodeOutputBuffer}
+import is.hail.asm4s.implicits.valueToRichCodeOutputBuffer
 import is.hail.backend.ExecuteContext
 import is.hail.collection.compat.immutable.ArraySeq
 import is.hail.expr.ir._
@@ -14,11 +14,14 @@ import is.hail.types.physical.stypes.concrete.{SJavaString, SJavaStringValue}
 import is.hail.types.virtual._
 import is.hail.utils.fatal
 
-class StreamWriterState(override val kb: EmitClassBuilder[_], indexKey: Option[PStruct]) extends AggregatorState {
+class StreamWriterState(override val kb: EmitClassBuilder[_], indexKey: Option[PStruct])
+    extends AggregatorState {
   val outb: Settable[OutputBuffer] = kb.genFieldThisRef[OutputBuffer]()
   val part: Settable[String] = kb.genFieldThisRef[String]()
+
   val indexWriter = indexKey.map { key =>
-    val branchingFactor = Option(kb.ctx.getFlag("index_branching_factor")).map(_.toInt).getOrElse(4096)
+    val branchingFactor =
+      Option(kb.ctx.getFlag("index_branching_factor")).map(_.toInt).getOrElse(4096)
     StagedIndexWriter.withDefaults(key, kb, branchingFactor = branchingFactor)
   }
 
@@ -46,12 +49,17 @@ class StreamWriterState(override val kb: EmitClassBuilder[_], indexKey: Option[P
 
   override def deserialize(codec: BufferSpec): (EmitCodeBuilder, Value[InputBuffer]) => Unit = ???
 
-  private[agg] def addToIndex(cb: EmitCodeBuilder, codeRow: SValue): Unit = indexWriter.foreach { iw =>
-    val row = codeRow.asBaseStruct
-    val rowKey = row.subset(indexKey.get.fieldNames: _*)
-    iw.add(cb, IEmitCode.present(cb, rowKey), outb.invoke[Long]("indexOffset"),
-          IEmitCode.present(cb, PCanonicalStruct().loadCheapSCode(cb, 0L)))
-  }
+  private[agg] def addToIndex(cb: EmitCodeBuilder, codeRow: SValue): Unit =
+    indexWriter.foreach { iw =>
+      val row = codeRow.asBaseStruct
+      val rowKey = row.subset(indexKey.get.fieldNames: _*)
+      iw.add(
+        cb,
+        IEmitCode.present(cb, rowKey),
+        outb.invoke[Long]("indexOffset"),
+        IEmitCode.present(cb, PCanonicalStruct().loadCheapSCode(cb, 0L)),
+      )
+    }
 }
 
 class StreamWriterAggregator(spec: TypedCodecSpec, indexed: Boolean) extends StagedAggregator {
@@ -60,7 +68,8 @@ class StreamWriterAggregator(spec: TypedCodecSpec, indexed: Boolean) extends Sta
   val initOpTypes: IndexedSeq[Type] = ArraySeq(
     TString, // partfile base name
     TString, // path root _with_  'directory' separator
-  ) ++ (if (indexed) Some(TString) else None) // if indexed, index root path _with_ 'directory' separator
+  ) ++ (if (indexed) Some(TString)
+        else None) // if indexed, index root path _with_ 'directory' separator
   val seqOpTypes: IndexedSeq[Type] = ArraySeq(spec.encodedVirtualType)
   val resultEmitType = EmitType(SJavaString, true)
 
@@ -79,7 +88,8 @@ class StreamWriterAggregator(spec: TypedCodecSpec, indexed: Boolean) extends Sta
     val os = cb.emb.createUnbuffered(root.concat(part))
 
     state.indexWriter.foreach { iw =>
-      val root = ixrootEC.get.toI(cb).getOrFatal(cb, "index path cannot be missing").asString.loadString(cb)
+      val root =
+        ixrootEC.get.toI(cb).getOrFatal(cb, "index path cannot be missing").asString.loadString(cb)
       val path = cb.memoize(root.concat(part).concat(".idx"))
       iw.init(cb, path, cb.memoize(cb.emb.getObject[Map[String, Any]](Map.empty)))
     }
@@ -97,7 +107,6 @@ class StreamWriterAggregator(spec: TypedCodecSpec, indexed: Boolean) extends Sta
     cb += state.outb.writeByte(1.asInstanceOf[Byte])
     encoder.apply(cb, row, state.outb)
   }
-
 
   override protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region])
     : IEmitCode = {

--- a/hail/hail/src/is/hail/expr/ir/agg/StreamWriterAggregator.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/StreamWriterAggregator.scala
@@ -1,0 +1,83 @@
+package is.hail.expr.ir.agg
+
+import is.hail.annotations.Region
+import is.hail.asm4s._
+import is.hail.asm4s.implicits.{valueToRichCodeOutputBuffer, valueToRichCodeRegion}
+import is.hail.backend.ExecuteContext
+import is.hail.collection.compat.immutable.ArraySeq
+import is.hail.expr.ir._
+import is.hail.io.{BufferSpec, InputBuffer, OutputBuffer, TypedCodecSpec}
+import is.hail.types.physical._
+import is.hail.types.physical.stypes.EmitType
+import is.hail.types.physical.stypes.concrete.{SJavaString, SJavaStringValue}
+import is.hail.types.virtual._
+import is.hail.utils.fatal
+
+class StreamWriterState(override val kb: EmitClassBuilder[_]) extends AggregatorState {
+  val outb: Settable[OutputBuffer] = kb.genFieldThisRef[OutputBuffer]()
+  val path: Settable[String] = kb.genFieldThisRef[String]()
+
+  override def storageType = PCanonicalStringRequired
+
+  override def createState(cb: EmitCodeBuilder): Unit = {}
+
+  override def newState(cb: EmitCodeBuilder, off: Value[Long]): Unit = {}
+
+  override def load(
+    cb: EmitCodeBuilder,
+    regionLoader: (EmitCodeBuilder, Value[Region]) => Unit,
+    src: Value[Long],
+  ): Unit = fatal("makes no sense to load a writer's state")
+
+  override def store(
+    cb: EmitCodeBuilder,
+    regionStorer: (EmitCodeBuilder, Value[Region]) => Unit,
+    dest: Value[Long],
+  ): Unit = {}
+
+  override def copyFrom(cb: EmitCodeBuilder, src: Value[Long]): Unit = ???
+
+  override def serialize(codec: BufferSpec): (EmitCodeBuilder, Value[OutputBuffer]) => Unit = ???
+
+  override def deserialize(codec: BufferSpec): (EmitCodeBuilder, Value[InputBuffer]) => Unit = ???
+}
+
+class StreamWriterAggregator(spec: TypedCodecSpec) extends StagedAggregator {
+  type State = StreamWriterState
+
+  val initOpTypes: IndexedSeq[Type] = ArraySeq(TString)
+  val seqOpTypes: IndexedSeq[Type] = ArraySeq(spec.encodedVirtualType)
+  val resultEmitType = EmitType(SJavaString, true)
+
+  override protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
+    val Array(pathEC) = init
+    val path = pathEC.toI(cb).getOrFatal(cb, "path cannot be missing").asString.loadString(cb)
+    val os = cb.emb.createUnbuffered(path)
+    cb.assign(state.path, path)
+    cb.assign(state.outb, spec.buildCodeOutputBuffer(os))
+  }
+
+  override protected def _seqOp(cb: EmitCodeBuilder, state: State, seq: Array[EmitCode]): Unit = {
+    val Array(rowEC) = seq
+    val row = rowEC.toI(cb).getOrFatal(cb, "row cannot be missing")
+    val encoder = spec.encodedType.buildEncoder(row.st, cb.emb.ecb)
+    cb += state.outb.writeByte(1.asInstanceOf[Byte])
+    encoder.apply(cb, row, state.outb)
+  }
+
+  override protected def _result(cb: EmitCodeBuilder, state: State, region: Value[Region])
+    : IEmitCode = {
+    cb += state.outb.writeByte(0.asInstanceOf[Byte])
+    cb += state.outb.flush()
+    cb += state.outb.close()
+    IEmitCode.present(cb, new SJavaStringValue(state.path))
+  }
+
+  override protected def _combOp(
+    ctx: ExecuteContext,
+    cb: EmitCodeBuilder,
+    region: Value[Region],
+    state: State,
+    other: State,
+  ): Unit = fatal("makes no sense to call a combop on the writer")
+}

--- a/hail/hail/src/is/hail/expr/ir/agg/StreamWriterAggregator.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/StreamWriterAggregator.scala
@@ -78,12 +78,12 @@ class StreamWriterAggregator(spec: TypedCodecSpec, indexed: Boolean) extends Sta
 
   override protected def _initOp(cb: EmitCodeBuilder, state: State, init: Array[EmitCode]): Unit = {
     val (partEC, rootEC, ixrootEC) = init match {
-      case Array(root, part) =>
+      case Array(part, root) =>
         require(!indexed)
-        (root, part, None)
-      case Array(root, part, ixroot) =>
+        (part, root, None)
+      case Array(part, root, ixroot) =>
         require(indexed)
-        (root, part, Some(ixroot))
+        (part, root, Some(ixroot))
     }
 
     val root = rootEC.toI(cb).getOrFatal(cb, "path cannot be missing").asString.loadString(cb)

--- a/hail/hail/src/is/hail/expr/ir/functions/UtilFunctions.scala
+++ b/hail/hail/src/is/hail/expr/ir/functions/UtilFunctions.scala
@@ -660,6 +660,13 @@ object UtilFunctions extends RegistryFunctions {
     }
 
     registerSCode1(
+      "sizeofValue",
+      tv("T"),
+      TInt64,
+      (_, _) => SInt64,
+    )((region, cb, st, sv, _) => sv.sizeToStoreInBytes(cb))
+
+    registerSCode1(
       "prefixCode",
       tv("T"),
       TBinary,

--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerDistributedSort.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerDistributedSort.scala
@@ -48,20 +48,20 @@ object LowerDistributedSort extends Logging {
       )
     val reader = PartitionNativeReader(spec, "__dummy_uid")
     val initialTmpPath = ctx.createTmpPath("hail_shuffle_temp_initial")
-    val writer = PartitionNativeWriter(
-      spec,
-      keyToSortBy.fieldNames,
-      initialTmpPath,
-      None,
-      trackTotalBytes = true,
-    )
 
     logger.info("DISTRIBUTED SORT: PHASE 1: WRITE DATA")
     val initialStageData =
       CompileAndEvaluate[Row](
         ctx,
         inputStage.mapCollectWithGlobals("shuffle_initial_write")(
-          WritePartition(_, UUID4(), writer)
+          TableWriter.writerHelper(
+            spec,
+            _,
+            partFile = UUID4(),
+            partRoot = Str(initialTmpPath),
+            indexInfo = None,
+            trackTotalBytes = true
+          )
         ) {
           (part, globals) =>
             maketuple(
@@ -516,7 +516,15 @@ object LowerDistributedSort extends Logging {
               )
             })
 
-          WritePartition(sortedStream, UUID4(), writer)
+
+          TableWriter.writerHelper(
+            spec,
+            sortedStream,
+            partFile = UUID4(),
+            partRoot = Str(initialTmpPath),
+            indexInfo = None,
+            trackTotalBytes = true
+          )
       }
 
     logger.info(s"DISTRIBUTED SORT: PHASE ${i + 1}: LOCALLY SORT FILES")

--- a/hail/hail/src/is/hail/io/BufferSpecs.scala
+++ b/hail/hail/src/is/hail/io/BufferSpecs.scala
@@ -293,13 +293,18 @@ object StreamBlockBufferSpec2 {
 final class StreamBlockBufferSpec2 extends BlockBufferSpec {
   override def buildInputBuffer(in: InputStream): InputBlockBuffer = new StreamBlockInputBuffer2(in)
 
-  override def buildOutputBuffer(out: OutputStream): OutputBlockBuffer = StreamBlockBufferSpec2.buildOutputBuffer(out)
+  override def buildOutputBuffer(out: OutputStream): OutputBlockBuffer =
+    StreamBlockBufferSpec2.buildOutputBuffer(out)
 
   override def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBlockBuffer] =
     Code.newInstance[StreamBlockInputBuffer2, InputStream](in)
 
   override def buildCodeOutputBuffer(out: Code[OutputStream]): Code[OutputBlockBuffer] =
-    Code.invokeScalaObject1[OutputStream, OutputBlockBuffer](StreamBlockBufferSpec2.getClass, "buildOutputBuffer", out)
+    Code.invokeScalaObject1[OutputStream, OutputBlockBuffer](
+      StreamBlockBufferSpec2.getClass,
+      "buildOutputBuffer",
+      out,
+    )
 
   override def equals(other: Any): Boolean = other.isInstanceOf[StreamBlockBufferSpec2]
 }

--- a/hail/hail/src/is/hail/io/BufferSpecs.scala
+++ b/hail/hail/src/is/hail/io/BufferSpecs.scala
@@ -4,6 +4,7 @@ import is.hail.asm4s._
 import is.hail.compatibility.{LEB128BufferSpec, LZ4BlockBufferSpec}
 import is.hail.io.compress.LZ4
 import is.hail.rvd.AbstractRVDSpec
+import is.hail.utils.implicits.ByteTrackingOutputStream
 
 import java.io._
 
@@ -266,8 +267,10 @@ object StreamBlockBufferSpec {
 final class StreamBlockBufferSpec extends BlockBufferSpec {
   override def buildInputBuffer(in: InputStream): InputBlockBuffer = new StreamBlockInputBuffer(in)
 
-  override def buildOutputBuffer(out: OutputStream): OutputBlockBuffer =
-    new StreamBlockOutputBuffer(out)
+  override def buildOutputBuffer(out: OutputStream): OutputBlockBuffer = out match {
+    case out: ByteTrackingOutputStream => new StreamBlockOutputBuffer(out)
+    case out => new StreamBlockOutputBuffer(new ByteTrackingOutputStream(out))
+  }
 
   override def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBlockBuffer] =
     Code.newInstance[StreamBlockInputBuffer, InputStream](in)
@@ -280,19 +283,23 @@ final class StreamBlockBufferSpec extends BlockBufferSpec {
 
 object StreamBlockBufferSpec2 {
   def extract(jv: JValue): StreamBlockBufferSpec2 = new StreamBlockBufferSpec2
+
+  def buildOutputBuffer(out: OutputStream): OutputBlockBuffer = out match {
+    case out: ByteTrackingOutputStream => new StreamBlockOutputBuffer2(out)
+    case out => new StreamBlockOutputBuffer2(new ByteTrackingOutputStream(out))
+  }
 }
 
 final class StreamBlockBufferSpec2 extends BlockBufferSpec {
   override def buildInputBuffer(in: InputStream): InputBlockBuffer = new StreamBlockInputBuffer2(in)
 
-  override def buildOutputBuffer(out: OutputStream): OutputBlockBuffer =
-    new StreamBlockOutputBuffer2(out)
+  override def buildOutputBuffer(out: OutputStream): OutputBlockBuffer = StreamBlockBufferSpec2.buildOutputBuffer(out)
 
   override def buildCodeInputBuffer(in: Code[InputStream]): Code[InputBlockBuffer] =
     Code.newInstance[StreamBlockInputBuffer2, InputStream](in)
 
   override def buildCodeOutputBuffer(out: Code[OutputStream]): Code[OutputBlockBuffer] =
-    Code.newInstance[StreamBlockOutputBuffer2, OutputStream](out)
+    Code.invokeScalaObject1[OutputStream, OutputBlockBuffer](StreamBlockBufferSpec2.getClass, "buildOutputBuffer", out)
 
   override def equals(other: Any): Boolean = other.isInstanceOf[StreamBlockBufferSpec2]
 }

--- a/hail/hail/src/is/hail/io/OutputBuffers.scala
+++ b/hail/hail/src/is/hail/io/OutputBuffers.scala
@@ -250,7 +250,7 @@ final class BlockingOutputBuffer(blockSize: Int, out: OutputBlockBuffer) extends
   }
 }
 
-final class StreamBlockOutputBuffer(out: ByteTrackingOutputStream) extends OutputBlockBuffer {
+final class StreamBlockOutputBuffer(out: OutputStream) extends OutputBlockBuffer {
   private val lenBuf = new Array[Byte](4)
 
   override def flush(): Unit =

--- a/hail/hail/src/is/hail/io/OutputBuffers.scala
+++ b/hail/hail/src/is/hail/io/OutputBuffers.scala
@@ -265,7 +265,7 @@ final class StreamBlockOutputBuffer(out: OutputStream) extends OutputBlockBuffer
     out.write(buf, 0, len)
   }
 
-  override def getPos(): Long = out.bytesWritten
+  override def getPos(): Long = out.asInstanceOf[ByteTrackingOutputStream].bytesWritten
 }
 
 final class StreamBlockOutputBuffer2(out: ByteTrackingOutputStream) extends OutputBlockBuffer {

--- a/hail/hail/src/is/hail/io/OutputBuffers.scala
+++ b/hail/hail/src/is/hail/io/OutputBuffers.scala
@@ -250,7 +250,7 @@ final class BlockingOutputBuffer(blockSize: Int, out: OutputBlockBuffer) extends
   }
 }
 
-final class StreamBlockOutputBuffer(out: OutputStream) extends OutputBlockBuffer {
+final class StreamBlockOutputBuffer(out: ByteTrackingOutputStream) extends OutputBlockBuffer {
   private val lenBuf = new Array[Byte](4)
 
   override def flush(): Unit =
@@ -265,10 +265,10 @@ final class StreamBlockOutputBuffer(out: OutputStream) extends OutputBlockBuffer
     out.write(buf, 0, len)
   }
 
-  override def getPos(): Long = out.asInstanceOf[ByteTrackingOutputStream].bytesWritten
+  override def getPos(): Long = out.bytesWritten
 }
 
-final class StreamBlockOutputBuffer2(out: OutputStream) extends OutputBlockBuffer {
+final class StreamBlockOutputBuffer2(out: ByteTrackingOutputStream) extends OutputBlockBuffer {
   override def flush(): Unit =
     out.flush()
 
@@ -288,7 +288,7 @@ final class StreamBlockOutputBuffer2(out: OutputStream) extends OutputBlockBuffe
     out.write(buf, 0, len)
   }
 
-  override def getPos(): Long = out.asInstanceOf[ByteTrackingOutputStream].bytesWritten
+  override def getPos(): Long = out.bytesWritten
 }
 
 final class LZ4OutputBlockBuffer(lz4: LZ4, blockSize: Int, out: OutputBlockBuffer)

--- a/hail/hail/test/src/is/hail/expr/ir/IRSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/IRSuite.scala
@@ -3652,12 +3652,7 @@ class IRSuite {
       WritePartition(
         MakeStream(FastSeq(), TStream(TStruct())),
         NA(TString),
-        PartitionNativeWriter(
-          TypedCodecSpec(ctx, PType.canonical(TStruct()), BufferSpec.default),
-          IndexedSeq(),
-          "path",
-          None,
-        ),
+        TableTextPartitionWriter(TStruct(), ",", writeHeader = false),
       ),
       WriteMetadata(
         Begin(FastSeq()),

--- a/hail/hail/test/src/is/hail/expr/ir/UtilFunctionsSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/UtilFunctionsSuite.scala
@@ -4,8 +4,8 @@ import is.hail.ExecStrategy
 import is.hail.ExecStrategy.ExecStrategy
 import is.hail.TestUtils._
 import is.hail.backend.ExecuteContext
-import is.hail.expr.ir.defs.{Die, False, MakeStream, NA, Str, True}
-import is.hail.types.virtual.{TBoolean, TInt32}
+import is.hail.expr.ir.defs._
+import is.hail.types.virtual._
 
 import org.junit.jupiter.api.Test
 
@@ -84,5 +84,11 @@ class UtilFunctionsSuite {
   @Test def testParseFunctionRequiredness(implicit ctx: ExecuteContext): Unit = {
     assertEvalsTo(invoke("toInt32OrMissing", TInt32, Str("123")), 123)
     assertEvalsTo(invoke("toInt32OrMissing", TInt32, Str("foo")), null)
+  }
+
+  @Test def testSizeofValue(implicit ctx: ExecuteContext): Unit = {
+    assertEvalsTo(invoke("sizeofValue", TInt64, Str("123")), 7)
+    assertEvalsTo(invoke("sizeofValue", TInt64, I32(0xDEADBEEF)), 4)
+    assertEvalsTo(invoke("sizeofValue", TInt64, maketuple(Str("123"), I32(0))), 11)
   }
 }


### PR DESCRIPTION
Add byte tracking to the table writer helper. To do this add a wrapper around sizeToStoreInBytes as a UtilFunction, called `sizeofValue`.

## Security Assessment
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP
