### PR TITLE
[auth] allow role patching for inactive users

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -1176,9 +1176,9 @@ async def patch_system_roles_for_user(request: web.Request, _) -> web.Response:
 
     # Verify user exists - and get a user record - from either ID or unique username:
     if isinstance(user_id, int):
-        user = await db.select_and_fetchone("SELECT id, username FROM users WHERE id = %s", (user_id,))
+        user = await db.select_and_fetchone("SELECT id, username, state FROM users WHERE id = %s", (user_id,))
     else:
-        user = await db.select_and_fetchone("SELECT id, username FROM users WHERE username = %s", (user_id,))
+        user = await db.select_and_fetchone("SELECT id, username, state FROM users WHERE username = %s", (user_id,))
 
     if not user:
         raise web.HTTPNotFound(text='User not found')
@@ -1186,6 +1186,8 @@ async def patch_system_roles_for_user(request: web.Request, _) -> web.Response:
     @transaction(db)
     async def modify_roles(tx):
         if 'role_addition' in body:
+            if user['state'] != 'active':
+                raise web.HTTPBadRequest(text=f'Cannot add roles to user {user["username"]} with state {user["state"]}')
             role_name = body['role_addition']
 
             # Check if user already has this role

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -1176,16 +1176,12 @@ async def patch_system_roles_for_user(request: web.Request, _) -> web.Response:
 
     # Verify user exists - and get a user record - from either ID or unique username:
     if isinstance(user_id, int):
-        user = await db.select_and_fetchone(
-            "SELECT id, username FROM users WHERE id = %s AND state = 'active'", (user_id,)
-        )
+        user = await db.select_and_fetchone("SELECT id, username FROM users WHERE id = %s", (user_id,))
     else:
-        user = await db.select_and_fetchone(
-            "SELECT id, username FROM users WHERE username = %s AND state = 'active'", (user_id,)
-        )
+        user = await db.select_and_fetchone("SELECT id, username FROM users WHERE username = %s", (user_id,))
 
     if not user:
-        raise web.HTTPNotFound(text='User not found or not active')
+        raise web.HTTPNotFound(text='User not found')
 
     @transaction(db)
     async def modify_roles(tx):

--- a/auth/auth/driver/driver.py
+++ b/auth/auth/driver/driver.py
@@ -659,8 +659,7 @@ async def _remove_stale_namespaces(app):
             """
 SELECT u.id, u.namespace_name
 FROM users u
-WHERE u.state = 'active'
-  AND u.namespace_name IS NOT NULL
+WHERE u.namespace_name IS NOT NULL
   AND u.id NOT IN (
       SELECT usr.user_id
       FROM users_system_roles usr


### PR DESCRIPTION
## Change Description

Allows the role patching APIs to be called on inactive users.

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Good for system hygiene to be able to remove superuser roles on users even if they are inactive

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
