### PR TITLE
[query] Fix `transform_gvcf` docs.

### DIFF
--- a/hail/python/hail/vds/combiner/combine.py
+++ b/hail/python/hail/vds/combiner/combine.py
@@ -254,10 +254,7 @@ def transform_gvcf(
     mt : :class:`.MatrixTable`
         The GVCF being transformed.
     reference_entry_fields_to_keep : :class:`list` of :class:`str`
-        Genotype fields to keep in the reference table. If empty, the first
-        10,000 reference block rows of ``mt`` will be sampled and all fields
-        found to be defined other than ``GT``, ``AD``, and ``PL`` will be entry
-        fields in the resulting reference matrix in the dataset.
+        Genotype fields to keep in the reference table.
     info_to_keep : :class:`list` of :class:`str`
         Any ``INFO`` fields in the GVCF that are to be kept and put in the ``gvcf_info`` entry
         field. By default, all ``INFO`` fields except ``END`` and ``DP`` are kept.


### PR DESCRIPTION
The function no longer does defined reference entry inference, relying on `new_combiner` or the user.

No security impact on broad managed batch service.

