### PR TITLE
[compiler] fix new_combiner compilation error with batch size > 2

### DIFF
--- a/hail/hail/src/is/hail/expr/ir/MatrixWriter.scala
+++ b/hail/hail/src/is/hail/expr/ir/MatrixWriter.scala
@@ -2497,17 +2497,16 @@ case class MatrixNativeMultiWriter(
 
     val contextUnionType = TStruct("__matrix_id" -> TInt32, "__options" -> unionType)
 
-    val emptyUnionIRs: IndexedSeq[(Int, IR)] =
-      ArraySeq.tabulate(unionType.size)(i => i -> NA(unionType.types(i)))
-
     val concatenatedContexts =
       flatten(
         MakeArray(
           components.zipWithIndex.map { case (c, matrixId) =>
-            ToArray(mapIR(c.stage.contexts) { ctx =>
+            ToArray(c.stage.contexts.streamMap { ctx =>
               makestruct(
                 "__matrix_id" -> I32(matrixId),
-                "__options" -> MakeTuple(emptyUnionIRs.updated(matrixId, matrixId -> ctx.ir)),
+                "__options" -> MakeTuple(ArraySeq.tabulate(unionType.size) { i =>
+                  i -> (if (i == matrixId) ctx.ir else NA(unionType.types(i)))
+                }),
               )
             })
           },
@@ -2531,25 +2530,22 @@ case class MatrixNativeMultiWriter(
 
         result <- cdaIR(concatenatedContexts, allBroadcasts, "matrix_multi_writer") {
           (ctx, globals) =>
-            Switch(
-              GetField(ctx, "__matrix_id"),
-              default = Die("MatrixId exceeds matrix count", components.head.writePartitionType),
-              cases = components.zipWithIndex.map { case (component, i) =>
-                val binds = component.stage.broadcastVals.map { case (name, _) =>
-                  name -> GetField(globals, name.str)
-                }
-
-                Let(
-                  binds,
+            ctx.get("__options").bind { options =>
+              Switch(
+                ctx.get("__matrix_id"),
+                default = Die("MatrixId exceeds matrix count", components.head.writePartitionType),
+                cases = components.zipWithIndex.map { case (component, i) =>
                   IRBuilder.scoped { b =>
-                    val options = GetField(ctx, "__options")
-                    val ctxRef = b.memoize(GetTupleElement(options, i))
+                    for ((name, _) <- component.stage.broadcastVals)
+                      b.strictMemoize(globals.get(name.str), name)
+
+                    val ctxRef = b.memoize(options.get(i))
                     val rows = b.memoize(component.stage.partition(ctxRef))
                     component.writePartition(rows, ctxRef)
-                  },
-                )
-              },
-            )
+                  }
+                },
+              )
+            }
         }
 
         partCounts = components.map(_.stage.numPartitions).scanLeft(0)(_ + _)

--- a/hail/python/test/hail/matrixtable/test_matrix_table.py
+++ b/hail/python/test/hail/matrixtable/test_matrix_table.py
@@ -1684,16 +1684,13 @@ class Tests(unittest.TestCase):
         assert localized._same(t)
 
     def test_multi_write(self):
-        mt = self.get_mt()
-        f = new_temp_file()
-        hl.experimental.write_matrix_tables([mt, mt], f)
-        path1 = f + '0.mt'
-        path2 = f + '1.mt'
-        mt1 = hl.read_matrix_table(path1)
-        mt2 = hl.read_matrix_table(path2)
-        self.assertTrue(mt._same(mt1))
-        self.assertTrue(mt._same(mt2))
-        self.assertTrue(mt1._same(mt2))
+        mt = hl.utils.range_matrix_table(10, 10)
+        mts = [mt] * 3  # RR: 15604
+        prefix = new_temp_file()
+        paths = hl.experimental.write_matrix_tables(mts, prefix)
+        for path in paths:
+            mt_n = hl.read_matrix_table(path)
+            self.assertTrue(mt._same(mt_n))
 
     def test_matrix_type_equality(self):
         mt = hl.utils.range_matrix_table(1, 1)


### PR DESCRIPTION
Fixes #15604

When batch size > 2, the context union generated by `MatrixNativeMultiWriter`  
contains shared IR nodes, causing the compiler to fall over.

This change does not affect the broad-managed batch service in GCP
