### PR TITLE
[compiler] Add `LiftAvailableExprs`, a weak-ANF CSE/LICM/PRE pass

### DIFF
--- a/dev-docs/compiler-team/lift-available-exprs.md
+++ b/dev-docs/compiler-team/lift-available-exprs.md
@@ -1,0 +1,528 @@
+# LiftAvailableExprs
+
+`LiftAvailableExprs` (`is.hail.expr.ir.lowering`):
+
+- rewrites an IR into a weak A-normal form;
+- deduplicates repeated pure computations;
+- hoists bindings as far out as is sound.
+
+The ANF is scaffolding, not the goal: it introduces many single-use bindings that are
+trivial to inline away later. The payoff is the genuinely shared or hoisted values.
+
+## Nomenclature
+
+- **ANF** — A-normal form: every compound subexpression is bound to a name, so operators take
+  only atoms (refs and constants) as operands.
+- **CSE** — common-subexpression elimination.
+- **LICM** — loop-invariant code motion.
+- **PRE** — partial redundancy elimination.
+- **GVN** — global value numbering: hash-consing expressions to value numbers (VNs), so every
+  form of one value shares a number.
+
+## Motivation
+
+Humans write abstractions, and abstractions are never zero-cost, whatever the C++ committee
+says.
+
+Our Python client builds expressions as a DAG, and when serialising that DAG to the IR tree
+it deduplicates nodes shared by object identity. But two structurally equal expressions built
+separately are distinct objects, so it might still emit the same subexpression many times
+over — and lowering (MatrixIR → TableIR → streams) then manufactures duplication the client
+never saw. The client has the harder job, deduplicating a DAG; we get a tree and structural
+equality, and so our life is much, much easier.
+
+The result is IR like the left of this, when we would rather compile the right:
+
+```ml
+map (fun row -> row.idx + (global.x + global.x)) rows
+
+↦
+
+let t0 = global.x
+    t1 = t0 + t0
+in map (\row -> row.idx + t1) rows
+```
+
+One evaluation of `t1` instead of `2 × length rows`, and the compiler downstream sees a smaller
+tree.
+
+## The idea
+
+If you remember one thing: **name every strict subexpression, remember what is named, and put
+each name as high as is sound**. Everything else is bookkeeping about where names may live.
+
+Readers who took a compilers course will recognise GVN-PRE (VanDrunen & Hosking, CC 2004): a
+linear analysis assigning every expression a value number and computing anticipability *over
+VNs*, followed by a rewrite that inserts hoisted bindings and eliminates redundancies against
+a VN-keyed availability map. The twist is that Hail IR is a tree, not a CFG: program order is
+dominance order, so the paper's Insert and Eliminate fuse into one rebuild pass; scoping does
+the work of basic blocks and bit vectors; and neither phase iterates to a fixed point — a
+tree has no back edges, and the constructs that would be (loops, stream bodies) are walls.
+
+Four transformations fall out of the two phases:
+
+- **naming** (weak ANF): each liftable child of a strict edge is bound to a fresh name in an
+  enclosing block. "Weak" because atoms stay inline and non-strict children keep their shape.
+- **CSE**: an expression whose value number matches one already bound and in scope collapses
+  to a reference to that binding.
+- **code motion**: a binding lands at the shallowest point at which its free names all
+  resolve, so values invariant in a stream or loop body float out of it (LICM).
+- **PRE**: an expression pinned under a conditional still rises to a block that is certain to
+  evaluate it anyway — a later occurrence on the spine, or (for total heads) an occurrence on
+  every branch.
+
+## What may be named; what may be reused; what may move
+
+Three questions, three mechanisms.
+
+### Naming
+
+`isLiftable` is a shape test — may this expression be bound to a name at all?
+
+- **Atoms** (refs and constants) may not: a ref to the binding is no smaller or cheaper than
+  the atom itself; naming one buys nothing.
+- **Stream-typed expressions** may not: a stream is not a value but a deferred loop — the
+  emitter compiles it to control flow at its point of consumption, and it may be consumed
+  only once, so a shared name is exactly what we must not offer.
+- **Void-typed strict children** are skipped by the traversal itself (there is no value to
+  bind; `RunAgg`'s body is the one legitimate carrier), as are expressions containing
+  **aggregator intermediates**. This one needs background, because the machinery is opaque.
+  Aggregation in Hail is not an expression over values; it compiles to a mutable state
+  machine threaded through the IR. Each aggregator owns a numbered state slot:
+
+  - `InitOp` initialises the slot;
+  - `SeqOp` folds one observation into it;
+  - `CombOp` merges two slots (partial results from different partitions);
+  - `SerializeAggs`/`DeserializeAggs` ship slots between workers;
+  - `ResultOp` reads the final value out.
+
+  These are imperative reads and writes of shared mutable state wearing expression syntax, so
+  structural equality does not imply value equality: two identical `ResultOp`s denote
+  different values if a `SeqOp` runs between them. Anything containing one is never named or
+  reused.
+
+Everything else is named. Whether the name may then be reused or moved is a property of the
+whole subtree, not the head.
+
+### Reuse
+
+A named binding is published — offered to structurally equal expressions — unless an effect
+or nondeterminism hides anywhere within it:
+
+- **Void-typed operations** (`WriteMetadata` and friends) and the impure writers
+  (`WritePartition`, `WriteValue`) exist for their effects; collapsing two equal forms
+  would elide one.
+- **`UUID4`** must draw a fresh value per occurrence, so two occurrences are never "the same"
+  computation.
+- **`Apply("index_bgen", …)`** — the registry's one effectful plain function is an effect by name.
+
+Note that `ConsoleLog` and `Die` are not considered effects - `ForwardLets` moves them
+freely — if every path leads to them, earlier placement is unobservable in the same sense.
+
+The lookup side needs no guard of its own: an effectful head draws a fresh value number per
+occurrence, so equal forms of an effect never share a number — nothing effectful is ever
+published, and nothing effectful ever matches a published entry.
+
+### Motion
+
+Hoisting past a non-strict edge changes how many times the expression runs: an `If` branch
+may never run, a stream body may run once per element or not at all. Motion comes in two
+strengths, gated by two facts.
+
+*Down-safe motion* asks only that the expression be **clean** — deeply pure, deterministic,
+and free of aggregator dependence, throughout the subtree. A placement is *down-safe* when
+the expression is evaluated on every path leaving it; an anticipated later occurrence on the
+spine witnesses exactly that. Down-safety never inspects the head: even a failure-capable
+one — `mod`, a registered `Apply` — may hoist, firing its failure earlier rather than adding
+one. (Busy occurrences — one on every branch of a conditional — license a weaker form that
+*does* inspect the head; see the busy arm below.)
+
+*Speculation* crosses an edge the source may have evaluated zero times (a possibly-empty
+loop body), forcing an evaluation that never happened. That is unobservable only if the head
+is also **total** — defined and error-free on every well-typed input. `isTotal` is a
+conservative whitelist: building and projecting structs, tuples and arrays, casts,
+comparisons, overflow-wrapping arithmetic. The instructive absences: integer division throws
+on zero, and `Apply` — registered functions in general — may raise user-visible errors.
+
+Everything that is not clean is named in place, preserving evaluation count and order.
+
+## Worked examples
+
+Deduplication and alias forwarding:
+
+```ml
+(a + 1, a + 1)  ↦  let t = a + 1 in (t, t)
+
+let x = a + 1   ↦  let x = a + 1 in x + x
+    y = a + 1 
+in x + y
+```
+
+In the second, `y`'s value collapses to the ref `x`; rather than emit `let y = x`, the pass
+records `y ↦ x` and rewrites uses. Expressions built over the alias then dedup too: `y + y`
+becomes `x + x` and matches an available `x + x`.
+
+LICM — a constant (or any total expression whose free names are bound  outside) rises through
+a stream-body edge:
+
+```ml
+map (fun _ -> "a") s  ↦  let t = "a" in map (fun _ -> t) s
+```
+
+PRE — `a + 1` in the branch is *anticipated*: every execution of  this block evaluates
+`a + 1` later, so hoisting it moves an evaluation earlier rather than adding one, and the
+later occurrence collapses onto it:
+
+```ml
+let x = if c then a + 1 else b + 1  ↦  let y = a + 1
+    y = a + 1                              x = if c then y else b + 1
+in x + y                                in x + y
+```
+
+The same licence applies when the later occurrence is in the *same* binding's value
+(`let x = (if c then a + 1 else b) * (a + 1)`), when the branch sits inside a nested block,
+and when the later occurrence is a sibling on a non-block spine (`(if c then e else b, e)`).
+Being down-safe, it also extends to failure-capable heads like `mod`: the anticipated
+occurrence guarantees the failure was coming anyway.
+
+Busy expressions — a conditional's branches are exhaustive alternatives, so a value on the
+spine of *every* branch is evaluated whichever runs, and hoists even with no occurrence on
+the enclosing spine:
+
+```ml
+if c then a + 1 else (a + 1) * b  ↦  let t = a + 1 in if c then t else t * b
+```
+
+Here totality is load-bearing where anticipation's licence was not: a *missing* predicate
+skips all branches (the emitter jumps straight to the missing continuation), so busy-ness
+proves evaluation only conditional on the predicate being present. A total head evaluated on
+those rows is unobservable; a failure-capable one (`mod`) could fail on a row the source
+never touched, so non-total busy values stay pinned.
+
+## Aggregation contexts
+
+Hail expressions occupy one of three scopes — `EVAL`, `AGG`, `SCAN` — and edges may shift
+them (an `AggFilter`'s condition is an agg-scope expression; `StreamAgg` creates a fresh agg
+context; `AggFold` promotes its child into the element scope). Two rules:
+
+- an aggregation never crosses a non-strict edge — but CSE still applies *within* a context:
+
+  ```ml
+  streamAgg (fun _ -> (count (), count ())) xs
+  ↦
+  streamAgg (fun _ -> let n = count () in (n, n)) xs
+  ```
+
+- structural equality is not value equality across a context change. A count inside
+  `aggFilter` is not the total count, so lookup must not reuse an entry bound over different
+  elements.
+
+  Edges that *reinterpret* the aggregable elements while agg expressions stay legal — the
+  transformers `AggFilter`, `AggExplode`, `AggGroupBy`, `AggArrayPerElement` on their agg
+  child; `StreamAgg`/`StreamAggScan` bodies — erect a lookup **wall**: agg- (scan-) dependent
+  lookups see nothing bound above it. Edges that remove or replace the scope (`AggFold`'s
+  promote/drop children; `TableAggregate`) need no wall — the stale entries are swapped out
+  of reach.
+
+Anticipation is not computed in agg or scan scope: a block's spine describes one evaluation,
+not one evaluation per aggregated element, so PRE is eval-only.
+
+## What we don't do
+
+- **Speculating `Apply`**: registered functions take down-safe hoists — anticipation never
+  adds an evaluation — but never cross a possibly-zero-evaluation edge, and never hoist on a
+  busy licence. We could enable both later by adding a `noThrow` property on `Apply`.
+- **Anticipation under agg/scan**, per the above.
+- **Busy hoists out of `Coalesce` and short-circuit `lor`/`land`**: their arms are not
+  exhaustive alternatives, so a shared arm expression is not certain to run.
+
+## Implementation
+
+The pass runs two phases per region. **Analyze** is one post-order traversal of the source
+that stamps the marks, assigns value numbers, and records each node's anticipated set. Each
+region numbers its values afresh: VNs never enter the IR — the canonical `__vn_` names
+live only in the table's keys — so numbering restarting at each region is harmless.
+**Rebuild** is one recursive rewrite producing the weak-ANF output, consulting the frozen
+analysis: availability is keyed by VN, and anticipation probes are VN-set membership, so
+motion cannot hide a match behind renaming.
+
+### Regions, frames, levels
+
+A **region** is the traversal state of one root IR expression: relational nodes lift each of
+their IR children as a region of its own. Within one, names may be shared anywhere except
+across a `dropEval` edge (e.g. `TableAggregate`'s query, `RelationalLet`'s value): such an
+edge opens an ordinary frame whose `regionFloor` is raised — a hard floor no placement, not
+even an anticipated hoist, may cross — and its transition clears the eval availability
+entries for the duration, so nothing bound outside the edge is found within. A created agg
+scope still tags the levels beneath it so bindings materialise with the right scope (a
+`TableAggregate` aggregand gets AGG-tagged bindings at the query root):
+
+```ml
+("a", tableAggregate t ("a", "a"))
+↦
+let x = "a" in (x, tableAggregate t (let y = "a" in (y, y)))
+
+tableAggregate t (max (row.idx * row.idx))
+↦
+tableAggregate t (agglet { t0 = row.idx; t1 = t0 * t0 } in max t1)
+```
+
+A **frame** is a landing spot for bindings: one at the root plus one per non-strict edge
+on the path from the region root to the current expression. Frames are numbered by depth —
+their **level**. Each frame owns an append-only `IRBuilder`; when the frame closes, its
+accumulated bindings wrap the child in a `Block`. Each frame carries:
+
+- `floor` — the deepest *conditionally evaluated* frame at or above it (`If`/`Switch` arms,
+  `Coalesce` operands, short-circuit `lor`/`land` right operands, and strict-but-void
+  children). Nothing may be placed shallower than the floor, except by anticipation.
+
+  Stream and loop bodies do **not** raise the floor: hoisting a total expression out of a
+  possibly-empty loop is safe and almost always profitable, whereas hoisting out of one
+  branch of an `If` is a coin toss. The floor is a profitability guard, not a soundness one —
+  soundness is `isTotal`'s job.
+- `regionFloor` — the deepest `dropEval` frame at or above it; a hard floor that not even
+  anticipation may cross.
+- `aggWall`, `scanWall` — the deepest agg (scan) context change at or above it; bounds
+  lookup as described above.
+- `anticipated` — the VNs of the frame's site, fixed at frame creation (see below); a probe
+  hit licenses a down-safe hoist to this frame.
+- `escapes` — the shallowest enclosing level the frame's block still references; returned as
+  the wrapped child's availability level when the frame closes.
+
+Every subexpression is lifted to a pair `(newIR, level)`: the rewritten expression and its
+**availability level**, the maximum level at which any of its free names is bound (names
+bound outside the region contribute 0). That level is the shallowest frame the expression
+could be placed at.
+
+Operand ordering needs no fix-up pass:
+
+- within a frame, builders are append-only and the traversal follows evaluation order, so a
+  definition is appended before any expression using it is processed;
+- across frames, an expression placed at level `l` only references names bound at levels
+  `≤ l`, whose blocks lexically enclose it;
+- the PRE hoist preserves this too: the decision fires while folding the conditional's
+  children, so the hoisted binding is appended *before* the conditional itself is memoised.
+
+### AvailableExprs
+
+Per region, the expressions already bound to a name and eligible for reuse: three buffers —
+`eval`, `agg`, `scan` — mirroring Hail's binding environments. Each holds one immutable map
+`VN → Atom` per frame, tagged with the scope in which a binding landing at that level must
+be declared. `eval` is always the buffer that lookups and insertions target; `agg` and
+`scan` (each optional) hold entries usable per element of an enclosing aggregation.
+
+Scope transitions swap whole buffers, in lockstep across every frame:
+
+- **promote** installs the element environment as current (lifting an AGG binding's value
+  evaluates it per element);
+- **drop** discards a compartment and its entries;
+- **create** opens a fresh context whose element environment extends the current eval
+  entries (a shallow copy — slot immutability makes this copy-on-write).
+
+A three-reference snapshot is saved before the edge and restored after: additions to
+surviving compartments ride along; additions to dropped or created ones die with the buffer.
+
+Lookup searches from the deepest frame outward and, for agg- (scan-) dependent expressions,
+stops at the wall.
+
+### Aliases
+
+A block binding whose value collapses to an atom — a bare ref or a constant — becomes an
+alias: uses are forwarded to the referent (each use takes a copy, preserving no-sharing) and
+the binding dropped. The point is not tidiness: the alias keeps the *referent's* level — a
+constant's is 0, having no free names — so expressions built on it may hoist past the frame
+the alias was declared in. Dedup needs no forwarding help: the alias's name carries the
+referent's value number, so `x + x` under `x ↦ xt` and `xt + xt` share a number by
+construction, as do forms over an alias and over the constant itself (`x + a` and
+`5 + a` under `x ↦ 5`).
+
+Only atoms are forwarded: they are safe to duplicate and no larger than the ref they
+replace. `Literal`, `EncodedLiteral` and `Str` are not atoms — duplicating them into use
+sites would trade one binding for many copies — so they stay bound.
+
+### Value numbering
+
+Phase 1 hash-conses every node of the region to a **value number**: two expressions share a
+VN exactly when the analysis can prove they denote the same value. The table key is the
+node's *canonical form* — itself with each IR child replaced by a `Ref` naming the child's
+VN — so structurally distinct forms of one value unify bottom-up. The rules:
+
+- A name bound to a liftable value free of effects and aggregator intermediates shares the
+  value's VN, so aliases and lifted nests vanish by construction: `ArrayLen(t)` and
+  `ArrayLen(ToArray(s))` share a number when `t = ToArray(s)`. Agg-result dependence does not
+  block the sharing — a VN is a key, and the walls guard reuse at lookup. Every other name —
+  lambda and loop parameters, free names, relational refs, effectful or agg-intermediate
+  bindings — is **opaque**: one fresh VN per name, so canonical forms never unify through one.
+- Effect-bearing heads and aggregator-state reads draw a fresh VN per *occurrence*: equal
+  effects are never "the same" computation. An effect deeper inside makes the enclosing VNs
+  unique automatically, through the child's number.
+- A block is transparent — its VN is its body's — when its bindings are free of effects and
+  aggregator intermediates; otherwise it, too, is opaque.
+- Relational children stay verbatim in the key (deep structural equality; rare).
+
+The rebuild extends the same table: a rebuilt node's canonical form is hash-consed against
+it, and a published binding's name carries its value's VN, so rebuilt forms stay
+numbered like their sources — `ArrayLen(t)` in the output answers to the same number the
+analysis gave `ArrayLen(ToArray(s))` in the source. A VN match is a *key*, never a
+*licence*: reuse always goes through the walled availability lookup, and publication gates
+on the marks.
+
+### Anticipated sets
+
+An expression is **anticipated** at a frame if it is certain to be evaluated whenever the
+frame runs. Phase 1 records, for every node, the VNs certain to be evaluated whenever that
+node is: its own (when clean and liftable), unioned across its strict, non-`dropEval`,
+transition-free children — the same edges the rebuild names along — with block spines
+recursing through EVAL binding values and the body, plus one extra arm at conditionals (the
+busy arm, below). Computing anticipability *over VNs* is what keeps the frozen analysis
+exact under motion: an alias contributes nothing new, a hoisted nest keeps its numbers, and
+no form drifts out from under the sets. The analysis is a single post-order traversal;
+a tree has no back edges, so nothing iterates.
+
+Each frame fixes its anticipated set at creation — its site child's set, and the region root
+takes the whole region's — because a site's own spine certainly runs whenever the site does.
+This covers every position uniformly: block spines, non-block strict spines
+(`(if c then e else b, e)` hoists `e`), and the region root itself. A VN evaluated on the
+spine *behind* the probe point is found in availability first — lookup precedes placement —
+so a probe hit never duplicates an evaluation, only moves one earlier.
+
+Membership implies liftability and cleanliness, which guarantees the anticipated occurrence
+dedups against the hoisted binding — otherwise the hoist would *add* an evaluation.
+
+### The busy arm
+
+At `If` and `Switch`, the anticipated set additionally takes the intersection of the
+branches' sets (default included), filtered to **total** heads: a value on the spine of
+every branch is evaluated whichever branch runs. The totality gate is the missingness
+argument from the worked example: a missing predicate skips all branches, so busy-ness
+proves evaluation only conditional on the predicate being present, and only a total head is
+unobservable on the missing rows. Non-total VNs still enter anticipated sets through genuine
+spine occurrences — down-safe as ever — so one set serves both licences. `Coalesce` and
+short-circuit `lor`/`land` get no busy arm: their arms are not exhaustive alternatives.
+
+The hoist needs no further machinery: inside the first branch, a busy value places above the
+conditional — the decision fires while the conditional's children are being folded, so the
+binding is appended before the conditional itself is memoised, in dependency order — and the
+other branches' copies collapse onto it through ordinary availability.
+
+### Marks
+
+Four per-node facts steer naming, publishing, lookup and motion: does the node contain 
+  - an aggregator intermediate (never named)?
+  - an agg result (reusable, but only behind the matching wall)?
+  - a scan result?
+  - an effect or nondeterminism (named, never published or moved)?
+
+Walking the subtree at every decision point would make the pass quadratic, so the facts are
+cached in the shared `BaseIR.mark` word (`Memo`): each run reserves sixteen consecutive mark
+values via `IrMetadata.nextFlags(16)` and stamps nodes with `base + bits`, one bit per fact.
+Reads subtract the base and range-check, so a word stamped by any other pass — or never
+stamped — decodes to zero, "clean".
+
+`derive` computes a rebuilt node's facts from its head and its direct children's: a
+one-level recurrence mirroring `ContainsAggIntermediate`, `ContainsAgg` and `ContainsScan`
+(`Exists.scala`), plus the deep effect fact, seeded by `isEffect` at each head (what counts
+as an effect is the Reuse section's business, encoded once there).
+
+The recurrence is exact on both trees: the analysis stamps source nodes post-order, so its
+filters (own-VN eligibility, name transparency, block transparency) read exact facts, and
+the rebuild stamps every node it returns, including the wrapping `Block` a closing frame
+builds, while atoms stay unstamped and correctly read clean — leaves compute nothing and
+perform nothing.
+
+Relational nodes are execution boundaries: their agg facts are their own business, but their
+effects still happen, so a `UUID4` buried in a table pipeline (inside a `TableMapRows` body,
+say) blocks reuse of the enclosing expression. This is one place the facts see more than the
+walking predicates, which stop at IR children.
+
+### Names
+
+The input must satisfy `UniquelyNamed` (verified on entry), and the output must too. Fresh
+names come from the compiler-wide `freshName()` (`__iruid_<n>`), so output uniqueness rests
+on that counter's one contract: it only ever increases within a JVM.
+
+## The `lift` traversal
+
+`lift(region, ir)` has three cases.
+
+**`Block`** — existing bindings stay in place: each value is re-lifted in its declared scope
+(with the compartment transition applied around AGG/SCAN values), then republished under its
+name — withheld from reuse if an aggregator intermediate or effect hides within; a value
+collapsing to an atom becomes an alias. The body is lifted last and returned unwrapped —
+flattening nested blocks into the frame. Hoists out of conditionals within a value are
+licensed by the frame's fixed anticipated set: the value's own spine is in it, so a later
+occurrence anywhere on the frame's spine counts.
+
+**`LeafRef`** (`Ref`, `RelationalRef`) — resolve through the alias map; the availability
+level is the referent's binding level (0 if bound outside the region).
+
+**Everything else** — fold over the children, dispatching on the edge:
+
+- *`dropEval` edge*: open a frame with `regionFloor` raised and eval availability cleared
+  (see above); bindings dependent on the child land there and cannot escape.
+- *Strict, non-void child*: lift it and, if liftable and free of aggregator intermediates,
+  memoise it under a fresh name in the deepest frame — the ANF step; the binding is
+  published for reuse unless it contains an effect. Its level joins the parent's running
+  maximum.
+- *Otherwise* (branch arm, stream or loop body, lazy operand, strict void child): open a
+  fresh frame — floor raised if the edge is conditionally evaluated (or strict void), wall
+  raised if the edge changes aggregation context — and lift the child inside it; bindings
+  placed in the frame wrap the child in a block on the way out, and the frame's `escapes`
+  joins the parent's level.
+
+With all strict compound children now atoms, the node itself is decided:
+
+- if an expression with the same value number is visible in `AvailableExprs` (respecting
+  walls), reuse its atom;
+- an expression that is not clean stays put — its parent memoises it in the current frame
+  (a total head can hide an aggregation or an effect in an unliftable stream child, which
+  pins no name; cleanliness is a property of the whole subtree, so it is still seen);
+- a clean one may rise to its availability level: through the floor only where down-safe
+  (it is anticipated at that level); to the floor regardless when its head is total. If the
+  resulting level is strictly above the current frame, it is memoised there, published, and
+  replaced by the ref;
+- otherwise it, too, evaluates in place.
+
+## Caveats
+
+`IsStrict`/`NonStrict` — the per-edge strictness table — was synthesised from `Pretty`'s
+`blockArgs` and from `Binds`, not from first principles. It has no independent oracle, and an
+edge wrongly classified strict would move or dedup an expression across a lazy boundary.
+Treat it as the pass's soft underbelly when auditing.
+
+## Alternative Designs 
+
+- **Syntax-based anticipation**.
+
+  The first analysis compared *source syntax* against *rebuilt* queries while the rewrite 
+  changed the tree under it. Three symptoms shared that root cause:
+
+    - aliases and lifted nests hid matches, so the query side grew shallow alias resolution
+      and an atom-unfolding map — and a miss was silent, a lost optimisation rather than an
+      error
+    - each spine position had to rescan its own suffix lazily (a cached suffix would miss
+      aliases recorded after it), making anticipation quadratic
+    - coverage was positional — the region root had no anticipated slot and non-block strict
+      spines pushed none, so redundancy migrating to those positions never converged.
+
+  We could have patched the holes one-by-one; used a dedicated anticipated slot for the region
+  root (and another mechanism for non-block strict spines) would have fixed the known misses.
+
+  Value numbers fix all these issues at once: an alias contributes nothing new to a VN set,
+  a hoisted nest keeps its numbers, and "the VNs of this site" is one uniform rule with no
+  position to forget.
+
+- **Convergence by iteration.** 
+
+  Rather than move a whole nest in one run, the pass could move one layer per run and let the
+  surrounding `Optimize` loop find the fixed point. This was rejected as the loop's iteration 
+  count is a heuristic. Canonical-form VNs make the point moot — a nest's inner and outer 
+  layers share numbers with their hoisted forms, so whole nests move in a single run.
+
+- **Hoisting busy values by surgery.**
+  
+  Lifting a value out of a conditional after the conditional is built means editing already
+  emitted bindings. Instead the busy arm rides the ordinary anticipated-set probe: the decision 
+  fires while the conditional's children are still being folded, so the hoisted binding is
+  appended before the conditional itself — the same surgery-free moment as every other hoist,
+  and `IRBuilder` stays append-only.

--- a/hail/hail/bench/src/is/hail/expr/ir/lowering/LiftAvailableExprsBenchmark.scala
+++ b/hail/hail/bench/src/is/hail/expr/ir/lowering/LiftAvailableExprsBenchmark.scala
@@ -1,0 +1,176 @@
+package is.hail.expr.ir.lowering
+
+import is.hail.HailFeatureFlags
+import is.hail.backend.{ExecuteContext, TempFileManager}
+import is.hail.collection.{FastSeq, ImmutableMap}
+import is.hail.expr.ir._
+import is.hail.expr.ir.defs._
+import is.hail.expr.ir.lowering.LiftAvailableExprsBenchmark._
+import is.hail.types.virtual.{TBoolean, TInt32}
+
+import scala.annotation.tailrec
+
+import java.util.concurrent.TimeUnit
+
+import org.openjdk.jmh.annotations.{Param, Scope => JmhScope, _}
+
+// The value-IR shapes, one per bottleneck under study: JMH runs the cartesian
+// product of shape and size, and builds each input on demand at setup.
+@State(JmhScope.Thread)
+class ValueShape {
+  @Param(Array("bindingChain", "distinctExprs", "repeatedNests",
+    "loopInvariantNest", "conditionalBusy"))
+  var shape: String = _
+
+  @Param(Array("10", "50", "100", "500"))
+  var size: Int = _
+
+  var ir: BaseIR = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit =
+    ir = builders(shape)(size)
+}
+
+// an order deeper than the value-IR shapes: user pipelines reach thousands of
+// relational ops
+@State(JmhScope.Thread)
+class RelationalChain {
+  @Param(Array("100", "1000", "10000", "100000"))
+  var size: Int = _
+
+  var ir: BaseIR = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit =
+    ir = buildRelationalChain(size)
+}
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(JmhScope.Thread)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+// the module's forkArgs don't reach JMH's forked JVM, so the stack for deep-IR
+// recursion is set here
+@Fork(value = 1, jvmArgsAppend = Array("-Xss32m", "-Xmx4g"))
+class LiftAvailableExprsBenchmark {
+
+  private var ctx: ExecuteContext = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit =
+    ctx = minimalExecuteContext
+
+  @TearDown(Level.Trial)
+  def teardown(): Unit =
+    ctx.close()
+
+  @Benchmark
+  def lift(shape: ValueShape): BaseIR = LiftAvailableExprs(ctx, shape.ir)
+
+  // a chain of n TableMapRows with a small body each: per-region setup cost
+  // and the trampolined walk along the relational spine, which must hold at
+  // any chain length on a production-like stack
+  @Benchmark
+  @Fork(value = 1, jvmArgsAppend = Array("-Xss4m", "-Xmx4g"))
+  def liftRelationalChain(shape: RelationalChain): BaseIR = LiftAvailableExprs(ctx, shape.ir)
+}
+
+object LiftAvailableExprsBenchmark {
+
+  // fresh nodes per use: the no-sharing invariant forbids reusing them
+  private def a = Ref(Name("a"), TInt32)
+  private def b = Ref(Name("b"), TInt32)
+  private def cond = Ref(Name("cond"), TBoolean)
+
+  private[lowering] val builders: Map[String, Int => BaseIR] =
+    Map(
+      "bindingChain" -> buildBindingChain,
+      "distinctExprs" -> buildDistinctExprs,
+      "repeatedNests" -> buildRepeatedNests,
+      "loopInvariantNest" -> buildLoopInvariantNest,
+      "conditionalBusy" -> buildConditionalBusy,
+    )
+
+  // n dependent bindings already in weak-ANF: per-node overhead of the two
+  // phases with no motion, reuse, or hoisting
+  private def buildBindingChain(n: Int): IR = {
+    def go(acc: IR, k: Int): IR =
+      if (k <= 0) acc
+      else bindIR(acc + 1)(r => go(r, k - 1))
+
+    go(a, n)
+  }
+
+  // n distinct compound expressions in one strict node: vnTable growth and
+  // anticipated-set unions with no CSE hits
+  private def buildDistinctExprs(n: Int): IR =
+    maketuple((0 until n).map(i => a + I32(i)): _*)
+
+  // n copies of one nest: every occurrence after the first collapses via
+  // Vn-keyed availability (CSE)
+  private def buildRepeatedNests(n: Int): IR = {
+    def nest: IR = ((a + 1) * (b + 2)) + ((a + 1) * (b + 2))
+
+    maketuple(Seq.fill(n)(nest): _*)
+  }
+
+  // a depth-n invariant nest inside a stream lambda: every level hoists
+  // across the loop frame (LICM)
+  private def buildLoopInvariantNest(n: Int): IR = {
+    def deep(k: Int): IR =
+      if (k <= 0) a
+      else deep(k - 1) + k
+
+    ToArray(mapIR(rangeIR(10))(elt => elt + deep(n)))
+  }
+
+  // n Ifs each with a total value busy in both branches: the busy arm of the
+  // anticipated sets licenses a hoist above each conditional (PRE)
+  private def buildConditionalBusy(n: Int): IR = {
+    def go(k: Int): IR =
+      if (k <= 0) a
+      else bindIR(If(cond, a + k, (a + k) * (b + 1)))(x => go(k - 1) + x)
+
+    go(n)
+  }
+
+  private[lowering] def buildRelationalChain(n: Int): BaseIR = {
+    @tailrec def go(t: TableIR, k: Int): TableIR =
+      if (k <= 0) t
+      else go(
+        t.mapRows((_, row) => InsertFields(row, FastSeq("x" -> (GetField(row, "idx") + 1)))),
+        k - 1,
+      )
+
+    go(TableRange(10, 1), n)
+  }
+
+  // the pass reads only irMetadata and (gated-off) invariant flags, so the
+  // backend, filesystem, and region slots can stay empty
+  private[lowering] def minimalExecuteContext: ExecuteContext =
+    new ExecuteContext(
+      tmpdir = "/tmp",
+      localTmpdir = "file:///tmp",
+      backend = null,
+      references = Map.empty,
+      fs = null,
+      r = null,
+      tempFileManager = NoTempFiles,
+      theHailClassLoader = null,
+      flags = HailFeatureFlags.fromEnv(Map.empty),
+      irMetadata = new IrMetadata(),
+      BlockMatrixCache = ImmutableMap.empty,
+      CompileCache = ImmutableMap.empty,
+      PersistedIrCache = ImmutableMap.empty,
+      PersistedCoercerCache = ImmutableMap.empty,
+    )
+
+  private object NoTempFiles extends TempFileManager {
+    override def newTmpPath(tmpdir: String, prefix: String, extension: String): String =
+      throw new UnsupportedOperationException("benchmarks may not create temp files")
+
+    override def close(): Unit = ()
+  }
+}

--- a/hail/hail/ir-gen/src/Main.scala
+++ b/hail/hail/ir-gen/src/Main.scala
@@ -74,6 +74,7 @@ trait IRDSL {
 
   val Atom: Trait
   val BaseRef: Trait
+  val LeafRef: Trait
   def TypedIR(t: String): Trait
   val NDArrayIR: Trait
   // AbstractApplyNodeUnseededMissingness{Aware, Oblivious}JVMFunction
@@ -119,6 +120,7 @@ object IRDSL_Impl extends IRDSL {
 
   override val Atom: Trait = Trait("Atom")
   override val BaseRef: Trait = Trait("BaseRef")
+  override val LeafRef: Trait = Trait("LeafRef")
   override def TypedIR(typ: String): Trait = Trait(s"TypedIR[$typ]")
   override val NDArrayIR: Trait = Trait("NDArrayIR")
 
@@ -640,7 +642,7 @@ object Main {
       .withPreamble("override lazy val size: Int = bindings.length + 1")
       .withCompanionExtension
 
-    r += node("Ref", name, _typ().mutable).withTraits(BaseRef, Atom)
+    r += node("Ref", name, _typ().mutable).withTraits(LeafRef)
 
     r += node(
       "TailLoop",
@@ -659,7 +661,7 @@ object Main {
     r += node("Recur", name, in("args", child.*), _typ().mutable).withTraits(BaseRef)
 
     r += node("RelationalLet", name, in("value", child), in("body", child))
-    r += node("RelationalRef", name, _typ()).withTraits(BaseRef, Atom)
+    r += node("RelationalRef", name, _typ()).withTraits(LeafRef)
 
     r += node("ApplyBinaryPrimOp", in("op", att("BinaryOp")), in("l", child), in("r", child))
     r += node("ApplyUnaryPrimOp", in("op", att("UnaryOp")), in("x", child))

--- a/hail/hail/src/is/hail/expr/ir/BaseIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/BaseIR.scala
@@ -39,6 +39,23 @@ abstract class BaseIR {
       copyWithNewChildren(newChildren)
   }
 
+  def foldChildrenWithIndex[S](s0: S)(f: (BaseIR, Int, S) => (BaseIR, S)): (BaseIR, S) = {
+    val newChildren = childrenSeq.toArray
+    var changed = false
+    var s = s0
+    for (i <- newChildren.indices) {
+      val child = newChildren(i)
+      val (newChild, newS) = f(child, i, s)
+      if (!(newChild eq child)) {
+        newChildren(i) = newChild
+        changed = true
+      }
+      s = newS
+    }
+    val res = if (changed) copyWithNewChildren(ArraySeq.unsafeWrapArray(newChildren)) else this
+    (res, s)
+  }
+
   def mapChildren(f: (BaseIR) => BaseIR): BaseIR = {
     val newChildren = childrenSeq.map(f)
     if (childrenSeq.elementsSameObjects(newChildren))

--- a/hail/hail/src/is/hail/expr/ir/Binds.scala
+++ b/hail/hail/src/is/hail/expr/ir/Binds.scala
@@ -313,7 +313,7 @@ object Bindings {
           )
         else
           Bindings(accum.map { case (name, value) => (name, value.typ) })
-      case StreamBufferedAggregate(stream, _, _, _, name, _, _) if i > 0 =>
+      case StreamBufferedAggregate(stream, _, _, _, name, _, _) if i > 1 =>
         Bindings(FastSeq(name -> elementType(stream.typ)))
       case RunAggScan(a, name, _, _, _, _) if i == 2 || i == 3 =>
         Bindings(FastSeq(name -> elementType(a.typ)))

--- a/hail/hail/src/is/hail/expr/ir/Exists.scala
+++ b/hail/hail/src/is/hail/expr/ir/Exists.scala
@@ -74,9 +74,9 @@ object ContainsAgg {
   })
 }
 
-object ContainsAggIntermediate {
+object IsAggIntermediate {
   def apply(root: IR): Boolean =
-    (root match {
+    root match {
       case _: ResultOp => true
       case _: SeqOp => true
       case _: InitOp => true
@@ -87,10 +87,21 @@ object ContainsAggIntermediate {
       case _: CombOpValue => true
       case _: InitFromSerializedValue => true
       case _ => false
-    }) || root.children.exists {
-      case child: IR => ContainsAggIntermediate(child)
-      case _ => false
     }
+}
+
+object ContainsAggIntermediate {
+  def apply(root: IR): Boolean =
+    IsAggIntermediate(root) || (root match {
+      // a relational aggregate's query runs in its own execution: state
+      // ops within cannot read the enclosing context's aggregator state
+      case _: TableAggregate => false
+      case _: MatrixAggregate => false
+      case _ => root.children.exists {
+          case child: IR => ContainsAggIntermediate(child)
+          case _ => false
+        }
+    })
 }
 
 object AggIsCommutative {
@@ -128,4 +139,9 @@ object ContainsScan {
         case _ => false
       }
   })
+}
+
+object AggContextDependent {
+  def apply(ir: IR): Boolean =
+    ContainsAgg(ir) || ContainsScan(ir) || ContainsAggIntermediate(ir)
 }

--- a/hail/hail/src/is/hail/expr/ir/IR.scala
+++ b/hail/hail/src/is/hail/expr/ir/IR.scala
@@ -45,6 +45,11 @@ abstract class IR extends BaseIR {
   override def mapChildrenWithIndex(f: (BaseIR, Int) => BaseIR): IR =
     super.mapChildrenWithIndex(f).asInstanceOf[IR]
 
+  override def foldChildrenWithIndex[E](env: E)(f: (BaseIR, Int, E) => (BaseIR, E)): (IR, E) = {
+    val (newIR, newEnv) = super.foldChildrenWithIndex(env)(f)
+    (newIR.asInstanceOf[IR], newEnv)
+  }
+
   override def deepCopy: this.type = {
     val cp = super.deepCopy
     if (_typ != null)
@@ -263,6 +268,8 @@ package defs {
     def name: Name
     def _typ: Type
   }
+
+  trait LeafRef extends BaseRef with Atom
 
   object ArrayZipBehavior extends Enumeration {
     type ArrayZipBehavior = Value

--- a/hail/hail/src/is/hail/expr/ir/IsPure.scala
+++ b/hail/hail/src/is/hail/expr/ir/IsPure.scala
@@ -1,12 +1,13 @@
 package is.hail.expr.ir
 
-import is.hail.expr.ir.defs.{Die, WritePartition, WriteValue}
+import is.hail.expr.ir.defs.{Atom, WritePartition, WriteValue}
 import is.hail.types.virtual.TVoid
 
 object IsPure {
   def apply(x: IR): Boolean = x match {
+    case _: Atom => true // note Void() is pure
     case _ if x.typ == TVoid => false
-    case _: Die | _: WritePartition | _: WriteValue => false
+    case _: WritePartition | _: WriteValue => false
     case _ => true
   }
 }

--- a/hail/hail/src/is/hail/expr/ir/lowering/ForwardLets.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/ForwardLets.scala
@@ -2,8 +2,8 @@ package is.hail.expr.ir.lowering
 
 import is.hail.backend.ExecuteContext
 import is.hail.expr.ir.{
-  BaseIR, BindingEnv, Bindings, ComputeUsesAndDefs, ContainsAgg, ContainsAggIntermediate,
-  ContainsScan, Env, IR, IsPure, Pretty, RefEquality, Scope, UsesAndDefs,
+  AggContextDependent, BaseIR, BindingEnv, Bindings, ComputeUsesAndDefs, Env, IR, IsPure, Pretty,
+  RefEquality, Scope, UsesAndDefs,
 }
 import is.hail.expr.ir.defs._
 import is.hail.expr.ir.lowering.invariant.UniquelyNamed
@@ -27,8 +27,7 @@ object ForwardLets extends Logging {
             refs.isEmpty ||
             (refs.size == 1 &&
               nestingDepth.lookupRef(refs.head) == nestingDepth.lookupBinding(base, scope) &&
-              (value.typ.isInstanceOf[TStream] ||
-                !(ContainsScan(value) || ContainsAgg(value) || ContainsAggIntermediate(value))))
+              (value.typ.isInstanceOf[TStream] || !AggContextDependent(value)))
         )
 
       def rewrite(ir: BaseIR, env: BindingEnv[IR]): BaseIR =

--- a/hail/hail/src/is/hail/expr/ir/lowering/LiftAvailableExprs.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LiftAvailableExprs.scala
@@ -1,0 +1,945 @@
+package is.hail.expr.ir.lowering
+
+import is.hail.backend.ExecuteContext
+import is.hail.expr.ir.{RefEquality => _, _}
+import is.hail.expr.ir.AggEnv.Promote
+import is.hail.expr.ir.Scope._
+import is.hail.expr.ir.defs._
+import is.hail.expr.ir.lowering.invariant.{Invariant, LowerableIR, UniquelyNamed}
+import is.hail.types.virtual.{TStream, TVoid}
+import is.hail.utils.StackSafe._
+import is.hail.utils.TimedBlock
+
+import scala.annotation.tailrec
+import scala.collection.immutable.IntMap
+import scala.collection.mutable
+
+import java.util
+
+// Rewrites an IR into weak A-normal form: each liftable child of a strict edge
+// is bound to a fresh name in an enclosing Block (atoms stay inline; non-strict
+// children keep their shape). On top of the naming:
+//   - Common-Subexpression Elimination (CSE): an expression whose value number
+//     matches an in-scope binding collapses to a reference to it;
+//   - Loop-Invariant Code Motion (LICM): a total expression lands at the
+//     shallowest frame at which its free names all resolve;
+//   - Partial Redundancy Elimination (PRE): an expression pinned under a
+//     conditional still rises to a frame certain to evaluate it later, moving
+//     an evaluation earlier rather than adding one.
+// Two phases per region (GVN-PRE, after VanDrunen & Hosking 2004):
+//   1. Analyze: one post-order traversal hash-conses every node to a value
+//      number (Vn) — aliases and lifted forms of one value share a number by
+//      construction — and records each node's anticipated set: the Vns certain
+//      to be evaluated whenever the node evaluates.
+//   2. Rebuild: one recursive rewrite tracking a Region (frame stack, name
+//      levels, aliases) whose Frames (one per non-strict edge) hold the landing
+//      spots and the Vn-keyed AvailableExprs eligible for reuse; anticipation
+//      probes are Vn-set membership, so motion cannot hide a match behind
+//      renaming.
+object LiftAvailableExprs {
+
+  def apply(ctx: ExecuteContext, in: BaseIR): BaseIR =
+    TimedBlock.enter {
+      UniquelyNamed.verify(ctx, in)
+      val out = new Impl(new Memo(ctx.irMetadata.nextFlags(16)))(in)
+      WeakANF.verify(ctx, out)
+      out
+    }
+
+  // CSE candidate operations, provided
+  //   - the operation does not contain side effects,
+  //   - reuse doesn't change aggregation semantics.
+  private def isLiftable(ir: IR): Boolean =
+    !(ir.isInstanceOf[Atom] || ir.typ.isInstanceOf[TStream])
+
+  // Operations that cannot fail: evaluating one on a path that never needs its
+  // value is unobservable, so it may cross an edge the source evaluated zero
+  // times (a possibly-empty loop body) — speculation.
+  private def isTotal(ir: IR): Boolean =
+    ir match {
+      case _: Literal | _: EncodedLiteral | _: Str // non-Atom constants
+          | _: MakeArray | _: ArrayLen
+          | _: MakeStruct | _: GetField | _: SelectFields | _: InsertFields
+          | _: MakeTuple | _: GetTupleElement
+          | _: IsNA
+          | _: Cast | _: CastToArray | _: CastRename
+          | _: ApplyUnaryPrimOp | _: ApplyComparisonOp => true
+      case ApplyBinaryPrimOp(Add() | Subtract() | Multiply(), _, _) => true
+      case _ => false
+    }
+
+  // Effectful operations may not be speculated along a conditional edge.
+  private def isEffect(ir: IR): Boolean =
+    ir match {
+      case _: UUID4 | Apply("index_bgen", _, _, _, _) => true
+      case _ => !IsPure(ir)
+    }
+
+  // Children the parent may evaluate zero times. Such frames set the floor:
+  // placing a binding above one would evaluate it on paths that never need it.
+  private def isConditionallyEvaluated(parent: IR, childIdx: Int): Boolean =
+    parent match {
+      case _: If => childIdx > 0
+      case _: Switch => childIdx > 0
+      case _: Coalesce => true
+      case ApplySpecial("lor" | "land", _, _, _, _) => childIdx > 0
+      case _ => false
+    }
+
+  // Edges that need a lookup wall: the aggregable elements change while agg-
+  // (scan-) dependent expressions stay legal, so an equal expression bound
+  // outside is in scope yet aggregates different elements. Edges that remove or
+  // replace the scope (AggFold, Table/MatrixAggregate) need none: stale entries
+  // leave scope with the buffers holding them.
+  private def changesAggContext(ir: IR, i: Int): Option[Scope] =
+    ir match {
+      case AggFilter(_, _, isScan) if i == 1 => Some(if (isScan) SCAN else AGG)
+      case AggExplode(_, _, _, isScan) if i == 1 => Some(if (isScan) SCAN else AGG)
+      case AggGroupBy(_, _, isScan) if i == 1 => Some(if (isScan) SCAN else AGG)
+      case AggArrayPerElement(_, _, _, _, _, isScan) if i == 1 =>
+        Some(if (isScan) SCAN else AGG)
+      case _: StreamAgg if i == 1 => Some(AGG)
+      case _: StreamAggScan if i == 1 => Some(SCAN)
+      case _ => None
+    }
+
+  private def noTransitions(bindings: Bindings[_]): Boolean = {
+    def noTransition(env: AggEnv): Boolean =
+      env match {
+        case AggEnv.NoOp | AggEnv.Bind(_) => true
+        case _ => false
+      }
+
+    !bindings.dropEval && noTransition(bindings.agg) && noTransition(bindings.scan)
+  }
+
+  // A Value number
+  private[LiftAvailableExprs] type Vn <: Int
+
+  // A landing spot for bindings: one frame per non-strict edge on the path from
+  // the region root. The floors bound placement (no speculation); the walls
+  // bound lookup (see Region.lookup).
+  final private class Frame(
+    // the deepest conditionally-evaluated frame at or above this one
+    val floor: Int,
+
+    // the deepest dropEval frame at or above this one; a hard floor that not
+    // even anticipation may cross
+    val regionFloor: Int,
+
+    // the deepest agg context change at or above this one
+    val aggWall: Int,
+
+    // the deepest scan context change at or above this one
+    val scanWall: Int,
+
+    // The Vns of this frame's site: those certain to be evaluated on its strict
+    // spine whenever the frame runs. A probe hit licenses a down-safe hoist to
+    // this frame; one already evaluated on the spine is found available instead
+    // (lookup precedes placement), so a hit never duplicates an evaluation.
+    val anticipated: VnSet,
+  ) {
+    val builder: IRBuilder = new IRBuilder
+
+    // the max level (below this frame's own) of any name occurring free within
+    // this frame's block.
+    var escapes: Int = 0
+  }
+
+  // A frame's available expressions, keyed by value number and tagged with the
+  // scope (EVAL, AGG or SCAN) a binding placed at that frame must be declared
+  // in: placement happens at a distance, and the scope depends on where the
+  // landing frame sits relative to scope transitions.
+  private def ScopedEnv(s: Scope): ScopedEnv =
+    ScopedEnv(s, IntMap.empty)
+
+  final private case class ScopedEnv(scope: Scope, env: IntMap[Atom]) {
+    def bind(vn: Vn, atom: Atom): ScopedEnv =
+      copy(env = env.updated(vn, atom))
+  }
+
+  // The expressions available at every frame of a region, one buffer per
+  // binding environment (eval — always the lookup/insert target — agg, and
+  // scan), each holding one env per frame. Transitions apply to all frames in
+  // lockstep, so an edge's transition swaps whole buffers.
+  private def AvailableExprs: AvailableExprs =
+    new AvailableExprs(
+      mutable.ArrayBuffer(ScopedEnv(EVAL)),
+      Some(mutable.ArrayBuffer(ScopedEnv(AGG))),
+      Some(mutable.ArrayBuffer(ScopedEnv(SCAN))),
+    )
+
+  final private class AvailableExprs(
+    private var eval: mutable.ArrayBuffer[ScopedEnv],
+    private var agg: Option[mutable.ArrayBuffer[ScopedEnv]],
+    private var scan: Option[mutable.ArrayBuffer[ScopedEnv]],
+  ) {
+    // A freshly-pushed frame has no available expressions of its own; bindings
+    // placed there from the current compartment are plain (EVAL) lets.
+    def push(): Unit = {
+      eval += ScopedEnv(EVAL)
+      agg.foreach(_ += ScopedEnv(AGG))
+      scan.foreach(_ += ScopedEnv(SCAN))
+    }
+
+    def pop(): Unit = {
+      val end = eval.length - 1
+      eval.remove(end): Unit
+      agg.foreach(_.remove(end))
+      scan.foreach(_.remove(end))
+    }
+
+    def scopeAt(level: Int): Scope =
+      eval(level).scope
+
+    // Both aggregation compartments intact: the eval buffer is the region's
+    // ordinary evaluation environment, not a promoted one.
+    def full: Boolean = agg.isDefined && scan.isDefined
+
+    def bind(level: Int, vn: Vn, atom: Atom): Unit =
+      eval(level) = eval(level).bind(vn, atom)
+
+    // Search from the deepest frame outward; levels shallower than `wall` are
+    // invisible (see Region.lookup).
+    def lookup(vn: Vn, wall: Int): Option[(Atom, Int)] = {
+      @tailrec def go(level: Int): Option[(Atom, Int)] =
+        if (level < wall) None
+        else eval(level).env.get(vn) match {
+          case Some(atom) => Some(atom -> level)
+          case None => go(level - 1)
+        }
+
+      go(eval.length - 1)
+    }
+
+    def save: AvailableExprs =
+      new AvailableExprs(eval, agg, scan)
+
+    // Apply an edge's transition to every frame at once.
+    def extend(bindings: Bindings[_]): Unit = {
+      if (bindings.dropEval)
+        eval = eval.map(_ => ScopedEnv(EVAL))
+
+      bindings.agg match {
+        case AggEnv.Drop =>
+          agg = None
+        case AggEnv.Promote =>
+          eval = agg.get
+          agg = None
+        case AggEnv.Create(_) =>
+          agg = Some(eval.clone())
+        case _ =>
+      }
+
+      bindings.scan match {
+        case AggEnv.Drop =>
+          scan = None
+        case AggEnv.Promote =>
+          eval = scan.get
+          scan = None
+        case AggEnv.Create(_) =>
+          scan = Some(eval.clone())
+        case _ =>
+      }
+    }
+
+    // Inverse of `extend`, where `saved` was taken before the edge: reinstate
+    // the compartment structure while keeping additions to compartments that
+    // survive the edge.
+    def restore(bindings: Bindings[_], saved: AvailableExprs): Unit = {
+      bindings.scan match {
+        case AggEnv.Promote =>
+          scan = Some(eval)
+          eval = saved.eval
+        case AggEnv.Drop | AggEnv.Create(_) =>
+          scan = saved.scan
+        case _ =>
+      }
+
+      bindings.agg match {
+        case AggEnv.Promote =>
+          agg = Some(eval)
+          eval = saved.eval
+        case AggEnv.Drop | AggEnv.Create(_) =>
+          agg = saved.agg
+        case _ =>
+      }
+
+      // `extend` replaced the eval buffer on dropEval; the saved one, with its
+      // entries, was untouched. (After a Promote this is a no-op.)
+      if (bindings.dropEval)
+        eval = saved.eval
+    }
+  }
+
+  // The traversal state of one region: its analysis (Vns and anticipated sets),
+  // its stack of frames, the levels its names are bound at, and its aliases.
+  // Names bound outside contribute level 0 (at or above the root frame).
+  final private class Region(
+    private[this] val analysis: Analysis,
+    private[this] val avail: AvailableExprs,
+    rootAnticipated: VnSet,
+  ) {
+    val frames: mutable.ArrayBuffer[Frame] =
+      mutable.ArrayBuffer(new Frame(0, 0, 0, 0, rootAnticipated))
+
+    // each in-scope name's frame level and, when its value collapsed to an
+    // atom, the referent uses are forwarded to. The levels of an expression's
+    // free names cap how shallow it may be placed; names bound outside the
+    // region root are absent and resolve to level 0.
+    private[this] val bound = new util.HashMap[Name, (Int, Option[Atom])]
+
+    def vn(ir: IR): Vn = analysis.vn(ir)
+    def ant(ir: IR): VnSet = analysis.ant(ir)
+
+    def deepest: Frame = frames.last
+    def depth: Int = frames.length - 1
+
+    // Record `name` as bound at `level`. An `alias` (a value that collapsed to
+    // an atom) forwards uses to the referent and drops the binding: dependents
+    // keep the referent's level and may hoist past this frame.
+    def declare(name: Name, level: Int, alias: Option[Atom] = None): Unit =
+      bound.put(name, (level, alias))
+
+    // Bind `value` to `name` in the block at `level`. Publishing makes the
+    // value available to equal-valued expressions under its Vn, and the name
+    // carries the number, keeping rebuilt forms numbered like their sources.
+    def memoize(name: Name, value: IR, level: Int, publish: Boolean): (IR, Int) = {
+      val atom = frames(level).builder.strictMemoize(value, name, avail.scopeAt(level))
+      if (publish) avail.bind(level, analysis.publish(name, value), atom)
+      declare(name, level)
+      returning(atom.ir, level)
+    }
+
+    def resolve(ref: LeafRef): (IR, Int) = {
+      val (level, alias) = bound.getOrDefault(ref.name, (0, None))
+      returning(alias.fold(ref: IR)(_.ir), level)
+    }
+
+    // Record that a value available at `level` flows through every deeper
+    // frame: their blocks cannot rise above it when they close (inFrame).
+    def returning(ir: IR, level: Int): (IR, Int) = {
+      var i = depth
+
+      while (i > level) {
+        val frame = frames(i)
+        if (level > frame.escapes) frame.escapes = level
+        i -= 1
+      }
+
+      (ir, level)
+    }
+
+    def lookup(vn: Vn, agg: Boolean, scan: Boolean): Option[(Atom, Int)] = {
+      // An agg (scan) expression is a value of the aggregable elements too: an
+      // equal entry bound outside the deepest context change is a different
+      // value, so lookup must not cross the wall.
+      val wall = math.max(
+        if (agg) deepest.aggWall else 0,
+        if (scan) deepest.scanWall else 0,
+      )
+      avail.lookup(vn, wall)
+    }
+
+    // Is the value numbered `Vn` certain to be evaluated on frame `level`'s
+    // strict spine? Only meaningful from the ordinary evaluation environment
+    // (avail.full), and never across a dropEval wall: a binding placed outside
+    // one cannot be referenced within.
+    def anticipatedAt(level: Int, vn: Vn): Boolean =
+      level >= deepest.regionFloor &&
+        avail.full &&
+        frames(level).anticipated.contains(vn)
+
+    // Run `f` with an edge's environment transition applied to the available
+    // expressions, restoring the compartment structure afterwards. A dropEval
+    // edge clears eval availability for the duration of `f`: nothing bound
+    // outside the edge may be found within.
+    def withTransitions(bindings: Bindings[_])(f: => (IR, Int)): (IR, Int) =
+      if (noTransitions(bindings)) f
+      else {
+        val saved = avail.save
+        avail.extend(bindings)
+        val result = f
+        avail.restore(bindings, saved)
+        result
+      }
+
+    // Visit a non-strict child in a fresh frame: bindings placed there wrap it
+    // in a Block on the way out, and the returned `escapes` is its availability
+    // level in the parent.
+    def inFrame(
+      barrier: Boolean,
+      region: Boolean,
+      wall: Option[Scope],
+      anticipated: VnSet,
+    )(
+      f: Int => IR
+    ): (IR, Int) = {
+      val level = frames.length
+      val frame = new Frame(
+        floor = if (barrier || region) level else deepest.floor,
+        regionFloor = if (region) level else deepest.regionFloor,
+        aggWall = if (wall.contains(AGG)) level else deepest.aggWall,
+        scanWall = if (wall.contains(SCAN)) level else deepest.scanWall,
+        anticipated = anticipated,
+      )
+      frames += frame
+      avail.push()
+      val result = f(level)
+      avail.pop()
+      frames.remove(level): Unit
+      val bindings = frame.builder.getBindings
+      val wrapped = if (bindings.nonEmpty) Block(bindings, result) else result
+      (wrapped, frame.escapes)
+    }
+  }
+
+  private object Memo {
+    final private val I = 1 // Contains agg intermediate
+    final private val A = 2 // Contains agg
+    final private val S = 4 // Contains scan
+    final private val E = 8 // Contains an effect or nondeterminism
+
+    class Result(private[Memo] val bits: Int) extends AnyVal {
+      def isClean: Boolean = bits == 0
+      def containsAggIntermediate: Boolean = (bits & Memo.I) != 0
+      def containsAgg: Boolean = (bits & Memo.A) != 0
+      def containsScan: Boolean = (bits & Memo.S) != 0
+      def containsEffect: Boolean = (bits & Memo.E) != 0
+    }
+  }
+
+  // This pass's memo of four per-node facts, encoded into the shared
+  // BaseIR.mark value as `base + bits`, where [base, base + 16) is reserved for
+  // this run alone.
+  final private class Memo(val base: Int) extends AnyVal {
+    import Memo._
+
+    def apply(ir: BaseIR): Result =
+      new Result({
+        val bits = ir.mark - base
+        if (0 <= bits && bits < 16) bits else 0
+      })
+
+    // Derive and record `ir`'s bits. The only write path: bits cannot be
+    // computed without being recorded, nor recorded unless derived.
+    def stamp(ir: BaseIR): Result = {
+      val r = derive(ir)
+      update(ir, r)
+      r
+    }
+
+    private def update(ir: BaseIR, r: Result): Unit =
+      ir.mark = base + r.bits
+
+    // The bits of a rebuilt node, from its head and its direct children's marks
+    // — the mark-based mirror of ContainsAggIntermediate, ContainsAgg and
+    // ContainsScan + deep effect scan.
+    private def derive(ir: BaseIR): Result =
+      ir match {
+        case _: Atom | Constant(_) =>
+          new Result(0)
+
+        case Block(bindings, body) =>
+          var bits = 0
+          bindings.foreach { case Binding(_, value, scope) =>
+            val x = apply(value).bits
+            bits |= x & (I | E)
+            bits |= (scope match {
+              case EVAL => x & (A | S)
+              case AGG => A
+              case SCAN => S
+            })
+          }
+          new Result(bits | apply(body).bits)
+
+        case _: TableAggregate | _: MatrixAggregate | _: TableIR | _: MatrixIR | _: BlockMatrixIR =>
+          var bits = 0
+          ir.children.foreach(child => bits |= apply(child).bits)
+          new Result(bits & E)
+
+        case ir: IR =>
+          var bits = 0
+          if (IsAggIntermediate(ir)) bits |= I
+          if (IsAggResult(ir)) bits |= A
+          if (IsScanResult(ir)) bits |= S
+          if (isEffect(ir)) bits |= E
+
+          var fromChildren = 0
+          ir.children.foreach(child => fromChildren |= apply(child).bits)
+
+          // A write inside an agg body still writes: the cuts do not apply to
+          // E.
+          val cut = ir match {
+            case _: StreamAgg => A
+            case _: StreamAggScan => S
+            case _ => 0
+          }
+          new Result(bits | (fromChildren & ~cut))
+      }
+  }
+
+  // IntMap (a patricia trie branching on key bits) beats HashSet[Int] here:
+  // probes hash nothing and box nothing, and union/intersection walk only where
+  // the trees overlap — the anticipated-set algebra unions small sets into
+  // large ones, where HashSet's concat paid for the large side.
+  private object VnSet {
+    import scala.collection.immutable.{IntMap => _Impl}
+    private[VnSet] type Impl = _Impl[Unit]
+
+    val empty: VnSet = new VnSet(_Impl.empty)
+    def apply(vn: Vn): VnSet = new VnSet(_Impl((vn, ())))
+  }
+
+  final private class VnSet(private val vs: VnSet.Impl) extends AnyVal {
+    def contains(vn: Vn): Boolean = vs.contains(vn)
+
+    def filter(pred: Vn => Boolean): VnSet =
+      new VnSet(vs.filter { case (vn, _) => pred(vn.asInstanceOf[Vn]) })
+
+    def |(that: VnSet): VnSet = new VnSet(vs.unionWith(that.vs, (_, _, _) => ()))
+    def &(that: VnSet): VnSet = new VnSet(vs.intersection(that.vs))
+  }
+
+  // ---- Phase 1: analyze ------------------------------------------------
+
+  // One post-order traversal per region root stamps marks, assigns Vns and
+  // records anticipated sets, which the rebuild reads through Region.
+  final private class Analysis(
+    val memo: Memo,
+    private[this] val vnNames: mutable.ArrayBuffer[Name],
+  ) {
+
+    private def vnName(vn: Vn): Name = {
+      while (vnNames.size <= vn) vnNames += Name(s"__Vn_${vnNames.size}")
+      vnNames(vn)
+    }
+
+    // canonical form -> Vn. A canonical form is the node with each IR child
+    // replaced by a Ref naming the child's Vn, so structurally distinct forms
+    // of one value share a number. A java HashMap caches each key's hash, so
+    // growing the table never recomputes the keys' structural hashCodes.
+    private[this] val vnTable = new util.HashMap[IR, Vn]
+
+    // per-occurrence Vn memo for compound nodes, over source and rebuilt nodes
+    // alike; leaf refs resolve through nameVn instead
+    private[this] val vns = new util.IdentityHashMap[IR, Vn]
+
+    // each name's Vn: a name bound to a liftable value free of effects and agg
+    // intermediates shares the value's number, so aliases and lifted nests
+    // vanish by construction; every other name (params, free names, effectful
+    // or agg-intermediate bindings) is opaque
+    private[this] val nameVn = new util.HashMap[Name, Vn]
+
+    // each source node's anticipated set: the Vns certain to be evaluated
+    // whenever the node is
+    private[this] val ants = new util.IdentityHashMap[IR, VnSet]
+
+    // the table Vns with total heads, for busy-arm filtering. Totality is a
+    // per-Vn constant — a canonical form keeps its node's head, so every node
+    // sharing a Vn shares the head; opaque Vns (names, effects) are never
+    // members.
+    private[this] val totals = mutable.BitSet.empty
+
+    private[this] var vnCount = 0
+
+    private def freshVn(): Vn = {
+      val vn = vnCount
+      vnCount += 1
+      vn.asInstanceOf[Vn]
+    }
+
+    // wipe for reuse by the next region; the tables keep their capacity
+    def reset(): Unit = {
+      vnTable.clear()
+      vns.clear()
+      nameVn.clear()
+      ants.clear()
+      totals.clear()
+      vnCount = 0
+    }
+
+    def vn(ir: IR): Vn =
+      ir match {
+        case ref: LeafRef =>
+          nameVn.computeIfAbsent(ref.name, _ => freshVn())
+
+        case _ =>
+          vns.computeIfAbsent(ir, computeVn)
+      }
+
+    private def computeVn(ir: IR): Vn =
+      ir match {
+        // a block evaluates to its body: bindings free of effects and agg
+        // intermediates are transparent, and their names carry the values' Vns
+        case Block(bindings, body) =>
+          val transparent =
+            bindings.forall { b =>
+              val bits = memo(b.value)
+              !bits.containsAggIntermediate && !bits.containsEffect
+            }
+
+          if (transparent) vn(body) else freshVn()
+
+        // equal effects and reads of mutable aggregator state never share a
+        // number: one per occurrence
+        case _ if isEffect(ir) || IsAggIntermediate(ir) =>
+          freshVn()
+
+        case _ =>
+          val key =
+            ir.mapChildren {
+              case child: IR => Ref(vnName(vn(child)), child.typ)
+              case child => child // relational children compare verbatim
+            }
+
+          vnTable.computeIfAbsent(
+            key,
+            _ => {
+              val vn = freshVn()
+              if (isTotal(ir)) totals += vn
+              vn
+            },
+          )
+      }
+
+    def ant(ir: IR): VnSet =
+      ants.get(ir)
+
+    // Publish a rebuilt binding: the name carries the value's number, keeping
+    // rebuilt forms numbered like their sources.
+    def publish(name: Name, value: IR): Vn = {
+      val v = vn(value)
+      nameVn.put(name, v)
+      v
+    }
+
+    // One post-order traversal per region: stamp marks, assign Vns and record
+    // anticipated sets. Relational children are separate regions, analyzed when
+    // the rebuild reaches them.
+    def analyze(ir: IR): Unit = {
+      ir match {
+        case Block(bindings, body) =>
+          bindings.foreach { case Binding(name, value, _) =>
+            analyze(value)
+            val bits = memo(value)
+            val transparent =
+              value.isInstanceOf[Atom] ||
+                (isLiftable(value) && !bits.containsAggIntermediate && !bits.containsEffect)
+
+            nameVn.put(name, if (transparent) vn(value) else freshVn())
+          }
+
+          analyze(body)
+
+        case _ =>
+          ir.children.foreach {
+            case child: IR => analyze(child)
+            case _ =>
+          }
+      }
+
+      val bits = memo.stamp(ir)
+
+      // the node's own Vn, plus those of its strict spine: the edges walked
+      // mirror the rebuild's naming step (strict, non-dropEval,
+      // transition-free; Blocks' EVAL values and body included)
+      val own =
+        if (isLiftable(ir) && bits.isClean) VnSet(vn(ir))
+        else VnSet.empty
+
+      val spine =
+        ir match {
+          case Block(bindings, body) =>
+            bindings.foldLeft(ant(body)) { (acc, b) =>
+              if (b.scope == EVAL) acc | ant(b.value) else acc
+            }
+
+          case _ =>
+            ir.children.view.zipWithIndex.foldLeft(VnSet.empty) {
+              case (acc, (child: IR, i)) if IsStrict(ir, i) && noTransitions(Bindings.get(ir, i)) =>
+                acc | ant(child)
+              case (acc, _) => acc
+            }
+        }
+
+      // The busy arm: a value on the spine of EVERY branch is evaluated
+      // whenever the conditional is — provided its head is total: a missing
+      // predicate skips all branches, and a total value hoisted onto those rows
+      // is unobservable. Coalesce/lor/land get no busy arm: their arms are not
+      // exhaustive alternatives.
+      val busy =
+        ir match {
+          case If(_, cnsq, altr) =>
+            ant(cnsq) & ant(altr)
+          case Switch(_, default, cases) =>
+            cases.foldLeft(ant(default))((acc, c) => acc & ant(c))
+          case _ =>
+            VnSet.empty
+        }
+
+      ants.put(ir, own | spine | busy.filter(totals))
+    }
+  }
+
+  // ---- Phase 2: rebuild --------------------------------------------------
+
+  final private class Impl(memo: Memo) {
+
+    // The canonical Name for each Vn, shared by every region's Analysis.
+    // Surprisingly, caching these is worth ~10% on canonical-key-heavy shapes
+    // (many compound nodes, so many vnTable probes): a shared Name caches its
+    // string's hash and compares by reference, where a fresh one re-hashes its
+    // characters on every probe.
+    private[this] val vnNames = mutable.ArrayBuffer.empty[Name]
+
+    // Finished Analyses park here for the next region, keeping their tables'
+    // capacity (growth-rehashing of vnTable dominated this pass's profile). A
+    // pool rather than one shared instance because relational children
+    // re-enter liftRegion mid-rebuild and need tables of their own.
+    private[this] val pool = mutable.ArrayBuffer.empty[Analysis]
+
+    def apply(ir0: BaseIR): BaseIR =
+      recur(ir0).run()
+
+    // Relational chains grow with the number of operations in a user's
+    // pipeline, so the walk between regions is trampolined. Within a value
+    // region `lift` recurses natively (depth is bounded by the region's own
+    // expression); a relational child there re-enters `apply` with a nested
+    // trampoline.
+    private def recur(ir0: BaseIR): StackFrame[BaseIR] =
+      ir0 match {
+        case ir: IR => done(stamped(liftRegion(ir)))
+        case _ => ir0.mapChildrenStackSafe(recur).map(stamped)
+      }
+
+    // liftRegion's result may be a fresh Block wrapping the region's bindings;
+    // like every rebuilt node, it needs marks
+    private def stamped(ir: BaseIR): BaseIR = {
+      memo.stamp(ir): Unit
+      ir
+    }
+
+    private def liftRegion(ir: IR): IR = {
+      val analysis =
+        if (pool.isEmpty) new Analysis(memo, vnNames)
+        else pool.remove(pool.length - 1)
+
+      analysis.analyze(ir)
+      val r = new Region(analysis, AvailableExprs, analysis.ant(ir))
+      val (result, _) = lift(r, ir)
+      val bindings = r.frames.head.builder.getBindings
+      val out = if (bindings.nonEmpty) Block(bindings, result) else result
+      analysis.reset()
+      pool += analysis
+      out
+    }
+
+    // the environment transition under which a Block binding's value is visited
+    private[this] val evalValue = Bindings.empty
+    private[this] val aggValue = Bindings.empty.copy(agg = Promote)
+    private[this] val scanValue = Bindings.empty.copy(scan = Promote)
+
+    // Returns the transformed expression and its availability level: the max
+    // level among the names occurring free in it, ie the shallowest frame at
+    // which it could be placed.
+    private def lift(r: Region, ir: IR): (IR, Int) =
+      ir match {
+        case Block(bindings, body) =>
+          // Each value is re-lifted and republished under its name (or turned
+          // into an alias if it collapsed to an atom). Hoists out of
+          // conditionals within a value are licensed by the frame's anticipated
+          // set: the value's own spine is in it, so a later occurrence anywhere
+          // on the frame's spine counts.
+          bindings.foreach { case Binding(name, value, scope) =>
+            val transition =
+              scope match {
+                case EVAL => evalValue
+                case AGG => aggValue
+                case SCAN => scanValue
+              }
+
+            r.withTransitions(transition) {
+              lift(r, value) match {
+                case (atom: Atom, level) =>
+                  r.declare(name, level, alias = Some(atom))
+                  (atom, level)
+                case (newValue, _) =>
+                  val bits = memo(newValue)
+                  val isAvailable =
+                    isLiftable(newValue) && !bits.containsAggIntermediate && !bits.containsEffect
+                  r.memoize(name, newValue, r.depth, publish = isAvailable)
+              }
+            }
+          }
+
+          lift(r, body)
+
+        case ref: LeafRef =>
+          r.resolve(ref)
+
+        case a: Atom =>
+          r.returning(a, 0)
+
+        case _ =>
+          val (newIR, lvl) =
+            ir.foldChildrenWithIndex(0) {
+              case (child: IR, i, maxLvl) =>
+                val bindings = Bindings.get(ir, i)
+
+                if (IsStrict(ir, i) && child.typ != TVoid && !bindings.dropEval) {
+                  // A strict child is evaluated exactly once, with its parent,
+                  // so naming it in an enclosing frame preserves semantics:
+                  // this is the ANF step, and memoize publishes the value for
+                  // reuse — unless an effect or UUID4 hides within, in which
+                  // case the naming stands but no equal expression may collapse
+                  // onto it.
+                  val (result, childLvl) =
+                    r.withTransitions(bindings) {
+                      val (newChild, valueLvl) = lift(r, child)
+                      val bits = memo(newChild)
+                      if (isLiftable(newChild) && !bits.containsAggIntermediate)
+                        r.memoize(freshName(), newChild, r.depth, publish = !bits.containsEffect)
+                      else (newChild, valueLvl)
+                    }
+
+                  (result, math.max(maxLvl, childLvl))
+                } else {
+                  // A non-strict child may run zero or many times, and a
+                  // dropEval child shares no names with its parent; either way
+                  // it gets a frame of its own where dependent bindings land,
+                  // guarded by the floors and walls described on Frame.
+
+                  val (newChild, escapes) =
+                    r.withTransitions(bindings) {
+                      r.inFrame(
+                        IsStrict(ir, i) || isConditionallyEvaluated(ir, i),
+                        bindings.dropEval,
+                        changesAggContext(ir, i),
+                        r.ant(child),
+                      ) {
+                        level =>
+                          bindings.all.foreach { case (name, _) => r.declare(name, level) }
+                          lift(r, child)._1
+                      }
+                    }
+
+                  // the wrapping Block `inFrame` may have built is not itself
+                  // visited: stamp it here from its rebuilt parts
+                  memo.stamp(newChild): Unit
+                  (newChild, math.max(maxLvl, escapes))
+                }
+
+              case (child, _, maxLvl) =>
+                (apply(child), maxLvl)
+            }
+
+          // All strict compound children are now atoms:
+          //   - reuse an available expression with the same value number, else
+          //   - decide where this one may be placed.
+          val bits = memo.stamp(newIR)
+
+          r.lookup(r.vn(newIR), agg = bits.containsAgg, scan = bits.containsScan) match {
+            case Some((atom, level)) =>
+              r.returning(atom.ir, level)
+
+            case None =>
+              // Clean bits are the movability requirement for a down-safe
+              // hoist: deeply pure, deterministic, and free of agg dependence.
+              // Speculation past the floor additionally demands totality.
+              if (!bits.isClean) r.returning(newIR, lvl)
+              else {
+                val floor = r.deepest.floor
+
+                val place =
+                  if (lvl < floor && r.anticipatedAt(lvl, r.vn(newIR))) lvl
+                  else if (isTotal(newIR)) math.max(lvl, floor)
+                  else r.depth
+
+                if (place < r.depth)
+                  r.memoize(freshName(), newIR, place, publish = true)
+                else r.returning(newIR, lvl)
+              }
+          }
+      }
+  }
+
+  private lazy val WeakANF: Invariant =
+    LowerableIR and Invariant {
+      case Block(bindings, body) =>
+        // A block asserts only its own shape: no value is an alias or a block,
+        // and the body is not a block. Values and body are checked as nodes
+        // themselves when visited.
+        bindings.forall(b => !b.value.isInstanceOf[Atom] && !b.value.isInstanceOf[Block]) &&
+        !body.isInstanceOf[Block]
+
+      case ir: IR =>
+        // Every liftable strict child has been named; what remains is an atom
+        // or unliftable. dropEval children are lifted in a frame of their own
+        // and never named into the parent. The subtree walk here is the spec
+        // Impl's mark-based detection must agree with.
+        ir.children.view.zipWithIndex.forall {
+          case (c: IR, i) =>
+            NonStrict(ir, i) ||
+            Bindings.get(ir, i).dropEval ||
+            !isLiftable(c) ||
+            isEffect(c) ||
+            ContainsAggIntermediate(c)
+          case _ => true
+        }
+
+      case _ => true // relational nodes: their IR children are checked when visited
+    }
+}
+
+object IsStrict {
+  def apply(ir: IR, i: Int): Boolean =
+    !NonStrict(ir, i)
+}
+
+object NonStrict {
+  def apply(ir: IR, i: Int): Boolean =
+    ir match {
+      case _: AggArrayPerElement => i == 1
+      case _: AggExplode => i == 1
+      case _: AggFilter => i == 1
+      case _: AggFold => i > 0
+      case _: AggGroupBy => i == 1
+      case ApplySpecial("lor" | "land", _, _, _, _) => i > 0
+      case _: ArrayMaximalIndependentSet => i == 1
+      case _: ArraySort => i == 1
+      case _: Coalesce => true
+      case _: CollectDistributedArray => i == 2
+      case _: ConsoleLog => i == 1
+      case _: If => i > 0
+      case _: MatrixAggregate => i == 1
+      case _: NDArrayMap => i == 1
+      case _: NDArrayMap2 => i == 2
+      case _: RelationalLet => true
+      case _: RunAgg => i == 1
+      case _: RunAggScan => i > 1
+      case _: ResultOp => i == 1
+      case _: StreamAgg => i == 1
+      case _: StreamAggScan => i == 1
+      case _: StreamBufferedAggregate => i > 1
+      case _: StreamDropWhile => i == 1
+      case _: StreamFlatMap => i == 1
+      case _: StreamFilter => i == 1
+      case _: StreamFold => i == 2
+      case StreamFold2(_, accum, _, _, _) => i > accum.length
+      case _: StreamFor => i == 1
+      case _: StreamJoinRightDistinct => i == 2
+      case _: StreamLeftIntervalJoin => i == 2
+      case _: StreamMap => i == 1
+      case _: StreamScan => i == 2
+      case _: StreamTakeWhile => i == 1
+      case StreamZip(as, _, _, _, _) => i == as.length
+      case StreamZipJoin(as, _, _, _, _) => i == as.length
+      case _: StreamZipJoinProducers => i > 0
+      case _: Switch => i > 0
+      case _: TableAggregate => i == 1
+      case TailLoop(_, args, _, _) => i == args.length
+      case _: WriteMetadata => true
+      case _ => false
+    }
+}

--- a/hail/hail/src/is/hail/expr/ir/lowering/LoweringPass.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LoweringPass.scala
@@ -24,6 +24,14 @@ final class IrMetadata() {
     markCounter += 1
     markCounter
   }
+
+  // Reserve `n` consecutive mark values for the exclusive use of one
+  // caller, returning the first.
+  def nextFlags(n: Int): Int = {
+    val base = markCounter + 1
+    markCounter += n
+    base
+  }
 }
 
 abstract class LoweringPass(implicit E: sourcecode.Enclosing) {

--- a/hail/hail/src/is/hail/expr/ir/lowering/Optimize.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/Optimize.scala
@@ -47,7 +47,7 @@ object Optimize {
             ir = FoldConstants(ctx, ir)
             ir = ExtractIntervalFilters(ctx, ir)
             ir = Simplify(ctx, ir)
-
+            ir = LiftAvailableExprs(ctx, ir)
             ir = {
               val ir_ = ForwardLets(ctx, ir)
               try

--- a/hail/hail/src/is/hail/expr/ir/lowering/Simplify.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/Simplify.scala
@@ -480,8 +480,6 @@ object Simplify {
                 && isDefinitelyDefined(step) =>
             Some(IsNA(arr))
 
-          // bindings are unaffected; move `IsNA` closer to the source of missingness
-          case Block(bindings, body) => Some(Block(bindings, IsNA(body)))
           case If(predicate, cnsq, altr) =>
             Some(Coalesce(FastSeq(If(predicate, IsNA(cnsq), IsNA(altr)), True())))
 
@@ -597,9 +595,6 @@ object Simplify {
 
       case StreamFlatMap(stream, x, f) =>
         stream match {
-          case Block(bindings, body) =>
-            Some(Block(bindings, StreamFlatMap(body, x, f)))
-
           case StreamMap(a, y, g) =>
             Some(StreamFlatMap(a, y, Let(FastSeq(x -> g), f)))
 
@@ -615,9 +610,6 @@ object Simplify {
       // FIXME: Unqualify when StreamFold supports folding over stream of streams
       case StreamFold(s, zero, accum, elem, f) =>
         s match {
-          case Block(bindings, body) =>
-            Some(Block(bindings, StreamFold(body, zero, accum, elem, f)))
-
           case StreamFilter(a, name, cond) if TIterable.elementType(a.typ).isRealizable =>
             val ref = Ref(name, TIterable.elementType(a.typ))
             val body = If(cond, Subst(f, BindingEnv.eval(elem -> ref)), Ref(accum, zero.typ))
@@ -640,9 +632,6 @@ object Simplify {
 
       case StreamFor(stream, x, f) =>
         stream match {
-          case Block(bindings, value) =>
-            Some(Block(bindings, StreamFor(value, x, f)))
-
           case StreamMap(inner, y, g) =>
             Some(StreamFor(inner, y, Let(FastSeq(x -> g), f)))
 
@@ -663,9 +652,6 @@ object Simplify {
 
       case StreamFilter(stream, x, cond) =>
         stream match {
-          case Block(bindings, body) =>
-            Some(Block(bindings, StreamFilter(body, x, cond)))
-
           case ArraySort(a, left, right, lessThan) =>
             Some(ArraySort(StreamFilter(a, x, cond), left, right, lessThan))
 
@@ -698,9 +684,6 @@ object Simplify {
           case MakeStream(args, _, _) =>
             Some(I32(args.length))
 
-          case Block(bindings, body) =>
-            Some(Block(bindings, StreamLen(body)))
-
           case StreamMap(s, _, _) =>
             Some(StreamLen(s))
 
@@ -722,9 +705,6 @@ object Simplify {
 
       case StreamMap(stream, x, f) =>
         stream match {
-          case Block(bindings, body) =>
-            Some(Block(bindings, StreamMap(body, x, f)))
-
           case MakeStream(Seq(), _, _) =>
             Some(MakeStream(FastSeq(), tcoerce[TStream](ir.typ)))
 
@@ -946,9 +926,6 @@ object Simplify {
         child match {
           case ToArray(s) if s.typ.isInstanceOf[TStream] =>
             Some(s)
-
-          case Block(bindings, ToArray(x)) if x.typ.isInstanceOf[TStream] =>
-            Some(Block(bindings, x))
 
           case MakeArray(args, t) =>
             Some(MakeStream(args, TStream(t.elementType)))

--- a/hail/hail/src/is/hail/expr/ir/lowering/invariant/package.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/invariant/package.scala
@@ -67,7 +67,7 @@ package object invariant {
     Fused(p)
 
   def LowerableIR(implicit E: Enclosing): Invariant =
-    NoSharedNodes and UniquelyNamed
+    UniquelyNamed and NoSharedNodes
 
   def NoSharedNodes: Invariant = {
     var mark: Int = 0

--- a/hail/hail/test/src/is/hail/expr/ir/lowering/ForwardLetsSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/lowering/ForwardLetsSuite.scala
@@ -12,13 +12,9 @@ import is.hail.types.virtual._
 
 import scala.collection.immutable.ArraySeq
 
-import org.junit.jupiter.api.{BeforeEach, Test}
+import org.junit.jupiter.api.Test
 
 class ForwardLetsSuite {
-
-  @BeforeEach
-  def resetUidCounter(): Unit =
-    is.hail.expr.ir.uidCounter = 0
 
   def testNonForwardingOps() = {
     val a = ToArray(StreamRange(I32(0), I32(10), I32(1)))
@@ -107,12 +103,8 @@ class ForwardLetsSuite {
   }
 
   @ParameterizedTest
-  def testNonForwardingOps(ir: IR)(implicit ctx: ExecuteContext): Unit = {
-    val after = ForwardLets(ctx, ir)
-    val normalizedBefore = NormalizeNames()(ctx, ir)
-    val normalizedAfter = NormalizeNames()(ctx, after)
-    assertEq(normalizedAfter, normalizedBefore)
-  }
+  def testNonForwardingOps(ir: IR)(implicit ctx: ExecuteContext): Unit =
+    assert(ForwardLets(ctx, ir) isAlphaEquiv ir)
 
   @ParameterizedTest
   def testNonForwardingNonEvalOps(ir: IR)(implicit ctx: ExecuteContext): Unit = {
@@ -201,16 +193,8 @@ class ForwardLetsSuite {
 
   @ParameterizedTest
   def testTrivialCases(input: IR, _expected: IR, reason: String)(implicit ctx: ExecuteContext)
-    : Unit = {
-    val normalize: (ExecuteContext, BaseIR) => BaseIR = NormalizeNames(allowFreeVariables = true)
-    val result = normalize(ctx, ForwardLets(ctx, input))
-    val expected = normalize(ctx, _expected)
-    assertEq(
-      result,
-      normalize(ctx, expected),
-      s"\ninput:\n${Pretty.sexprStyle(input)}\nexpected:\n${Pretty.sexprStyle(expected)}\ngot:\n${Pretty.sexprStyle(result)}\n$reason",
-    )
-  }
+    : Unit =
+    assert(ForwardLets(ctx, input) isAlphaEquiv _expected, reason)
 
   @Test def testAggregators(implicit ctx: ExecuteContext): Unit = {
     val row = Ref(freshName(), TStruct("idx" -> TInt32))

--- a/hail/hail/test/src/is/hail/expr/ir/lowering/LiftAvailableExprsSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/lowering/LiftAvailableExprsSuite.scala
@@ -1,0 +1,690 @@
+package is.hail.expr.ir.lowering
+
+import is.hail.ParameterizedTest
+import is.hail.annotations.RowSeq
+import is.hail.backend.ExecuteContext
+import is.hail.collection.FastSeq
+import is.hail.expr.ir.{Memoized => M, _}
+import is.hail.expr.ir.Scope._
+import is.hail.expr.ir.agg.{PhysicalAggSig, TypedStateSig}
+import is.hail.expr.ir.defs._
+import is.hail.expr.ir.implicits.forTesting._
+import is.hail.io.{BufferSpec, TypedCodecSpec}
+import is.hail.types.VirtualTypeWithReq
+import is.hail.types.encoded.EBinaryOptional
+import is.hail.types.physical.PInt64
+import is.hail.types.virtual._
+
+import org.scalactic.{Equivalence, Prettifier}
+import org.scalatest.matchers.{MatchResult, Matcher}
+import org.scalatest.matchers.dsl.MatcherFactory1
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+
+class LiftAvailableExprsSuite {
+
+  private def liftTo(expected: BaseIR)(implicit ctx: ExecuteContext) =
+    new MatcherFactory1[BaseIR, Equivalence] {
+      override def matcher[T <: BaseIR: Equivalence]: Matcher[T] =
+        Matcher[BaseIR] { input =>
+          val lifted = LiftAvailableExprs(ctx, input)
+
+          val prettyDiff =
+            s"""  before = \n${Pretty.sexprStyle(input).trim}\n
+               |   after = \n${Pretty.sexprStyle(lifted).trim}\n
+               |expected = \n${Pretty.sexprStyle(expected).trim}\n
+               | """.stripMargin
+
+          MatchResult(
+            matches = lifted isAlphaEquiv expected,
+            rawFailureMessage = s"The lifted IR was not alpha-equivalent:\n$prettyDiff",
+            rawNegatedFailureMessage = s"The lifted IR was alpha-equivalent:\n$prettyDiff",
+          )
+        }
+    }
+
+  implicit def irPrettifier(implicit ctx: ExecuteContext): Prettifier = {
+    case ir: BaseIR => Pretty(ctx, ir)
+    case x => Prettifier.default(x)
+  }
+
+  def ref(typ: Type) = Ref(Name("#undefined"), typ)
+  def a = Ref(Name("a"), TInt32)
+  def b = Ref(Name("b"), TInt32)
+  def s = Ref(Name("sierra"), TStream(TInt32))
+  def s2 = Ref(Name("tango"), TStream(TInt32))
+  def cond = Ref(Name("cond"), TBoolean)
+  def str = Str("a")
+
+  // A binding that can neither be forwarded (not a ref) nor speculated (not total)
+  def bindings = FastSeq(Binding(Name("x"), Die(ref(TString), TInt32, -1)))
+
+  def testLiftAvailableExprs =
+    FastSeq(
+      // -- Atoms and constants are unchanged --
+      I32(1) -> I32(1),
+      ref(TInt32) -> ref(TInt32),
+      str -> str,
+
+      // -- Nested Blocks flatten --
+      bindIR(a + b)(x => bindIR(b + a)(y => x + y)) ->
+        bindIRs(a + b, b + a) { case Seq(x, y) => x + y },
+
+      // -- Bindings whose value is a ref are forwarded to the referent --
+      bindIR(a)(x => bindIR(b)(y => x + y)) -> (a + b),
+
+      // -- Bindings whose value is a constant atom are forwarded, like refs --
+      bindIR(I32(5))(x => maketuple(x, x)) -> maketuple(I32(5), I32(5)),
+
+      // -- Forwarding unifies spellings: expressions built on the alias and on
+      // the constant itself dedup to one binding --
+      bindIR(I32(5))(x => maketuple(x + a, I32(5) + a)) ->
+        bindIR(I32(5) + a)(t => maketuple(t, t)),
+
+      // -- Blocks in binding values are lifted --
+      bindIR(bindIR(a + I32(1))(y => y + I32(1)))(x => x + x) ->
+        M.eval {
+          for {
+            y <- a + I32(1)
+            x <- y + I32(1)
+          } yield x + x
+        },
+
+      // -- Weak a-normal form: compound strict children are bound at the region root --
+      maketuple(a + I32(1)) ->
+        bindIR(a + I32(1))(a => maketuple(a)),
+
+      // -- Common strict subexpressions dedup to one binding --
+      maketuple(a + I32(1), a + I32(1)) ->
+        bindIR(a + I32(1))(y => maketuple(y, y)),
+
+      // -- Later occurrences of a named binding's value resolve to that binding --
+      bindIR(a + 1)(x => maketuple(a + 1, x)) ->
+        bindIR(a + 1)(x => maketuple(x, x)),
+
+      // -- Bindings with a common value are forwarded to the first --
+      bindIRs(a + 1, a + 1)(_ => ref(TInt32)) ->
+        bindIR(a + 1)(_ => ref(TInt32)),
+
+      // -- Lifting through strict positions --
+      // Binary op: both args, bindings merged left-to-right
+      bindIR(a + 1)(_ => ref(TInt32)) + bindIR(b + 1)(_ => ref(TInt32)) ->
+        M.eval {
+          for {
+            _ <- a + 1
+            _ <- b + 1
+          } yield ref(TInt32) + ref(TInt32)
+        },
+      // Ifs
+      If(Block(bindings, ref(TBoolean)), I32(1), I32(0)) ->
+        Block(bindings, If(ref(TBoolean), I32(1), I32(0))),
+      // Strict stream and zero args of a fold
+      foldIR(Block(bindings, s), ref(TInt32))((_, _) => ref(TInt32)) ->
+        Block(bindings, foldIR(s, ref(TInt32))((_, _) => ref(TInt32))),
+      M.eval {
+        for {
+          x <- If(cond, a + 1, b + 1)
+          y <- a + 1
+        } yield x + y
+      } -> M.eval {
+        for {
+          y <- a + 1
+          x <- If(cond, y, b + 1)
+        } yield x + y
+      },
+
+      // -- Anticipation includes the current binding's own spine: a later
+      // occurrence within the same value licenses the hoist --
+      M.eval {
+        for {
+          x <- If(cond, a + 1, b + 1) * (a + 1)
+        } yield x
+      } -> M.eval {
+        for {
+          t <- a + 1
+          u <- If(cond, t, b + 1)
+          x <- u * t
+        } yield x
+      },
+
+      // -- Anticipation requires the later occurrence on the unconditional
+      // spine: one hidden inside another If's branch does not license the
+      // hoist --
+      M.eval {
+        for {
+          x <- If(cond, a + 1, b + 1)
+          y <- If(cond, a + 1, I32(0))
+        } yield x + y
+      } -> M.eval {
+        for {
+          x <- If(cond, a + 1, b + 1)
+          y <- If(cond, a + 1, I32(0))
+        } yield x + y
+      },
+
+      // -- Anticipation licenses motion of any deeply pure, deterministic
+      // expression: a failure-capable head like mod is down-safe at its
+      // spine occurrence, firing the failure earlier rather than adding
+      // one --
+      {
+        def mod = Apply("mod", FastSeq(), FastSeq(a, I32(2)), TInt32)
+
+        M.eval {
+          for {
+            x <- If(cond, mod, b + 1)
+            y <- mod
+          } yield x + y
+        } -> M.eval {
+          for {
+            y <- mod
+            x <- If(cond, y, b + 1)
+          } yield x + y
+        }
+      },
+
+      // -- Anticipation covers the region root's own spine: a later
+      // occurrence as a sibling strict child licenses the hoist, with no
+      // enclosing Block in the source --
+      {
+        def mod = Apply("mod", FastSeq(), FastSeq(a, I32(2)), TInt32)
+
+        If(cond, mod, b + 1) + mod ->
+          M.eval {
+            for {
+              t <- mod
+              x <- If(cond, t, b + 1)
+            } yield x + t
+          }
+      },
+
+      // -- ...including non-Block strict spines like a tuple's fields --
+      {
+        def mod = Apply("mod", FastSeq(), FastSeq(a, I32(2)), TInt32)
+
+        maketuple(If(cond, mod, b + 1), mod) ->
+          M.eval {
+            for {
+              t <- mod
+              x <- If(cond, t, b + 1)
+            } yield maketuple(x, t)
+          }
+      },
+
+      // -- ...and every non-strict site's spine: a hoist out of a
+      // conditional in a loop body lands at the body frame where the
+      // element is bound, not outside the loop --
+      {
+        def mod(x: IR) = Apply("mod", FastSeq(), FastSeq(x, I32(2)), TInt32)
+
+        s.streamMap(x => If(cond, mod(x), b + 1) + mod(x)) ->
+          s.streamMap { x =>
+            M.eval {
+              for {
+                t <- mod(x)
+                y <- If(cond, t, b + 1)
+              } yield y + t
+            }
+          }
+      },
+
+      // -- Busy expressions: a total value on the spine of every branch
+      // is evaluated whichever branch runs, so it hoists above the
+      // conditional --
+      M.eval {
+        for {
+          x <- If(cond, a + 1, (a + 1) * b)
+        } yield x
+      } -> M.eval {
+        for {
+          t <- a + 1
+          x <- If(cond, t, t * b)
+        } yield x
+      },
+
+      // -- A non-total busy head stays pinned: a missing predicate skips
+      // both branches, and a hoisted failure-capable op would run on
+      // those rows --
+      {
+        def mod = Apply("mod", FastSeq(), FastSeq(a, I32(2)), TInt32)
+
+        If(cond, mod, mod * b) ->
+          If(cond, mod, bindIR(mod)(t => t * b))
+      },
+
+      // -- The busy intersection spans a Switch's default and cases --
+      Switch(b, a + 1, FastSeq((a + 1) * b)) ->
+        bindIR(a + 1)(t => Switch(b, t, FastSeq(t * b))),
+
+      // -- A busy nest hoists whole in one run: the shared VNs compose
+      // bottom-up --
+      {
+        def len = ArrayLen(MakeArray(FastSeq(a), TArray(TInt32)))
+
+        If(cond, len, len + 1) ->
+          M.eval {
+            for {
+              t <- MakeArray(FastSeq(a), TArray(TInt32))
+              u <- ArrayLen(t)
+            } yield If(cond, u, u + 1)
+          }
+      },
+
+      // -- Equal effects in both branches are not busy: each occurrence
+      // has its own value --
+      {
+        def u = maketuple(UUID4("rng"))
+
+        If(cond, u, u) ->
+          If(cond, bindIR(UUID4("rng"))(x => maketuple(x)), bindIR(UUID4("rng"))(x => maketuple(x)))
+      },
+
+      // -- A UUID4 hiding under a non-strict edge blocks reuse
+      {
+        def u = If(cond, UUID4("rng"), str)
+
+        maketuple(u, u) -> bindIRs(u, u) { case Seq(x, y) => maketuple(x, y) }
+      },
+
+      // -- ...and blocks the down-safe hoist: the branch draw and the
+      // spine draw are distinct values --
+      {
+        def u = If(cond, UUID4("rng"), str)
+
+        M.eval {
+          for {
+            x <- If(cond, u, str)
+            y <- u
+          } yield maketuple(x, y)
+        } -> M.eval {
+          for {
+            x <- If(cond, u, str)
+            y <- u
+          } yield maketuple(x, y)
+        }
+      },
+
+      // -- index_bgen, the registry's one effectful function, is E by
+      // name: equal calls are not collapsed --
+      {
+        def idx = Apply(
+          "index_bgen",
+          FastSeq(TStruct("contig" -> TString, "position" -> TInt32)),
+          FastSeq(
+            ref(TString),
+            ref(TString),
+            ref(TDict(TString, TString)),
+            ref(TBoolean),
+            ref(TInt32),
+          ),
+          TInt64,
+        )
+
+        maketuple(idx, idx) -> bindIRs(idx, idx) { case Seq(x, y) => maketuple(x, y) }
+      },
+
+      // -- An effect hiding under a non-strict edge blocks reuse too:
+      // collapsing equal spellings would drop a write --
+      {
+        def w = If(
+          cond,
+          WriteValue(
+            ref(TString),
+            ref(TString),
+            ETypeValueWriter(TypedCodecSpec(EBinaryOptional, TString, BufferSpec.default)),
+          ),
+          str,
+        )
+
+        maketuple(w, w) -> bindIRs(w, w) { case Seq(x, y) => maketuple(x, y) }
+      },
+
+      // -- An effect buried in a relational child blocks reuse too: each
+      // aggregate runs its pipeline, drawing its own UUID --
+      {
+        def agg = TableAggregate(
+          TableRange(10, 1).mapGlobals(_.insert("u" -> UUID4("rng"))),
+          ApplyAggOp(Count())(),
+        )
+
+        def expected = TableAggregate(
+          TableRange(10, 1).mapGlobals(g => bindIR(UUID4("rng"))(u => g.insert("u" -> u))),
+          ApplyAggOp(Count())(),
+        )
+
+        maketuple(agg, agg) -> bindIRs(expected, expected) { case Seq(x, y) => maketuple(x, y) }
+      },
+
+      // -- A movable-but-not-total head still takes a down-safe hoist:
+      // the spine occurrence guarantees the evaluation happens anyway.
+      // The enclosing ArrayLen hoists too: rebuilt as ArrayLen(t), its
+      // unfolded spelling matches the anticipated set --
+      M.eval {
+        for {
+          x <- If(cond, ArrayLen(ToArray(s2)), b)
+          y <- ArrayLen(ToArray(s2))
+        } yield x + y
+      } -> M.eval {
+        for {
+          t <- ToArray(s2)
+          u <- ArrayLen(t)
+          x <- If(cond, u, b)
+        } yield x + u
+      },
+
+      // -- Unfolding composes through nesting: each hoisted layer's
+      // binding is recorded in source spelling, so a two-deep nest
+      // hoists fully in one run --
+      M.eval {
+        for {
+          x <- If(cond, Cast(ArrayLen(ToArray(s2)), TInt64), Cast(b, TInt64))
+          y <- Cast(ArrayLen(ToArray(s2)), TInt64)
+        } yield maketuple(x, y)
+      } -> M.eval {
+        for {
+          t <- ToArray(s2)
+          u <- ArrayLen(t)
+          v <- Cast(u, TInt64)
+          x <- If(cond, v, Cast(b, TInt64))
+        } yield maketuple(x, v)
+      },
+
+      // -- Anticipation sees through nested blocks: the outer block's suffix
+      // licenses a hoist from a branch inside an inner block's binding --
+      M.eval {
+        for {
+          x <- M.eval {
+            for {
+              p <- If(cond, a + 1, b + 1)
+            } yield p * p
+          }
+          y <- a + 1
+        } yield x + y
+      } -> M.eval {
+        for {
+          t <- a + 1
+          p <- If(cond, t, b + 1)
+          x <- p * p
+        } yield x + t
+      },
+
+      // -- Anticipation never hoists across a dropEval wall: a binding placed
+      // outside ArrayMaximalIndependentSet's tie-breaker could not be
+      // referenced from within it. AMIS is the one dropEval edge that leaves
+      // both aggregation environments untouched, so only the region floor
+      // pins the hoist --
+      {
+        def payload =
+          maketuple(I32(1))
+
+        def amis(tb: IR) =
+          ArrayMaximalIndependentSet(
+            ref(TArray(TTuple(TInt64, TInt64))),
+            Some((Name("l"), Name("r"), tb)),
+          )
+
+        Block(
+          FastSeq(Binding(Name("x"), amis(If(IsNA(payload), F64(0), F64(1))))),
+          payload,
+        ) ->
+          Block(
+            FastSeq(Binding(
+              Name("x"),
+              amis(M.eval {
+                for {
+                  t <- payload
+                  c <- IsNA(t)
+                } yield If(c, F64(0), F64(1))
+              }),
+            )),
+            payload,
+          )
+      },
+
+      // -- NOT lifting through non-strict positions --
+      // If consequent
+      If(True(), Block(bindings, ref(TInt32)), I32(0)) ->
+        If(True(), Block(bindings, ref(TInt32)), I32(0)),
+      // StreamMap body
+      s.streamMap(_ => Block(bindings, ref(TInt32))) ->
+        s.streamMap(_ => Block(bindings, ref(TInt32))),
+      // -- A strict TVoid child (RunAgg's body) is never named: void has no
+      // value to bind. Its spine still runs exactly once with the parent,
+      // so a clean value within is anticipated at the region root and
+      // hoists; the effectful InitOp stays in the body's own frame --
+      {
+        def sig = PhysicalAggSig(Sum(), TypedStateSig(VirtualTypeWithReq(PInt64(true))))
+
+        def runAgg(body: IR) =
+          RunAgg(body, ResultOp(0, sig), FastSeq(sig.state))
+
+        runAgg(
+          Begin(FastSeq(
+            InitOp(0, FastSeq(), sig),
+            SeqOp(0, FastSeq(Cast(a, TInt64)), sig),
+          ))
+        ) ->
+          Block(
+            FastSeq(Binding(Name("c"), Cast(a, TInt64))),
+            runAgg(
+              Block(
+                FastSeq(Binding(Name("i"), InitOp(0, FastSeq(), sig))),
+                SeqOp(0, FastSeq(Ref(Name("c"), TInt64)), sig),
+              )
+            ),
+          )
+      },
+
+      // -- Duplicate constants dedup to one binding --
+      maketuple(Str("a"), Str("a")) -> bindIR(Str("a"))(x => maketuple(x, x)),
+
+      // -- Constants rise through non-strict loop/agg-body edges: StreamMap body --
+      s.streamMap(_ => Str("a")) -> bindIR(Str("a"))(x => s.streamMap(_ => x)),
+
+      // -- A movable-but-not-total expression does not: the stream may run
+      // zero times, and a forced evaluation can fail --
+      s.streamMap(_ => ToArray(s2)) -> s.streamMap(_ => ToArray(s2)),
+
+      // -- Constants do NOT rise out of conditionally-evaluated children; a
+      // bare constant in an isolated branch evaluates to itself --
+      If(True(), Str("a"), Str("b")) -> If(True(), Str("a"), Str("b")),
+
+      // -- ...but the same constant in every branch is busy and hoists --
+      If(True(), Str("a"), Str("a")) ->
+        bindIR(Str("a"))(x => If(True(), x, x)),
+
+      // -- A Block binding whose value is a non-atom constant (Str) is left in
+      // place: only atoms are safe to duplicate into use sites --
+      Block(FastSeq(Binding(Name("x"), Str("a"))), ref(TInt32)) ->
+        Block(FastSeq(Binding(Name("x"), Str("a"))), ref(TInt32)),
+
+      // -- A constant inside a dropEval wall is bound at that subtree's root, not the outer
+      // root; the TableAggregate, a compound strict child, is lifted to the outer root --
+      maketuple(Str("a"), TableAggregate(TableRange(10, 1), maketuple(Str("a"), Str("a")))) ->
+        bindIRs(
+          Str("a"),
+          TableAggregate(TableRange(10, 1), bindIR(Str("a"))(inner => maketuple(inner, inner))),
+        ) { case Seq(outer, agg) => maketuple(outer, agg) },
+
+      // -- A dropEval wall that creates an agg scope contains its whole region: aggregands
+      // referencing agg-scope names get AGG-tagged bindings at the wall's root --
+      {
+        def idx = Ref(TableIR.rowName, TStruct("idx" -> TInt32)).get("idx")
+
+        TableAggregate(TableRange(10, 1), ApplyAggOp(Max())(idx * idx)) ->
+          TableAggregate(
+            TableRange(10, 1),
+            Block(
+              FastSeq(
+                Binding(Name("x"), idx, Scope.AGG),
+                Binding(Name("y"), Ref(Name("x"), TInt32) * Ref(Name("x"), TInt32), Scope.AGG),
+              ),
+              ApplyAggOp(Max())(Ref(Name("y"), TInt32)),
+            ),
+          )
+      },
+
+      // -- Loop-invariant code motion: an expression rises to the shallowest frame at which
+      // all its free names are bound, provided its head operation is total. Ref-valued
+      // bindings forward to their referent, so `x + x` hoists as `xt + xt`. Expressions
+      // depending on the RelationalRef are pinned by the RelationalLet body; constants and
+      // their derivatives rise above the RelationalLet entirely --
+      {
+        val collect = TableRange(10, 1).mapGlobals(_.insert("x" -> I32(1))).collect
+        val literal = Literal(TStruct("y" -> TInt32), RowSeq(0))
+
+        relationalBindIR(collect) { rng =>
+          mapArray(rng.get("rows")) { r =>
+            r.get("idx") +
+              bindIR(rng.get("global").get("x"))(x => x + x) +
+              literal.get("y")
+          }
+        } ->
+          M.eval {
+            for {
+              lit <- literal
+              y <- lit.get("y")
+            } yield relationalBindIR(collect) { rng =>
+              M.eval {
+                for {
+                  rows <- rng.get("rows")
+                  global <- rng.get("global")
+                  xt <- global.get("x")
+                  xx <- xt + xt
+                } yield rows.stream.streamMap { r =>
+                  M.eval {
+                    for {
+                      idx <- r.get("idx")
+                      t1 <- idx + xx
+                    } yield t1 + y
+                  }
+                }.toArray
+              }
+            }
+          }
+      },
+      // -- Expressions using the RelationalRef are pinned inside the RelationalLet's body
+      // (its value is a dropEval wall); expressions in the body may refer to dominating
+      // bindings outside it --
+      {
+        val value = TableRange(10, 1).mapGlobals(_.insert("x" -> I32(1))).collect
+
+        maketuple(Str("a"), relationalBindIR(value)(rng => maketuple(Str("a"), rng.get("rows")))) ->
+          M.eval {
+            for {
+              outer <- Str("a")
+              rlet <- relationalBindIR(value)(_.get("rows").bind(maketuple(outer, _)))
+            } yield maketuple(outer, rlet)
+          }
+      },
+      // -- Equal aggregations in the same context share a binding --
+      rangeIR(0, 10).streamAgg { _ =>
+        maketuple(ApplyAggOp(Count())(), ApplyAggOp(Count())())
+      } -> rangeIR(0, 10).streamAgg { _ =>
+        M.eval {
+          for {
+            count <- ApplyAggOp(Count())()
+          } yield maketuple(count, count)
+        }
+      },
+
+      // -- Aggregations are not deduplicated across a context-transforming
+      // edge: the filtered count is not the total count --
+      rangeIR(0, 10).streamAgg { elem =>
+        maketuple(
+          ApplyAggOp(Count())(),
+          AggFilter(
+            Apply("mod", FastSeq(), FastSeq(elem, I32(2)), TInt32) ceq 0,
+            ApplyAggOp(Count())(),
+            isScan = false,
+          ),
+        )
+      } -> rangeIR(0, 10).streamAgg { elem =>
+        M.eval {
+          for {
+            count <- ApplyAggOp(Count())()
+            zero <- M.lift[AGG.type] {
+              for {
+                mod <- Apply("mod", FastSeq(), FastSeq(elem, I32(2)), TInt32)
+                zero <- mod ceq 0
+              } yield zero
+            }
+            filtered <- AggFilter(zero, ApplyAggOp(Count())(), isScan = false)
+          } yield maketuple(count, filtered)
+        }
+      },
+
+      // -- Structurally equal reads of mutable aggregator state are not
+      // deduplicated: an InitOp or SeqOp may intervene between them --
+      {
+        def read = maketuple(ResultOp(
+          0,
+          PhysicalAggSig(Sum(), TypedStateSig(VirtualTypeWithReq(PInt64(true)))),
+        ))
+
+        maketuple(read, read) -> maketuple(read, read)
+      },
+    ) ++
+      FastSeq(Scope.AGG, Scope.SCAN).flatMap { scope =>
+        val isScan = scope == Scope.SCAN
+
+        FastSeq(
+          // -- EVAL -> AGG / SCAN
+          AggFilter(
+            Block(FastSeq(Binding(Name("x"), IsNA(ref(TBoolean)))), ref(TBoolean)),
+            ref(TInt32),
+            isScan,
+          ) ->
+            Block(
+              FastSeq(Binding(Name("x"), IsNA(ref(TBoolean)), scope)),
+              AggFilter(ref(TBoolean), ref(TInt32), isScan),
+            ),
+
+          // -- Nested blocks in AGG/SCAN context: all EVAL bindings promoted --
+          AggFilter(
+            Block(
+              FastSeq(Binding(
+                Name("x"),
+                Block(
+                  FastSeq(Binding(Name("y"), a + I32(1))),
+                  Ref(Name("y"), TInt32) + I32(2),
+                ),
+              )),
+              ref(TBoolean),
+            ),
+            ref(TInt32),
+            isScan,
+          ) ->
+            Block(
+              FastSeq(
+                Binding(Name("y"), a + I32(1), scope),
+                Binding(Name("x"), Ref(Name("y"), TInt32) + I32(2), scope),
+              ),
+              AggFilter(ref(TBoolean), ref(TInt32), isScan),
+            ),
+          // -- AGG/SCAN bindings in EVAL context are preserved --
+          Block(FastSeq(Binding(Name("x"), b + I32(2), scope)), ref(TInt32)) + I32(1) ->
+            Block(FastSeq(Binding(Name("x"), b + I32(2), scope)), ref(TInt32) + I32(1)),
+          // -- A constant in an AGG context gets a Scope.AGG-tagged root binding --
+          AggFilter(Str("a"), ref(TInt32), isScan) ->
+            Block(
+              FastSeq(Binding(Name("x"), Str("a"), scope)),
+              AggFilter(Ref(Name("x"), TString), ref(TInt32), isScan),
+            ),
+
+          // -- The same constant in EVAL and AGG contexts gets two separate bindings; the
+          // AggFilter, itself a compound strict child, is lifted too --
+          maketuple(Str("a"), AggFilter(Str("a"), ref(TInt32), isScan)) ->
+            Block(
+              FastSeq(
+                Binding(Name("x"), Str("a"), Scope.EVAL),
+                Binding(Name("y"), Str("a"), scope),
+                Binding(Name("z"), AggFilter(Ref(Name("y"), TString), ref(TInt32), isScan)),
+              ),
+              maketuple(Ref(Name("x"), TString), Ref(Name("z"), TInt32)),
+            ),
+        )
+      }
+
+  @ParameterizedTest
+  def testLiftAvailableExprs(input: IR, expected: IR)(implicit ctx: ExecuteContext): Unit =
+    input should liftTo(expected)
+}

--- a/hail/hail/test/src/is/hail/expr/ir/lowering/SimplifySuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/lowering/SimplifySuite.scala
@@ -425,12 +425,8 @@ class SimplifySuite {
     def g = Ref(Name("golf"), TInt32)
     def arr = Ref(Name("alpha"), TArray(TInt32))
 
-    def bindings = FastSeq(Binding(Name("x"), ref(TInt32)))
-
     FastSeq(
       // -- StreamFlatMap --
-      Block(bindings, s).streamFlatMap(_ => t) ->
-        Block(bindings, s.streamFlatMap(_ => t)),
       s.streamMap(_ => ref(TInt32)).streamFlatMap(_ => t) ->
         s.streamFlatMap(_ => bindIR(ref(TInt32))(_ => t)),
       s.streamFlatMap(_ => t).streamFlatMap(_ => t) ->
@@ -438,8 +434,6 @@ class SimplifySuite {
       NA(TStream(TInt32)).streamFlatMap(_ => t) ->
         NA(TStream(TInt32)),
       // -- StreamMap --
-      Block(bindings, s).streamMap(_ => ref(TInt32)) ->
-        Block(bindings, s.streamMap(_ => ref(TInt32))),
       s.streamMap(_ => ref(TInt32)).streamMap(_ => ref(TInt32)) ->
         s.streamMap(_ => bindIR(ref(TInt32))(_ => ref(TInt32))),
       s.zip(t)((_, _) => ref(TInt32)).streamMap(_ => ref(TInt32)) ->
@@ -457,8 +451,6 @@ class SimplifySuite {
       MakeStream.empty(TInt32).streamMap(_ => ref(TInt64)) ->
         MakeStream.empty(TInt64),
       // -- StreamFilter --
-      Block(bindings, s).filter(_ => ref(TBoolean)) ->
-        Block(bindings, s.filter(_ => ref(TBoolean))),
       StreamFilter(sortIR(s)((_, _) => ref(TBoolean)), Name("a"), ref(TBoolean)) ->
         sortIR(StreamFilter(s, Name("a"), ref(TBoolean)))((_, _) => ref(TBoolean)),
       s.streamFlatMap(_ => t).filter(_ => ref(TBoolean)) ->
@@ -471,8 +463,6 @@ class SimplifySuite {
       s.filter(_ => False()) ->
         StreamTake(s, I32(0)),
       // -- StreamFor --
-      Block(bindings, s).streamFor(_ => ref(TVoid)) ->
-        Block(bindings, s.streamFor(_ => ref(TVoid))),
       s.streamMap(_ => ref(TInt32)).streamFor(_ => ref(TVoid)) ->
         s.streamFor(_ => bindIR(ref(TInt32))(_ => ref(TVoid))),
       s.streamFlatMap(_ => t).streamFor(_ => ref(TVoid)) ->
@@ -488,8 +478,6 @@ class SimplifySuite {
       s.streamAggScan(_ => ref(TInt32)) ->
         s.streamMap(_ => ref(TInt32)),
       // -- StreamFold --
-      foldIR(Block(bindings, s), ref(TInt32))((_, _) => ref(TInt32)) ->
-        Block(bindings, foldIR(s, ref(TInt32))((_, _) => ref(TInt32))),
       foldIR(s.filter(_ > 0), ref(TInt32))(_ + _) ->
         foldIR(s, ref(TInt32))((acc, elem) => If(elem > 0, acc + elem, acc)),
       foldIR(s.streamFlatMap(_ => t), ref(TInt32))(_ + _) ->
@@ -506,8 +494,6 @@ class SimplifySuite {
         I32(3),
       MakeStream.empty(TInt32).len ->
         I32(0),
-      Block(bindings, s).len ->
-        Block(bindings, s.len),
       s.streamMap(_ => ref(TInt32)).len ->
         s.len,
       s.streamFlatMap(_ => ref(TStream(TInt32))).len ->
@@ -1208,10 +1194,6 @@ class SimplifySuite {
       (IsNA(ToArray(StreamMap(ToStream(a), elt, IsNA(Ref(elt, TInt32))))), IsNA(a)),
       (IsNA(Cast(x, TInt64)), IsNA(x)),
       (IsNA(SelectFields(st, FastSeq("a"))), IsNA(st)),
-      (
-        IsNA(Let(FastSeq(elt -> x), Ref(elt, TInt32))),
-        Let(FastSeq(elt -> x), IsNA(Ref(elt, TInt32))),
-      ),
       /* nodes with more than one strict child are transparent when every other child is definitely
        * defined */
       (IsNA(StreamTake(s, I32(2))), IsNA(s)),

--- a/hail/python/test/hail/expr/test_expr.py
+++ b/hail/python/test/hail/expr/test_expr.py
@@ -1283,11 +1283,12 @@ class Tests(unittest.TestCase):
         assert r.n_smaller == 0
         assert r.n_larger == 0
 
-    def test_aggregator_cse(self):
+    def test_aggregator_cse_1(self):
         ht = hl.utils.range_table(10)
         x = hl.agg.count()
         self.assertEqual(ht.aggregate((x, hl.agg.filter(ht.idx % 2 == 0, x))), (10, 5))
 
+    def test_aggregator_cse_2(self):
         mt = hl.utils.range_matrix_table(10, 10)
         x = hl.int64(5)
         rows = mt.annotate_rows(agg=hl.agg.sum(x + x), scan=hl.scan.sum(x + x), val=x + x).rows()


### PR DESCRIPTION
Adds `LiftAvailableExprs`, a compiler pass that

- rewrites each `IR` region into weak A-normal form (`WeakANF`);
- performs CSE, LICM, and PRE on top of the naming.

The pass is a two-phase GVN-PRE (after VanDrunen & Hosking, CC 2004) adapted to a tree IR:

- a linear post-order analysis per region assigns every expression a value number (VN) and
computes anticipability over VNs;
- a single rebuild then places bindings at the shallowest sound frame (bounded by speculation
and region floors, with agg/scan walls bounding reuse) and eliminates redundancies against a
VN-keyed availability map.

Being a tree, neither phase iterates: program order is dominance order, so the paper's Insert
and Eliminate fuse into one rebuild. Includes busy-expression hoisting at `If`/`Switch`, gated
on total heads because a missing predicate skips all branches.

The pass runs in the `Optimize` loop before `ForwardLets`, which inlines the single-use
bindings it introduces, so only genuinely shared or hoisted values persist as lets.

For example (from the test suite), the loop-invariant `x + x` and the literal projection
`lit.y` are computed once instead of per element:

```
RelationalLet rng = collect(...)                  let y = Literal({y: 0}).y
ToArray(StreamMap(rng.rows, r ->                  RelationalLet rng = collect(...)
  r.idx + (let x = rng.global.x in x + x)   ==>     let xt = rng.global.x, xx = xt + xt
        + Literal({y: 0}).y))                       ToArray(StreamMap(rng.rows, r ->
                                                      (r.idx + xx) + y))
```

Design notes, soundness arguments, and the alternatives rejected along the way are in
`dev-docs/compiler-team/lift-available-exprs.md`. 

## Supporting changes

- `Simplify`: `Block`\-hoisting rules are deleted
    - the new pass normalizes `Blocks`
    - `Simplify` no longer scrutinizes them when pattern-matching other operations.
- `IsPure`: atoms are pure (including `Void()`), and `Die` is no longer classed impure
    - consistent with `ForwardLets`, which already moves it freely.
- `Bindings` fix: `StreamBufferedAggregate` no longer binds its element name in the `initAggs `child.
- `BaseIR.foldChildrenWithIndex`: an indexed, state-threading child fold used by the rebuild.
- ir-gen: `Ref` and `RelationalRef` share a new `LeafRef` trait (`BaseRef with Atom`).

## Security Assessment

This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP