### PR TITLE
[claude] flamegraph skill: fix recursion inflation, name corruption, and cross-run noise in profile comparisons

### DIFF
--- a/.claude/skills/flamegraph/SKILL.md
+++ b/.claude/skills/flamegraph/SKILL.md
@@ -30,6 +30,7 @@ The comparison shows:
 - Total sample counts and their ratio
 - Functions with the largest increase/decrease in inclusive %
 - Self-time changes (where CPU time is actually spent, not just call-tree ancestry)
+- Self-time excess vs uniform scaling (see below — the key regression-vs-noise discriminator)
 - Functions unique to each profile
 
 ### Single file — trace call paths to a hot function
@@ -40,7 +41,7 @@ python3 <skill-dir>/scripts/parse_flamegraph.py profile.html --callers 'DECODE' 
 python3 <skill-dir>/scripts/parse_flamegraph.py profile.html --callers 'Region.*allocate' --depth 12
 ```
 
-Shows the full call stacks leading to every frame matching the regex, grouped by unique stack and sorted by sample count. Recursive cycles (e.g., mutual recursion between `applyTable` and `lower$2`) are automatically collapsed with a repetition count (`x29`).
+Shows the full call stacks leading to every frame matching the regex, grouped by unique stack and sorted by sample count. Recursive cycles (e.g., mutual recursion between `applyTable` and `lower$2`) are automatically collapsed with a repetition count (`x29`). When the matched function is itself recursive, only the topmost occurrence per stack is traced, so each sample is counted once.
 
 ### Flags
 
@@ -54,19 +55,22 @@ Shows the full call stacks leading to every frame matching the regex, grouped by
 
 ### JSON mode
 
-Use `--json` when you need to do further computation on the results (e.g., feeding into another script or building a report). The output is a single JSON object with `inclusive_top` and `self_time_top` arrays (single file), `by_increase`/`by_decrease` arrays (comparison), or `stacks` array (`--callers`). In `--callers --json` mode, recursive cycles appear as `{"cycle": [...], "count": N}` objects within the frames array.
+Use `--json` when you need to do further computation on the results (e.g., feeding into another script or building a report). The output is a single JSON object with `inclusive_top` and `self_time_top` arrays (single file), `by_increase`/`by_decrease`/`by_self_excess` arrays (comparison), or `stacks` array (`--callers`). In `--callers --json` mode, recursive cycles appear as `{"cycle": [...], "count": N}` objects within the frames array.
 
 ## How to interpret the output
 
-**Inclusive time** counts every sample where a function appears anywhere in the call stack. A function called from many places will have inclusive % > 100% — this is expected and means it's a common ancestor, not that it's hot by itself.
+**Inclusive time** counts every sample where a function appears anywhere in the call stack, counted once per sample: recursive functions are attributed at their topmost occurrence, so percentages are always ≤ 100%. (Naively summing frame widths would multiply a recursive walk's time by its recursion depth — a tree traversal 40 frames deep would misleadingly report 40× its true cost.)
 
 **Self time** counts only samples where the function is at the top of the stack (the CPU was executing that function, not one of its callees). This is where the CPU is actually spending cycles. Regressions in self-time point to the actual bottleneck; regressions in inclusive-time point to the call subtree containing the bottleneck.
 
+**Run-specific names are normalized** so the same code aligns across profiles: JVM lambda classes (`Foo$$Lambda$733/101464973` → `Foo$$Lambda$*`), reflection accessors (`GeneratedMethodAccessor120` → `GeneratedMethodAccessor*`), and Hail's generated classes/methods (`__C197...` → `__C*...`, `__m1206split_Block` → `__m*split_Block`). Compare Hail generated code by the method suffix (`split_StreamFor`, `DECODE_r_struct_of_...`, `btree_get`, ...).
+
 **When comparing two profiles:**
-- The sample ratio tells you the overall slowdown/speedup.
+- The sample ratio tells you the overall slowdown/speedup — but check whether the two captures are comparable (same capture window, same number of requests, same machine) before attributing it to code.
+- The "self-time EXCESS vs uniform scaling" section is the key discriminator: it ranks functions by how much their self-time deviates from `samples_a × ratio`. A localized code regression shows a large positive excess in specific functions; if every excess is near zero, the profiles have the same shape and the ratio comes from something global — a longer capture window, more requests captured, or a slower/contended CPU — not a code change.
 - Large increases in self-time % pinpoint where new work is being done.
-- Functions present in only one profile reveal structural changes to the code path (renamed functions, new call wrappers, refactored APIs).
-- For Hail's generated code, the class number (e.g., `__C197` vs `__C194`) changes between versions — compare by method suffix (`split_StreamFor`, `DECODE_r_struct_of_...`, `btree_get`, etc.) rather than the full class name.
+- Functions present in only one profile reveal structural changes to the code path (renamed functions, new call wrappers, refactored APIs). One recurring false positive: `NativeMethodAccessorImpl.invoke` in one profile vs `GeneratedMethodAccessor*.invoke` in the other is JVM reflection warmup (the JVM swaps in a generated accessor after ~16 calls), not a code change.
+- For JVM driver profiles, break down by thread group first: JIT compiler threads (`CompileBroker::compiler_thread_loop`) and GC workers (`GangWorker::loop`) often dominate total CPU. A regression confined to worker threads is a code change; uniform growth across JIT + GC + workers points at the environment.
 
 ## Analyzing Hail profiles specifically
 
@@ -99,9 +103,10 @@ Key Hail runtime functions to watch:
 
 1. Run the comparison: `python3 ... before.html after.html --top 30`
 2. Check the sample ratio — is there an overall slowdown?
-3. Look at self-time changes to find where new CPU work is happening
-4. Filter to Hail-specific code: `--filter 'hail|__C|split_|DECODE|Region|Memory|LZ4|btree'`
-5. Check for structural changes: new `split_ToArray` (materialization regression), new GCS write paths, new decode steps
-6. Cross-reference with the "functions only in X" sections to find renamed/refactored code paths
-7. Use `--callers` to trace call paths to any new hotspot: `--callers 'HotFunction' --depth 15`
-8. Summarize findings: what changed in the generated code, what changed in the runtime, what's the likely root cause
+3. Check the "self-time EXCESS vs uniform scaling" section first: if no function exceeds uniform scaling, stop blaming the code — verify the captures are comparable (window length, request count, machine/CPU contention) before digging further
+4. Look at self-time changes to find where new CPU work is happening
+5. Filter to Hail-specific code: `--filter 'hail|__C|split_|DECODE|Region|Memory|LZ4|btree'`
+6. Check for structural changes: new `split_ToArray` (materialization regression), new GCS write paths, new decode steps
+7. Cross-reference with the "functions only in X" sections to find renamed/refactored code paths
+8. Use `--callers` to trace call paths to any new hotspot: `--callers 'HotFunction' --depth 15`
+9. Summarize findings: what changed in the generated code, what changed in the runtime, what's the likely root cause

--- a/.claude/skills/flamegraph/scripts/parse_flamegraph.py
+++ b/.claude/skills/flamegraph/scripts/parse_flamegraph.py
@@ -62,10 +62,7 @@ def parse_flamegraph(filepath: str) -> FlameGraph:
 
     total = frames[0].width
 
-    inclusive = defaultdict(int)
-    for f in frames:
-        inclusive[f.name] += f.width
-
+    inclusive = _compute_inclusive(frames)
     self_time = _compute_self_time(frames)
 
     return FlameGraph(
@@ -84,11 +81,32 @@ def _extract_cpool(content: str) -> list[str]:
         sys.exit(1)
 
     entries = re.findall(r"'((?:[^'\\]|\\.)*)'", m.group(1))
-    cpool = list(entries)
+    # Unescape JS string escapes (\' \\ etc.) BEFORE prefix decoding: the
+    # prefix lengths refer to the decoded strings, so leftover backslashes
+    # shift every subsequent entry and corrupt names.
+    cpool = [re.sub(r'\\(.)', r'\1', e) for e in entries]
     for i in range(1, len(cpool)):
         prefix_len = ord(cpool[i][0]) - 32
         cpool[i] = cpool[i - 1][:prefix_len] + cpool[i][1:]
-    return cpool
+    return [_normalize_name(s) for s in cpool]
+
+
+# JIT-generated identifiers that differ between JVM runs even for identical
+# code: lambda classes get sequential ids + hashes, and Hail's generated
+# classes/methods get sequential numbers. Normalize so two profiles of the
+# same code produce the same frame names.
+_LAMBDA_RE = re.compile(r'\$\$Lambda(?:\$\d+)?(?:/(?:0x)?[0-9a-fA-F]+)?')
+_GENCLASS_RE = re.compile(r'__C\d+')
+_GENMETHOD_RE = re.compile(r'__m\d+')
+_ACCESSOR_RE = re.compile(r'Generated(Method|Constructor)Accessor\d+')
+
+
+def _normalize_name(name: str) -> str:
+    name = _LAMBDA_RE.sub('$$Lambda$*', name)
+    name = _GENCLASS_RE.sub('__C*', name)
+    name = _GENMETHOD_RE.sub('__m*', name)
+    name = _ACCESSOR_RE.sub(r'Generated\1Accessor*', name)
+    return name
 
 
 def _extract_frames(content: str, cpool: list[str]) -> list[Frame]:
@@ -132,6 +150,30 @@ def _extract_frames(content: str, cpool: list[str]) -> list[Frame]:
             frames.append(Frame(cpool[key >> 3], level0, left0, width0))
 
     return frames
+
+
+def _compute_inclusive(frames: list[Frame]) -> dict[str, int]:
+    """Inclusive time: samples where the function is anywhere on the stack.
+
+    Each sample is counted ONCE per function: a recursive frame is counted
+    only at its topmost occurrence, otherwise recursion depth would multiply
+    the count (a walk 40 frames deep would report 40x its true time).
+    Relies on frames being emitted in DFS order, so the last-seen frame at
+    each shallower level is the current frame's ancestor.
+    """
+    inclusive: dict[str, int] = defaultdict(int)
+    path: dict[int, Frame] = {}
+    for f in frames:
+        path[f.level] = f
+        nested = any(
+            (a := path.get(lvl)) is not None
+            and a.name == f.name
+            and a.left <= f.left < a.left + a.width
+            for lvl in range(f.level)
+        )
+        if not nested:
+            inclusive[f.name] += f.width
+    return dict(inclusive)
 
 
 def _compute_self_time(frames: list[Frame]) -> dict[str, int]:
@@ -205,7 +247,9 @@ def _trace_callers(
 
     Stacks are collapsed so that recursive cycles (A -> B -> A -> B ...)
     appear once with a repetition count, merging stacks that differ only
-    in recursion depth.
+    in recursion depth.  Only the TOPMOST matching frame of each stack is
+    traced: nested recursive matches are skipped so each sample is counted
+    once, not once per recursion level.
     """
     pat = re.compile(pattern)
 
@@ -229,6 +273,8 @@ def _trace_callers(
                 if f.left >= pleft and f.left < pleft + pwidth:
                     stack.append(pname)
         stack.reverse()
+        if any(pat.search(name) for name in stack[:-1]):
+            continue  # nested occurrence; counted at the topmost match
         collapsed = _collapse_recursion(tuple(stack))
         if depth and len(collapsed) > depth:
             collapsed = collapsed[-depth:]
@@ -410,6 +456,26 @@ def print_comparison(fg_a: FlameGraph, fg_b: FlameGraph, top_n: int, filter_pat:
     else:
         print("  (none)")
 
+    # Self-time excess over uniform scaling: with sa*ratio as the expected
+    # value, a localized regression shows a large positive excess, while a
+    # longer capture window or a slower/contended CPU scales everything and
+    # leaves every excess near zero.
+    print()
+    print(f"=== Top {top_n} by self-time EXCESS vs uniform {ratio:.2f}x scaling ===")
+    min_excess = max(5.0, fg_b.total_samples * 0.001)
+    excess_rows = []
+    for func in all_self:
+        sa = fg_a.self_time.get(func, 0)
+        sb = fg_b.self_time.get(func, 0)
+        e = sb - sa * ratio
+        if abs(e) >= min_excess:
+            excess_rows.append((func, str(sa), str(sb), f"{e:+.0f}"))
+    excess_rows.sort(key=lambda r: -abs(float(r[3])))
+    if excess_rows:
+        print(format_table(excess_rows[:top_n], ("Function", f"#{label_a}", f"#{label_b}", "Excess")))
+    else:
+        print("  (none — every function scaled uniformly; suspect capture length or CPU speed, not a code change)")
+
     # Unique functions
     only_a = {f for f in fg_a.inclusive if f not in fg_b.inclusive}
     only_b = {f for f in fg_b.inclusive if f not in fg_a.inclusive}
@@ -486,12 +552,29 @@ def print_json_comparison(fg_a: FlameGraph, fg_b: FlameGraph, top_n: int, filter
             f"samples_{label_b}": fg_b.inclusive.get(func, 0),
         })
 
+    ratio = fg_b.total_samples / fg_a.total_samples if fg_a.total_samples else None
+    all_self = set(fg_a.self_time) | set(fg_b.self_time)
+    if pat:
+        all_self = {f for f in all_self if pat.search(f)}
+    self_excess = []
+    for func in all_self:
+        sa = fg_a.self_time.get(func, 0)
+        sb = fg_b.self_time.get(func, 0)
+        self_excess.append({
+            "name": func,
+            f"self_{label_a}": sa,
+            f"self_{label_b}": sb,
+            "excess_vs_uniform": round(sb - sa * ratio, 1) if ratio else None,
+        })
+    self_excess.sort(key=lambda x: -abs(x["excess_vs_uniform"] or 0))
+
     result = {
         label_a: {"file": fg_a.path, "total_samples": fg_a.total_samples},
         label_b: {"file": fg_b.path, "total_samples": fg_b.total_samples},
-        "ratio": round(fg_b.total_samples / fg_a.total_samples, 2) if fg_a.total_samples else None,
+        "ratio": round(ratio, 2) if ratio else None,
         "by_increase": sorted(diffs, key=lambda x: -x["diff"])[:top_n],
         "by_decrease": sorted(diffs, key=lambda x: x["diff"])[:top_n],
+        "by_self_excess": self_excess[:top_n],
     }
     print(json.dumps(result, indent=2))
 


### PR DESCRIPTION
This change was generated by claude code.

## What

Fixes four defects in the flamegraph-analysis skill that produced misleading
results during a real regression investigation, and adds a new comparison
section that distinguishes code regressions from environmental noise.

### Parser fixes (`scripts/parse_flamegraph.py`)

1. **Inclusive time no longer inflated by recursion.** Inclusive counts
   previously summed every occurrence of a frame name, so a recursive
   tree-walk N frames deep reported N× its true cost (a 19-sample
   `annotateTypes` walk reported 815 samples and looked like a 2× parsing
   regression). Each sample is now counted once, at the topmost occurrence,
   so inclusive percentages are always ≤ 100%.

2. **Constant-pool decoding corrupted names.** JS string escapes (`\'`) were
   not unescaped before prefix-decoding, shifting every subsequent pool entry
   and producing garbage like `Compile::valid_bompiler_thread_loop`.

3. **Run-specific identifiers flooded comparisons.** JVM lambda classes
   (`Foo$$Lambda$733/101464973`), reflection accessors
   (`GeneratedMethodAccessor120`), and Hail generated classes/methods
   (`__C197`, `__m1206`) get fresh numbers each run, so identical code showed
   up as spurious ±20% "only in a / only in b" entries. These are now
   normalized (`$$Lambda$*`, `GeneratedMethodAccessor*`, `__C*`, `__m*`) so
   the same code aligns across profiles.

4. **`--callers` double-counted recursive matches.** Every recursive
   occurrence was traced as a separate stack, showing the same samples
   multiple times as rotations of one path. Only the topmost match per stack
   is traced now.

### New: "self-time excess vs uniform scaling" comparison section

Ranks functions by deviation of self-time from `samples_a × ratio` (text
output and `by_self_excess` in JSON). A localized regression shows a large
positive excess in specific functions; near-zero excess everywhere means the
two profiles have the same shape and the overall ratio comes from something
global (longer capture window, more requests captured, slower/contended CPU)
rather than a code change. This was the analysis that resolved the
investigation that motivated these fixes.

### Docs (`SKILL.md`)

- Corrected the now-wrong "inclusive % > 100% is expected" guidance.
- Documented the name normalization.
- Added the excess check as an early step in the regression workflow: if
  nothing exceeds uniform scaling, verify the captures are comparable before
  blaming the code.
- Added a note to break driver profiles down by thread group first (JIT
  compiler and GC threads can dominate total CPU).
- Flagged the `NativeMethodAccessorImpl.invoke` → `GeneratedMethodAccessor*`
  transition as JVM reflection warmup, a recurring false positive.

## Why

While comparing two driver profiles, the per-occurrence inclusive counting
manufactured a false "IR parsing doubled" regression, and lambda-ID noise
buried the real signal. After the fixes, the same comparison correctly showed
the two profiles were uniformly scaled copies of each other — no code-path
regression at all.

This change does not affect the broad-managed batch service in gcp.