### PR TITLE
[hailctl] add `emr` command group for AWS EMR

### DIFF
--- a/hail/hail/src/is/hail/io/fs/RouterFS.scala
+++ b/hail/hail/src/is/hail/io/fs/RouterFS.scala
@@ -33,6 +33,11 @@ object CloudStorageConfig {
         CloudStorageConfig(azure = Some(AzureStorageConfig(credentialsFile)))
       case Some("gcp") | None =>
         CloudStorageConfig(google = Some(GoogleStorageConfig(credentialsFile, None)))
+      case Some("aws") =>
+        // EMR provides EMRFS (s3://) and hadoop-aws (s3a://) on the Hadoop classpath,
+        // so RouterFS needs only its HadoopFS fallback. Returning an all-None config
+        // avoids constructing a GoogleStorageFS (which would require GCP credentials).
+        CloudStorageConfig()
       case unknown =>
         fatal(s"unknown cloud vendor: '$unknown'.")
     }

--- a/hail/python/hail/docs/change_log.md
+++ b/hail/python/hail/docs/change_log.md
@@ -52,6 +52,12 @@ supports.
 policy. Their functionality or even existence may change without notice. Please contact us if you
 critically depend on experimental functionality.**
 
+## Version 0.2.139
+
+### New Features
+
+- (hail#15612) (CHANGELOG) Add `hailctl emr`, a command group (`start`/`stop`/`list`/`submit`) for provisioning and running Hail on Amazon EMR, bringing AWS to parity with `hailctl dataproc` and `hailctl hdinsight`. Adds the `emr/region` and `emr/remote_tmpdir` config variables and support for `HAIL_CLOUD=aws`.
+
 ## Version 0.2.138
 
 Released 2026-04-13

--- a/hail/python/hail/docs/change_log.md
+++ b/hail/python/hail/docs/change_log.md
@@ -52,12 +52,6 @@ supports.
 policy. Their functionality or even existence may change without notice. Please contact us if you
 critically depend on experimental functionality.**
 
-## Version 0.2.139
-
-### New Features
-
-- (hail#15612) (CHANGELOG) Add `hailctl emr`, a command group (`start`/`stop`/`list`/`submit`) for provisioning and running Hail on Amazon EMR, bringing AWS to parity with `hailctl dataproc` and `hailctl hdinsight`. Adds the `emr/region` and `emr/remote_tmpdir` config variables and support for `HAIL_CLOUD=aws`.
-
 ## Version 0.2.138
 
 Released 2026-04-13

--- a/hail/python/hail/docs/cloud/amazon_web_services.rst
+++ b/hail/python/hail/docs/cloud/amazon_web_services.rst
@@ -50,7 +50,8 @@ Choosing an EMR release
 Hail requires Spark 3.5.x. The default release, ``emr-7.3.0``, provides Spark 3.5.3, which matches
 the Spark version Hail is built against. If you pass a ``--release-label`` that ships a different
 Spark minor version, ``hailctl emr start`` refuses to start the cluster; an unrecognized label
-produces a warning.
+produces a warning. Hail requires Python 3.10 or newer; the bootstrap installs Hail into Python
+3.11, which ships with EMR releases 7.1.0 and newer, so use ``emr-7.1.0`` or later.
 
 Advanced cluster options
 ------------------------

--- a/hail/python/hail/docs/cloud/amazon_web_services.rst
+++ b/hail/python/hail/docs/cloud/amazon_web_services.rst
@@ -2,7 +2,71 @@
 Amazon Web Services
 ===================
 
-Hail does not have any built-in tools for working with `Amazon EMR
-<https://aws.amazon.com/emr/>`__.
+``hailctl emr``
+---------------
 
-If you'd like to deploy Hail on AWS, we recommend that you try the `open-source Cloudformation tool <https://github.com/hms-dbmi/hail-on-AWS-spot-instances>`__ maintained by the `Avillach Lab <https://avillach-lab.hms.harvard.edu/>`_ at Harvard Medical School.
+Pip installations of Hail come bundled with a command-line tool, ``hailctl emr``, for working with
+`Amazon EMR <https://aws.amazon.com/emr/>`__ clusters configured for Hail.
+
+This tool requires the `AWS credentials <https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html>`__
+that boto3 uses (for example via ``aws configure``, environment variables, or an SSO profile). It
+does not require the ``aws`` CLI to be installed. You must also have permission to create EMR
+clusters and the EMR service and EC2 instance-profile IAM roles (``aws emr create-default-roles``
+creates the defaults).
+
+An EMR cluster consists of a master node and one or more core nodes. Hail is installed on every node
+by a bootstrap action, and Hail's JAR is placed on the Spark classpath through the cluster's
+configuration. Hail reads and writes ``s3://`` URIs directly through EMRFS.
+
+To start a cluster you must supply a cluster name and an S3 scratch location (either ``--s3-scratch``
+or the ``emr/remote_tmpdir`` config variable). The scratch location holds the uploaded bootstrap
+script and, for ``submit``, your job scripts.
+
+.. code-block:: text
+
+    hailctl emr start CLUSTER_NAME --s3-scratch s3://my-bucket/hail-tmp/
+
+To submit a Python job and wait for it to finish:
+
+.. code-block:: text
+
+    hailctl emr submit CLUSTER_ID SCRIPT.py --s3-scratch s3://my-bucket/hail-tmp/ [-- args to your script...]
+
+Your script should read and write ``s3://`` URIs (EMRFS resolves them). To list running clusters:
+
+.. code-block:: text
+
+    hailctl emr list
+
+Importantly, to shut down a cluster when you are done with it:
+
+.. code-block:: text
+
+    hailctl emr stop CLUSTER_ID
+
+Choosing an EMR release
+-----------------------
+
+Hail requires Spark 3.5.x. The default release, ``emr-7.3.0``, provides Spark 3.5.3, which matches
+the Spark version Hail is built against. If you pass a ``--release-label`` that ships a different
+Spark minor version, ``hailctl emr start`` refuses to start the cluster; an unrecognized label
+produces a warning.
+
+Advanced cluster options
+------------------------
+
+``hailctl emr start`` exposes common options directly (instance types and counts, ``--ec2-key-name``,
+``--subnet-id``, custom IAM roles). For any other EMR ``RunJobFlow`` setting, pass a JSON object with
+``--run-job-flow-json``; it is deep-merged into the request, so you can set spot instance fleets,
+extra applications, tags, and so on:
+
+.. code-block:: text
+
+    hailctl emr start CLUSTER_NAME --s3-scratch s3://my-bucket/hail-tmp/ \
+        --run-job-flow-json '{"Tags": [{"Key": "team", "Value": "genomics"}]}'
+
+Variant Effect Predictor (VEP)
+------------------------------
+
+Running VEP on EMR is not yet supported. Passing ``--vep`` raises an error. This is planned for a
+future release.

--- a/hail/python/hail/docs/cloud/amazon_web_services.rst
+++ b/hail/python/hail/docs/cloud/amazon_web_services.rst
@@ -52,11 +52,10 @@ the Spark version Hail is built against. If you pass a ``--release-label`` that 
 Spark minor version, ``hailctl emr start`` refuses to start the cluster; an unrecognized label
 produces a warning.
 
-Hail also requires a supported version of Python. The EMR 7.x application stack officially ships
-only Python 3.9 and 3.11, and its default ``python3`` is 3.9, which is too old for Hail. The
-bootstrap therefore installs Hail into Python 3.11 (available on EMR releases 7.1.0 and newer) and
-points Spark's driver and executors at it, so use ``emr-7.1.0`` or later. If a future EMR release
-ships a newer default Python that Hail supports, ``hailctl emr`` will be updated to target it.
+Hail also requires a supported version of Python. EMR 7.x runs Amazon Linux 2023, whose default
+``python3`` is 3.9 — too old for Hail. Amazon Linux 2023 packages Python 3.12 in its ``dnf``
+repositories, so the bootstrap installs Hail into Python 3.12 and points Spark's driver and
+executors at it.
 
 Advanced cluster options
 ------------------------

--- a/hail/python/hail/docs/cloud/amazon_web_services.rst
+++ b/hail/python/hail/docs/cloud/amazon_web_services.rst
@@ -32,7 +32,8 @@ To submit a Python job and wait for it to finish:
 
     hailctl emr submit CLUSTER_ID SCRIPT.py --s3-scratch s3://my-bucket/hail-tmp/ [-- args to your script...]
 
-Your script should read and write ``s3://`` URIs (EMRFS resolves them). To list running clusters:
+Your script should read and write ``s3://`` URIs (EMRFS resolves them). To list active clusters
+(pass ``--all`` to include terminated ones):
 
 .. code-block:: text
 

--- a/hail/python/hail/docs/cloud/amazon_web_services.rst
+++ b/hail/python/hail/docs/cloud/amazon_web_services.rst
@@ -50,8 +50,13 @@ Choosing an EMR release
 Hail requires Spark 3.5.x. The default release, ``emr-7.3.0``, provides Spark 3.5.3, which matches
 the Spark version Hail is built against. If you pass a ``--release-label`` that ships a different
 Spark minor version, ``hailctl emr start`` refuses to start the cluster; an unrecognized label
-produces a warning. Hail requires Python 3.10 or newer; the bootstrap installs Hail into Python
-3.11, which ships with EMR releases 7.1.0 and newer, so use ``emr-7.1.0`` or later.
+produces a warning.
+
+Hail also requires a supported version of Python. The EMR 7.x application stack officially ships
+only Python 3.9 and 3.11, and its default ``python3`` is 3.9, which is too old for Hail. The
+bootstrap therefore installs Hail into Python 3.11 (available on EMR releases 7.1.0 and newer) and
+points Spark's driver and executors at it, so use ``emr-7.1.0`` or later. If a future EMR release
+ships a newer default Python that Hail supports, ``hailctl emr`` will be updated to target it.
 
 Advanced cluster options
 ------------------------

--- a/hail/python/hail/docs/cloud/amazon_web_services.rst
+++ b/hail/python/hail/docs/cloud/amazon_web_services.rst
@@ -48,10 +48,10 @@ Importantly, to shut down a cluster when you are done with it:
 Choosing an EMR release
 -----------------------
 
-Hail requires Spark 3.5.x. The default release, ``emr-7.3.0``, provides Spark 3.5.3, which matches
-the Spark version Hail is built against. If you pass a ``--release-label`` that ships a different
-Spark minor version, ``hailctl emr start`` refuses to start the cluster; an unrecognized label
-produces a warning.
+Hail requires Spark 3.5.x. The tested default release, ``emr-7.3.0``, provides
+Spark 3.5.1-amzn-1. Hail is built against Spark 3.5.3, and patch differences within the 3.5.x
+line are allowed. If the final request uses a release that ships a different Spark minor version,
+``hailctl emr start`` refuses to start the cluster; an unrecognized label produces a warning.
 
 Hail also requires a supported version of Python. EMR 7.x runs Amazon Linux 2023, whose default
 ``python3`` is 3.9 — too old for Hail. Amazon Linux 2023 packages Python 3.12 in its ``dnf``
@@ -63,13 +63,19 @@ Advanced cluster options
 
 ``hailctl emr start`` exposes common options directly (instance types and counts, ``--ec2-key-name``,
 ``--subnet-id``, custom IAM roles). For any other EMR ``RunJobFlow`` setting, pass a JSON object with
-``--run-job-flow-json``; it is deep-merged into the request, so you can set spot instance fleets,
-extra applications, tags, and so on:
+``--run-job-flow-json``. Nested objects are deep-merged and list-valued fields are replaced. An
+``InstanceFleets`` overlay replaces the default ``InstanceGroups``. If you replace ``Applications``,
+the final list must still include Spark. For example, to set tags:
 
 .. code-block:: text
 
     hailctl emr start CLUSTER_NAME --s3-scratch s3://my-bucket/hail-tmp/ \
         --run-job-flow-json '{"Tags": [{"Key": "team", "Value": "genomics"}]}'
+
+``--off-heap-memory-per-core-mb`` caps Hail's native off-heap allocation per task core. It does not
+reserve YARN container memory or automatically change ``spark.executor.memoryOverhead``. Passing
+``--no-off-heap-memory`` leaves that Hail allocation uncapped; it does not disable native off-heap
+allocation.
 
 Variant Effect Predictor (VEP)
 ------------------------------

--- a/hail/python/hailtop/config/variables.py
+++ b/hail/python/hailtop/config/variables.py
@@ -21,6 +21,8 @@ class ConfigVariable(str, Enum):
     QUERY_BATCH_WORKER_MEMORY = 'query/batch_worker_memory'
     QUERY_NAME_PREFIX = 'query/name_prefix'
     QUERY_DISABLE_PROGRESS_BAR = 'query/disable_progress_bar'
+    EMR_REGION = 'emr/region'
+    EMR_REMOTE_TMPDIR = 'emr/remote_tmpdir'
     HTTP_TIMEOUT_IN_SECONDS = 'http/timeout_in_seconds'
 
     def to_section_option(self) -> Tuple[str, str]:

--- a/hail/python/hailtop/hailctl/__main__.py
+++ b/hail/python/hailtop/hailctl/__main__.py
@@ -6,6 +6,7 @@ from .auth import cli as auth_cli
 from .batch import cli as batch_cli
 from .config import cli as config_cli
 from .dataproc import cli as dataproc_cli
+from .emr import cli as emr_cli
 from .describe import describe
 from .dev import cli as dev_cli
 from .hdinsight import cli as hdinsight_cli
@@ -21,6 +22,7 @@ for cli in (
     batch_cli.app,
     config_cli.app,
     dataproc_cli.app,
+    emr_cli.app,
     dev_cli.app,
     hdinsight_cli.app,
 ):

--- a/hail/python/hailtop/hailctl/__main__.py
+++ b/hail/python/hailtop/hailctl/__main__.py
@@ -6,9 +6,9 @@ from .auth import cli as auth_cli
 from .batch import cli as batch_cli
 from .config import cli as config_cli
 from .dataproc import cli as dataproc_cli
-from .emr import cli as emr_cli
 from .describe import describe
 from .dev import cli as dev_cli
+from .emr import cli as emr_cli
 from .hdinsight import cli as hdinsight_cli
 
 app = typer.Typer(

--- a/hail/python/hailtop/hailctl/config/config_variables.py
+++ b/hail/python/hailtop/hailctl/config/config_variables.py
@@ -18,6 +18,7 @@ def _is_float_str(x: str) -> bool:
 
 def config_variables():
     from hailtop.aiotools.router_fs import RouterAsyncFS  # pylint: disable=import-outside-toplevel
+    from hailtop.aiocloud.aioaws.fs import S3AsyncFS  # pylint: disable=import-outside-toplevel
     from hailtop.batch_client.parse import CPU_REGEXPAT, MEMORY_REGEXPAT  # pylint: disable=import-outside-toplevel
 
     global _config_variables
@@ -137,6 +138,20 @@ def config_variables():
             ConfigVariable.HTTP_TIMEOUT_IN_SECONDS: ConfigVariableInfo(
                 help_msg='The default timeout for HTTP requests in seconds.',
                 validation=(_is_float_str, 'should be a float or an int like 42.42 or 42'),
+            ),
+            ConfigVariable.EMR_REGION: ConfigVariableInfo(
+                help_msg='Default AWS region for EMR clusters',
+                validation=(
+                    lambda x: re.fullmatch(r'[a-z]{2}-[a-z]+-\d', x) is not None,
+                    'should be a valid AWS region such as us-east-1',
+                ),
+            ),
+            ConfigVariable.EMR_REMOTE_TMPDIR: ConfigVariableInfo(
+                help_msg='S3 URI to use as a scratch directory for EMR jobs',
+                validation=(
+                    S3AsyncFS.valid_url,
+                    'should be a valid S3 URI such as s3://my-bucket/hail-tmp/',
+                ),
             ),
         }
 

--- a/hail/python/hailtop/hailctl/config/config_variables.py
+++ b/hail/python/hailtop/hailctl/config/config_variables.py
@@ -17,8 +17,8 @@ def _is_float_str(x: str) -> bool:
 
 
 def config_variables():
-    from hailtop.aiotools.router_fs import RouterAsyncFS  # pylint: disable=import-outside-toplevel
     from hailtop.aiocloud.aioaws.fs import S3AsyncFS  # pylint: disable=import-outside-toplevel
+    from hailtop.aiotools.router_fs import RouterAsyncFS  # pylint: disable=import-outside-toplevel
     from hailtop.batch_client.parse import CPU_REGEXPAT, MEMORY_REGEXPAT  # pylint: disable=import-outside-toplevel
 
     global _config_variables
@@ -142,7 +142,8 @@ def config_variables():
             ConfigVariable.EMR_REGION: ConfigVariableInfo(
                 help_msg='Default AWS region for EMR clusters',
                 validation=(
-                    lambda x: re.fullmatch(r'[a-z]{2}-[a-z]+-\d', x) is not None,
+                    # e.g. us-east-1, ap-southeast-3, us-gov-west-1
+                    lambda x: re.fullmatch(r'[a-z]{2}(-[a-z]+)+-\d+', x) is not None,
                     'should be a valid AWS region such as us-east-1',
                 ),
             ),

--- a/hail/python/hailtop/hailctl/emr/cli.py
+++ b/hail/python/hailtop/hailctl/emr/cli.py
@@ -1,4 +1,3 @@
-import importlib.resources as ir
 import json
 from typing import Annotated as Ann
 from typing import Optional
@@ -6,13 +5,6 @@ from typing import Optional
 import typer
 from typer import Argument as Arg
 from typer import Option as Opt
-
-from hailtop import __pip_version__
-from hailtop.config import ConfigVariable, configuration_of
-
-from . import emr
-from . import start as start_mod
-from . import submit as submit_mod
 
 app = typer.Typer(
     name='emr',
@@ -51,6 +43,12 @@ def start(
     dry_run: Ann[bool, Opt(help="Build the request but don't call AWS.")] = False,
 ):
     """Start an EMR cluster configured for Hail."""
+    from hailtop import __pip_version__  # pylint: disable=import-outside-toplevel
+    from hailtop.config import ConfigVariable, configuration_of  # pylint: disable=import-outside-toplevel
+
+    from . import emr  # pylint: disable=import-outside-toplevel
+    from . import start as start_mod  # pylint: disable=import-outside-toplevel
+
     if vep is not None:
         raise NotImplementedError('VEP on EMR is planned for a future release (Phase 2).')
 
@@ -93,6 +91,10 @@ def start(
 
 
 def _upload_bootstrap(bootstrap_s3_uri: str) -> None:
+    import importlib.resources as ir  # pylint: disable=import-outside-toplevel
+
+    from . import emr  # pylint: disable=import-outside-toplevel
+
     script_bytes = (
         ir.files('hailtop.hailctl.emr').joinpath('resources/install-hail-emr.sh').read_bytes()
     )
@@ -106,6 +108,8 @@ def stop(
     region: Ann[Optional[str], Opt(help='AWS region.')] = None,
 ):
     """Terminate an EMR cluster."""
+    from . import emr  # pylint: disable=import-outside-toplevel
+
     resolved_region = emr.resolve_region(region)
     print(f'Terminating cluster {cluster_id} ...')
     emr.emr_client(resolved_region).terminate_job_flows(JobFlowIds=[cluster_id])
@@ -116,6 +120,8 @@ def list(
     region: Ann[Optional[str], Opt(help='AWS region.')] = None,
 ):
     """List EMR clusters."""
+    from . import emr  # pylint: disable=import-outside-toplevel
+
     resolved_region = emr.resolve_region(region)
     resp = emr.emr_client(resolved_region).list_clusters()
     for cluster in resp.get('Clusters', []):
@@ -135,6 +141,10 @@ def submit(
     no_wait: Ann[bool, Opt('--no-wait', help='Return immediately after submitting, without waiting for completion.')] = False,
 ):
     """Submit a Python job to an EMR cluster configured for Hail."""
+    from hailtop.config import ConfigVariable, configuration_of  # pylint: disable=import-outside-toplevel
+
+    from . import submit as submit_mod  # pylint: disable=import-outside-toplevel
+
     scratch = configuration_of(ConfigVariable.EMR_REMOTE_TMPDIR, s3_scratch, None)
     if scratch is None:
         raise typer.BadParameter('Provide --s3-scratch or set `hailctl config set emr/remote_tmpdir`.')

--- a/hail/python/hailtop/hailctl/emr/cli.py
+++ b/hail/python/hailtop/hailctl/emr/cli.py
@@ -1,0 +1,151 @@
+import json
+from typing import Annotated as Ann
+from typing import List, Optional
+
+import typer
+from typer import Argument as Arg
+from typer import Option as Opt
+
+app = typer.Typer(
+    name='emr',
+    no_args_is_help=True,
+    help='Manage and monitor Hail Amazon EMR clusters.',
+    pretty_exceptions_show_locals=False,
+)
+
+
+@app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
+def start(
+    ctx: typer.Context,
+    cluster_name: str,
+    s3_scratch: Ann[
+        Optional[str],
+        Opt('--s3-scratch', help='S3 URI for scratch data (e.g. s3://bucket/hail-tmp/). Defaults to the emr/remote_tmpdir config.'),
+    ] = None,
+    region: Ann[Optional[str], Opt(help='AWS region for the cluster.')] = None,
+    release_label: Ann[str, Opt(help='EMR release label.')] = 'emr-7.3.0',
+    master_instance_type: Ann[str, Opt(help='Instance type for the master node.')] = 'm5.xlarge',
+    core_instance_type: Ann[str, Opt(help='Instance type for core (worker) nodes.')] = 'm5.xlarge',
+    core_instance_count: Ann[int, Opt(help='Number of core (worker) nodes.')] = 2,
+    ec2_key_name: Ann[Optional[str], Opt(help='EC2 key pair name for SSH access.')] = None,
+    subnet_id: Ann[Optional[str], Opt(help='VPC subnet id to launch the cluster in.')] = None,
+    log_uri: Ann[Optional[str], Opt(help='S3 URI for EMR logs. Defaults to <s3-scratch>/logs/.')] = None,
+    use_default_roles: Ann[bool, Opt(help='Use EMR_DefaultRole and EMR_EC2_DefaultRole.')] = True,
+    service_role: Ann[Optional[str], Opt(help='Custom EMR service role (requires --no-use-default-roles).')] = None,
+    instance_profile: Ann[Optional[str], Opt(help='Custom EC2 instance profile (requires --no-use-default-roles).')] = None,
+    no_off_heap_memory: Ann[bool, Opt('--no-off-heap-memory', help="Don't reserve off-heap memory for Hail values.")] = False,
+    off_heap_memory_per_core_mb: Ann[int, Opt(help='Off-heap memory reserved per core, in MB.')] = 1024,
+    run_job_flow_json: Ann[
+        Optional[str],
+        Opt('--run-job-flow-json', help='JSON object deep-merged into the boto3 run_job_flow request for advanced options.'),
+    ] = None,
+    vep: Ann[Optional[str], Opt(help='(Phase 2) Install VEP for the given reference genome.')] = None,
+    dry_run: Ann[bool, Opt(help="Build the request but don't call AWS.")] = False,
+):
+    """Start an EMR cluster configured for Hail."""
+    from hailtop import __pip_version__  # pylint: disable=import-outside-toplevel
+    from hailtop.config import ConfigVariable, configuration_of  # pylint: disable=import-outside-toplevel
+
+    from . import emr, start as start_mod  # pylint: disable=import-outside-toplevel
+
+    if vep is not None:
+        raise NotImplementedError('VEP on EMR is planned for a future release (Phase 2).')
+
+    scratch = configuration_of(ConfigVariable.EMR_REMOTE_TMPDIR, s3_scratch, None)
+    if scratch is None:
+        raise typer.BadParameter('Provide --s3-scratch or set `hailctl config set emr/remote_tmpdir`.')
+
+    start_mod.check_release_spark_compatibility(release_label)
+
+    resolved_region = emr.resolve_region(region)
+    bootstrap_s3_uri = f'{scratch.rstrip("/")}/bootstrap/{cluster_name}/install-hail-emr.sh'
+
+    kwargs = start_mod.build_run_job_flow_kwargs(
+        cluster_name=cluster_name,
+        release_label=release_label,
+        master_instance_type=master_instance_type,
+        core_instance_type=core_instance_type,
+        core_instance_count=core_instance_count,
+        ec2_key_name=ec2_key_name,
+        subnet_id=subnet_id,
+        log_uri=log_uri or (scratch.rstrip('/') + '/logs/'),
+        bootstrap_s3_uri=bootstrap_s3_uri,
+        pip_version=__pip_version__,
+        off_heap_memory_per_core_mb=None if no_off_heap_memory else off_heap_memory_per_core_mb,
+        use_default_roles=use_default_roles,
+        service_role=service_role,
+        instance_profile=instance_profile,
+    )
+
+    if run_job_flow_json is not None:
+        kwargs = start_mod.deep_merge(kwargs, json.loads(run_job_flow_json))
+
+    if dry_run:
+        print(json.dumps(kwargs, indent=2))
+        return
+
+    _upload_bootstrap(bootstrap_s3_uri)
+    resp = emr.emr_client(resolved_region).run_job_flow(**kwargs)
+    print(f"Started cluster {resp['JobFlowId']}.")
+
+
+def _upload_bootstrap(bootstrap_s3_uri: str) -> None:
+    import importlib.resources as ir  # pylint: disable=import-outside-toplevel
+
+    from . import emr  # pylint: disable=import-outside-toplevel
+
+    script_bytes = (
+        ir.files('hailtop.hailctl.emr').joinpath('resources/install-hail-emr.sh').read_bytes()
+    )
+    emr.upload_to_s3(bootstrap_s3_uri, script_bytes)
+
+
+@app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
+def stop(
+    ctx: typer.Context,
+    cluster_id: Ann[str, Arg(help='The EMR cluster (job flow) id, e.g. j-XXXX.')],
+    region: Ann[Optional[str], Opt(help='AWS region.')] = None,
+):
+    """Terminate an EMR cluster."""
+    from . import emr  # pylint: disable=import-outside-toplevel
+
+    resolved_region = emr.resolve_region(region)
+    print(f'Terminating cluster {cluster_id} ...')
+    emr.emr_client(resolved_region).terminate_job_flows(JobFlowIds=[cluster_id])
+
+
+@app.command()
+def list(
+    region: Ann[Optional[str], Opt(help='AWS region.')] = None,
+):
+    """List EMR clusters."""
+    from . import emr  # pylint: disable=import-outside-toplevel
+
+    resolved_region = emr.resolve_region(region)
+    resp = emr.emr_client(resolved_region).list_clusters()
+    for cluster in resp.get('Clusters', []):
+        print(f"{cluster['Id']}\t{cluster['Status']['State']}\t{cluster['Name']}")
+
+
+@app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
+def submit(
+    ctx: typer.Context,
+    cluster_id: Ann[str, Arg(help='The EMR cluster (job flow) id, e.g. j-XXXX.')],
+    script: Ann[str, Arg(help='Path to the local Python script.')],
+    s3_scratch: Ann[
+        Optional[str],
+        Opt('--s3-scratch', help='S3 URI for scratch data. Defaults to the emr/remote_tmpdir config.'),
+    ] = None,
+    region: Ann[Optional[str], Opt(help='AWS region.')] = None,
+    no_wait: Ann[bool, Opt('--no-wait', help='Return immediately after submitting, without waiting for completion.')] = False,
+):
+    """Submit a Python job to an EMR cluster configured for Hail."""
+    from hailtop.config import ConfigVariable, configuration_of  # pylint: disable=import-outside-toplevel
+
+    from . import submit as submit_mod  # pylint: disable=import-outside-toplevel
+
+    scratch = configuration_of(ConfigVariable.EMR_REMOTE_TMPDIR, s3_scratch, None)
+    if scratch is None:
+        raise typer.BadParameter('Provide --s3-scratch or set `hailctl config set emr/remote_tmpdir`.')
+
+    submit_mod.submit(cluster_id, script, scratch, region, ctx.args, wait=not no_wait)

--- a/hail/python/hailtop/hailctl/emr/cli.py
+++ b/hail/python/hailtop/hailctl/emr/cli.py
@@ -79,7 +79,11 @@ def start(
     )
 
     if run_job_flow_json is not None:
-        kwargs = start_mod.deep_merge(kwargs, json.loads(run_job_flow_json))
+        try:
+            overlay = json.loads(run_job_flow_json)
+        except json.JSONDecodeError as exc:
+            raise typer.BadParameter(f'--run-job-flow-json is not valid JSON: {exc}') from exc
+        kwargs = start_mod.deep_merge(kwargs, overlay)
 
     if dry_run:
         print(json.dumps(kwargs, indent=2))

--- a/hail/python/hailtop/hailctl/emr/cli.py
+++ b/hail/python/hailtop/hailctl/emr/cli.py
@@ -1,10 +1,18 @@
+import importlib.resources as ir
 import json
 from typing import Annotated as Ann
-from typing import List, Optional
+from typing import Optional
 
 import typer
 from typer import Argument as Arg
 from typer import Option as Opt
+
+from hailtop import __pip_version__
+from hailtop.config import ConfigVariable, configuration_of
+
+from . import emr
+from . import start as start_mod
+from . import submit as submit_mod
 
 app = typer.Typer(
     name='emr',
@@ -43,11 +51,6 @@ def start(
     dry_run: Ann[bool, Opt(help="Build the request but don't call AWS.")] = False,
 ):
     """Start an EMR cluster configured for Hail."""
-    from hailtop import __pip_version__  # pylint: disable=import-outside-toplevel
-    from hailtop.config import ConfigVariable, configuration_of  # pylint: disable=import-outside-toplevel
-
-    from . import emr, start as start_mod  # pylint: disable=import-outside-toplevel
-
     if vep is not None:
         raise NotImplementedError('VEP on EMR is planned for a future release (Phase 2).')
 
@@ -90,10 +93,6 @@ def start(
 
 
 def _upload_bootstrap(bootstrap_s3_uri: str) -> None:
-    import importlib.resources as ir  # pylint: disable=import-outside-toplevel
-
-    from . import emr  # pylint: disable=import-outside-toplevel
-
     script_bytes = (
         ir.files('hailtop.hailctl.emr').joinpath('resources/install-hail-emr.sh').read_bytes()
     )
@@ -107,8 +106,6 @@ def stop(
     region: Ann[Optional[str], Opt(help='AWS region.')] = None,
 ):
     """Terminate an EMR cluster."""
-    from . import emr  # pylint: disable=import-outside-toplevel
-
     resolved_region = emr.resolve_region(region)
     print(f'Terminating cluster {cluster_id} ...')
     emr.emr_client(resolved_region).terminate_job_flows(JobFlowIds=[cluster_id])
@@ -119,8 +116,6 @@ def list(
     region: Ann[Optional[str], Opt(help='AWS region.')] = None,
 ):
     """List EMR clusters."""
-    from . import emr  # pylint: disable=import-outside-toplevel
-
     resolved_region = emr.resolve_region(region)
     resp = emr.emr_client(resolved_region).list_clusters()
     for cluster in resp.get('Clusters', []):
@@ -140,10 +135,6 @@ def submit(
     no_wait: Ann[bool, Opt('--no-wait', help='Return immediately after submitting, without waiting for completion.')] = False,
 ):
     """Submit a Python job to an EMR cluster configured for Hail."""
-    from hailtop.config import ConfigVariable, configuration_of  # pylint: disable=import-outside-toplevel
-
-    from . import submit as submit_mod  # pylint: disable=import-outside-toplevel
-
     scratch = configuration_of(ConfigVariable.EMR_REMOTE_TMPDIR, s3_scratch, None)
     if scratch is None:
         raise typer.BadParameter('Provide --s3-scratch or set `hailctl config set emr/remote_tmpdir`.')

--- a/hail/python/hailtop/hailctl/emr/cli.py
+++ b/hail/python/hailtop/hailctl/emr/cli.py
@@ -89,6 +89,9 @@ def start(
         print(json.dumps(kwargs, indent=2))
         return
 
+    if use_default_roles:
+        emr.check_default_roles()
+
     _upload_bootstrap(bootstrap_s3_uri)
     resp = emr.emr_client(resolved_region).run_job_flow(**kwargs)
     print(f"Started cluster {resp['JobFlowId']}.")

--- a/hail/python/hailtop/hailctl/emr/cli.py
+++ b/hail/python/hailtop/hailctl/emr/cli.py
@@ -69,6 +69,12 @@ def start(
     if scratch is None:
         raise typer.BadParameter('Provide --s3-scratch or set `hailctl config set emr/remote_tmpdir`.')
 
+    if use_default_roles and (service_role is not None or instance_profile is not None):
+        raise typer.BadParameter(
+            '--service-role and --instance-profile apply only with --no-use-default-roles, '
+            'which this command defaults to off.'
+        )
+
     start_mod.check_release_spark_compatibility(release_label)
 
     resolved_region = emr.resolve_region(region)

--- a/hail/python/hailtop/hailctl/emr/cli.py
+++ b/hail/python/hailtop/hailctl/emr/cli.py
@@ -1,6 +1,9 @@
+import builtins
 import json
+import re
 from typing import Annotated as Ann
 from typing import Optional
+from urllib.parse import urlparse
 
 import typer
 from typer import Argument as Arg
@@ -16,6 +19,33 @@ app = typer.Typer(
 # Clusters that still exist and may still cost money. TERMINATING is included so
 # a cluster does not vanish from `list` before it has actually shut down.
 ACTIVE_CLUSTER_STATES = ['STARTING', 'BOOTSTRAPPING', 'RUNNING', 'WAITING', 'TERMINATING']
+
+
+def _require_s3_uri(uri: str, option_name: str) -> None:
+    from hailtop.aiocloud.aioaws.fs import S3AsyncFS  # pylint: disable=import-outside-toplevel
+
+    try:
+        parsed = urlparse(uri)
+    except ValueError:
+        parsed = None
+    bucket = parsed.netloc if parsed is not None else ''
+    valid_bucket = (
+        re.fullmatch(r'[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]', bucket) is not None
+        and '..' not in bucket
+        and '.-' not in bucket
+        and '-.' not in bucket
+    )
+    valid = (
+        parsed is not None
+        and S3AsyncFS.valid_url(uri)
+        and parsed.scheme == 's3'
+        and valid_bucket
+        and not parsed.params
+        and not parsed.query
+        and not parsed.fragment
+    )
+    if not valid:
+        raise typer.BadParameter(f'{option_name} must be a valid S3 URI such as s3://my-bucket/hail-tmp/.')
 
 
 @app.command()
@@ -42,9 +72,9 @@ def start(
         Optional[str], Opt(help='Custom EC2 instance profile (requires --no-use-default-roles).')
     ] = None,
     no_off_heap_memory: Ann[
-        bool, Opt('--no-off-heap-memory', help="Don't reserve off-heap memory for Hail values.")
+        bool, Opt('--no-off-heap-memory', help="Don't set a per-core cap on Hail off-heap allocations.")
     ] = False,
-    off_heap_memory_per_core_mb: Ann[int, Opt(help='Off-heap memory reserved per core, in MB.')] = 1024,
+    off_heap_memory_per_core_mb: Ann[int, Opt(help='Maximum Hail off-heap allocation per task core, in MB.')] = 1024,
     run_job_flow_json: Ann[
         Optional[str],
         Opt(
@@ -68,17 +98,18 @@ def start(
     scratch = configuration_of(ConfigVariable.EMR_REMOTE_TMPDIR, s3_scratch, None)
     if scratch is None:
         raise typer.BadParameter('Provide --s3-scratch or set `hailctl config set emr/remote_tmpdir`.')
+    _require_s3_uri(scratch, '--s3-scratch')
 
     if use_default_roles and (service_role is not None or instance_profile is not None):
         raise typer.BadParameter(
-            '--service-role and --instance-profile apply only with --no-use-default-roles, '
-            'which this command defaults to off.'
+            'Default roles are enabled; pass --no-use-default-roles with '
+            '--service-role and --instance-profile to use custom roles.'
         )
-
-    start_mod.check_release_spark_compatibility(release_label)
 
     resolved_region = emr.resolve_region(region)
     bootstrap_s3_uri = f'{scratch.rstrip("/")}/bootstrap/{cluster_name}/install-hail-emr.sh'
+    resolved_log_uri = log_uri or (scratch.rstrip('/') + '/logs/')
+    _require_s3_uri(resolved_log_uri, '--log-uri')
 
     kwargs = start_mod.build_run_job_flow_kwargs(
         cluster_name=cluster_name,
@@ -88,7 +119,7 @@ def start(
         core_instance_count=core_instance_count,
         ec2_key_name=ec2_key_name,
         subnet_id=subnet_id,
-        log_uri=log_uri or (scratch.rstrip('/') + '/logs/'),
+        log_uri=resolved_log_uri,
         bootstrap_s3_uri=bootstrap_s3_uri,
         pip_version=__pip_version__,
         off_heap_memory_per_core_mb=None if no_off_heap_memory else off_heap_memory_per_core_mb,
@@ -102,14 +133,46 @@ def start(
             overlay = json.loads(run_job_flow_json)
         except json.JSONDecodeError as exc:
             raise typer.BadParameter(f'--run-job-flow-json is not valid JSON: {exc}') from exc
-        kwargs = start_mod.deep_merge(kwargs, overlay)
+        if not isinstance(overlay, dict):
+            raise typer.BadParameter('--run-job-flow-json must contain a JSON object.')
+        kwargs = start_mod.merge_run_job_flow_overlay(kwargs, overlay)
+
+    final_release_label = kwargs.get('ReleaseLabel')
+    if not isinstance(final_release_label, str):
+        raise typer.BadParameter('The final RunJobFlow ReleaseLabel must be a string.')
+    start_mod.check_release_spark_compatibility(final_release_label)
+
+    applications = kwargs.get('Applications')
+    if not isinstance(applications, builtins.list) or not any(
+        isinstance(application, dict)
+        and isinstance(application.get('Name'), str)
+        and application['Name'].lower() == 'spark'
+        for application in applications
+    ):
+        raise typer.BadParameter('The final RunJobFlow Applications list must include Spark.')
+
+    instances = kwargs.get('Instances')
+    if not isinstance(instances, dict):
+        raise typer.BadParameter('The final RunJobFlow Instances value must be a JSON object.')
+    if 'InstanceGroups' in instances and 'InstanceFleets' in instances:
+        raise typer.BadParameter('RunJobFlow Instances cannot contain both InstanceGroups and InstanceFleets.')
+
+    final_log_uri = kwargs.get('LogUri')
+    if not isinstance(final_log_uri, str):
+        raise typer.BadParameter('The final RunJobFlow LogUri must be a string.')
+    _require_s3_uri(final_log_uri, 'The final RunJobFlow LogUri')
 
     if dry_run:
         print(json.dumps(kwargs, indent=2))
         return
 
-    if use_default_roles:
-        emr.check_default_roles()
+    final_uses_default_service_role = kwargs.get('ServiceRole') == emr.DEFAULT_SERVICE_ROLE
+    final_uses_default_job_flow_role = kwargs.get('JobFlowRole') == emr.DEFAULT_JOB_FLOW_ROLE
+    if final_uses_default_service_role or final_uses_default_job_flow_role:
+        emr.check_default_roles(
+            check_service_role=final_uses_default_service_role,
+            check_job_flow_role=final_uses_default_job_flow_role,
+        )
 
     _upload_bootstrap(bootstrap_s3_uri)
     resp = emr.emr_client(resolved_region).run_job_flow(**kwargs)
@@ -176,5 +239,6 @@ def submit(
     scratch = configuration_of(ConfigVariable.EMR_REMOTE_TMPDIR, s3_scratch, None)
     if scratch is None:
         raise typer.BadParameter('Provide --s3-scratch or set `hailctl config set emr/remote_tmpdir`.')
+    _require_s3_uri(scratch, '--s3-scratch')
 
     submit_mod.submit(cluster_id, script, scratch, region, ctx.args, wait=not no_wait)

--- a/hail/python/hailtop/hailctl/emr/cli.py
+++ b/hail/python/hailtop/hailctl/emr/cli.py
@@ -13,13 +13,20 @@ app = typer.Typer(
     pretty_exceptions_show_locals=False,
 )
 
+# Clusters that still exist and may still cost money. TERMINATING is included so
+# a cluster does not vanish from `list` before it has actually shut down.
+ACTIVE_CLUSTER_STATES = ['STARTING', 'BOOTSTRAPPING', 'RUNNING', 'WAITING', 'TERMINATING']
+
 
 @app.command()
 def start(
     cluster_name: str,
     s3_scratch: Ann[
         Optional[str],
-        Opt('--s3-scratch', help='S3 URI for scratch data (e.g. s3://bucket/hail-tmp/). Defaults to the emr/remote_tmpdir config.'),
+        Opt(
+            '--s3-scratch',
+            help='S3 URI for scratch data (e.g. s3://bucket/hail-tmp/). Defaults to the emr/remote_tmpdir config.',
+        ),
     ] = None,
     region: Ann[Optional[str], Opt(help='AWS region for the cluster.')] = None,
     release_label: Ann[str, Opt(help='EMR release label.')] = 'emr-7.3.0',
@@ -31,12 +38,19 @@ def start(
     log_uri: Ann[Optional[str], Opt(help='S3 URI for EMR logs. Defaults to <s3-scratch>/logs/.')] = None,
     use_default_roles: Ann[bool, Opt(help='Use EMR_DefaultRole and EMR_EC2_DefaultRole.')] = True,
     service_role: Ann[Optional[str], Opt(help='Custom EMR service role (requires --no-use-default-roles).')] = None,
-    instance_profile: Ann[Optional[str], Opt(help='Custom EC2 instance profile (requires --no-use-default-roles).')] = None,
-    no_off_heap_memory: Ann[bool, Opt('--no-off-heap-memory', help="Don't reserve off-heap memory for Hail values.")] = False,
+    instance_profile: Ann[
+        Optional[str], Opt(help='Custom EC2 instance profile (requires --no-use-default-roles).')
+    ] = None,
+    no_off_heap_memory: Ann[
+        bool, Opt('--no-off-heap-memory', help="Don't reserve off-heap memory for Hail values.")
+    ] = False,
     off_heap_memory_per_core_mb: Ann[int, Opt(help='Off-heap memory reserved per core, in MB.')] = 1024,
     run_job_flow_json: Ann[
         Optional[str],
-        Opt('--run-job-flow-json', help='JSON object deep-merged into the boto3 run_job_flow request for advanced options.'),
+        Opt(
+            '--run-job-flow-json',
+            help='JSON object deep-merged into the boto3 run_job_flow request for advanced options.',
+        ),
     ] = None,
     vep: Ann[Optional[str], Opt(help='(Phase 2) Install VEP for the given reference genome.')] = None,
     dry_run: Ann[bool, Opt(help="Build the request but don't call AWS.")] = False,
@@ -101,9 +115,7 @@ def _upload_bootstrap(bootstrap_s3_uri: str) -> None:
 
     from . import emr  # pylint: disable=import-outside-toplevel
 
-    script_bytes = (
-        ir.files('hailtop.hailctl.emr').joinpath('resources/install-hail-emr.sh').read_bytes()
-    )
+    script_bytes = ir.files('hailtop.hailctl.emr').joinpath('resources/install-hail-emr.sh').read_bytes()
     emr.upload_to_s3(bootstrap_s3_uri, script_bytes)
 
 
@@ -123,14 +135,17 @@ def stop(
 @app.command()
 def list(
     region: Ann[Optional[str], Opt(help='AWS region.')] = None,
+    all_states: Ann[bool, Opt('--all', help='Include terminated clusters.')] = False,
 ):
-    """List EMR clusters."""
+    """List active EMR clusters."""
     from . import emr  # pylint: disable=import-outside-toplevel
 
     resolved_region = emr.resolve_region(region)
-    resp = emr.emr_client(resolved_region).list_clusters()
-    for cluster in resp.get('Clusters', []):
-        print(f"{cluster['Id']}\t{cluster['Status']['State']}\t{cluster['Name']}")
+    kwargs = {} if all_states else {'ClusterStates': ACTIVE_CLUSTER_STATES}
+    paginator = emr.emr_client(resolved_region).get_paginator('list_clusters')
+    for page in paginator.paginate(**kwargs):
+        for cluster in page.get('Clusters', []):
+            print(f"{cluster['Id']}\t{cluster['Status']['State']}\t{cluster['Name']}")
 
 
 @app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
@@ -143,7 +158,9 @@ def submit(
         Opt('--s3-scratch', help='S3 URI for scratch data. Defaults to the emr/remote_tmpdir config.'),
     ] = None,
     region: Ann[Optional[str], Opt(help='AWS region.')] = None,
-    no_wait: Ann[bool, Opt('--no-wait', help='Return immediately after submitting, without waiting for completion.')] = False,
+    no_wait: Ann[
+        bool, Opt('--no-wait', help='Return immediately after submitting, without waiting for completion.')
+    ] = False,
 ):
     """Submit a Python job to an EMR cluster configured for Hail."""
     from hailtop.config import ConfigVariable, configuration_of  # pylint: disable=import-outside-toplevel

--- a/hail/python/hailtop/hailctl/emr/cli.py
+++ b/hail/python/hailtop/hailctl/emr/cli.py
@@ -14,9 +14,8 @@ app = typer.Typer(
 )
 
 
-@app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
+@app.command()
 def start(
-    ctx: typer.Context,
     cluster_name: str,
     s3_scratch: Ann[
         Optional[str],
@@ -108,9 +107,8 @@ def _upload_bootstrap(bootstrap_s3_uri: str) -> None:
     emr.upload_to_s3(bootstrap_s3_uri, script_bytes)
 
 
-@app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
+@app.command()
 def stop(
-    ctx: typer.Context,
     cluster_id: Ann[str, Arg(help='The EMR cluster (job flow) id, e.g. j-XXXX.')],
     region: Ann[Optional[str], Opt(help='AWS region.')] = None,
 ):

--- a/hail/python/hailtop/hailctl/emr/emr.py
+++ b/hail/python/hailtop/hailctl/emr/emr.py
@@ -1,0 +1,41 @@
+import os
+from typing import Optional
+
+from hailtop.aiotools.router_fs import RouterAsyncFS
+from hailtop.config import ConfigVariable, configuration_of
+from hailtop.utils import async_to_blocking
+
+
+def resolve_region(explicit_region: Optional[str]) -> Optional[str]:
+    """Resolve the AWS region for EMR operations.
+
+    Order: explicit argument, then the emr/region config variable, then the
+    AWS_DEFAULT_REGION / AWS_REGION environment variables. Returns None if
+    unset so that botocore can resolve it from the user's AWS config.
+    """
+    if explicit_region is not None:
+        return explicit_region
+    config_region = configuration_of(ConfigVariable.EMR_REGION, None, None)
+    if config_region is not None:
+        return config_region
+    return os.environ.get('AWS_DEFAULT_REGION') or os.environ.get('AWS_REGION')
+
+
+def emr_client(region: Optional[str]):
+    import boto3  # pylint: disable=import-outside-toplevel
+
+    return boto3.client('emr', region_name=region)
+
+
+def upload_to_s3(dest_uri: str, data: bytes) -> None:
+    """Write bytes to an s3:// URI through Hail's RouterAsyncFS.
+
+    S3 file I/O goes through the same FS abstraction the rest of hailtop uses,
+    rather than a raw boto3 S3 client.
+    """
+
+    async def _upload() -> None:
+        async with RouterAsyncFS() as fs:
+            await fs.write(dest_uri, data)
+
+    async_to_blocking(_upload())

--- a/hail/python/hailtop/hailctl/emr/emr.py
+++ b/hail/python/hailtop/hailctl/emr/emr.py
@@ -22,7 +22,7 @@ def resolve_region(explicit_region: Optional[str]) -> Optional[str]:
 
 
 def emr_client(region: Optional[str]):
-    import boto3  # pylint: disable=import-outside-toplevel  # noqa: PLC0415
+    import boto3  # pylint: disable=import-outside-toplevel
 
     return boto3.client('emr', region_name=region)
 

--- a/hail/python/hailtop/hailctl/emr/emr.py
+++ b/hail/python/hailtop/hailctl/emr/emr.py
@@ -27,6 +27,48 @@ def emr_client(region: Optional[str]):
     return boto3.client('emr', region_name=region)
 
 
+DEFAULT_SERVICE_ROLE = 'EMR_DefaultRole'
+DEFAULT_JOB_FLOW_ROLE = 'EMR_EC2_DefaultRole'
+
+
+def _role_exists(iam, role_name: str) -> bool:
+    from botocore.exceptions import ClientError  # pylint: disable=import-outside-toplevel
+
+    try:
+        iam.get_role(RoleName=role_name)
+        return True
+    except ClientError as exc:
+        if exc.response.get('Error', {}).get('Code') == 'NoSuchEntity':
+            return False
+        raise
+
+
+def check_default_roles(iam=None) -> None:
+    """Verify the EMR default IAM roles exist, printing a clear message.
+
+    `aws emr create-default-roles` prints only the roles it *creates*, so it
+    returns an empty list (``[]``) when they already exist -- which reads as if
+    nothing happened. This preflight instead reports explicitly that the roles
+    are present, and raises an actionable error listing any that are missing.
+
+    IAM is global, so no region is needed.
+    """
+    if iam is None:
+        import boto3  # pylint: disable=import-outside-toplevel
+
+        iam = boto3.client('iam')
+
+    roles = (DEFAULT_SERVICE_ROLE, DEFAULT_JOB_FLOW_ROLE)
+    missing = [role for role in roles if not _role_exists(iam, role)]
+    if missing:
+        raise ValueError(
+            f"Missing EMR default IAM role(s): {', '.join(missing)}. "
+            f"Create them once with `aws emr create-default-roles`, or pass "
+            f"--no-use-default-roles together with --service-role and --instance-profile."
+        )
+    print(f"Using existing EMR default roles: {', '.join(roles)}.")
+
+
 def upload_to_s3(dest_uri: str, data: bytes) -> None:
     """Write bytes to an s3:// URI through Hail's RouterAsyncFS.
 

--- a/hail/python/hailtop/hailctl/emr/emr.py
+++ b/hail/python/hailtop/hailctl/emr/emr.py
@@ -22,7 +22,7 @@ def resolve_region(explicit_region: Optional[str]) -> Optional[str]:
 
 
 def emr_client(region: Optional[str]):
-    import boto3  # pylint: disable=import-outside-toplevel
+    import boto3  # pylint: disable=import-outside-toplevel  # noqa: PLC0415
 
     return boto3.client('emr', region_name=region)
 

--- a/hail/python/hailtop/hailctl/emr/emr.py
+++ b/hail/python/hailtop/hailctl/emr/emr.py
@@ -43,7 +43,20 @@ def _role_exists(iam, role_name: str) -> bool:
         raise
 
 
-def check_default_roles(iam=None) -> None:
+def _instance_profile_contains_role(iam, instance_profile_name: str, role_name: str) -> bool:
+    from botocore.exceptions import ClientError  # pylint: disable=import-outside-toplevel
+
+    try:
+        response = iam.get_instance_profile(InstanceProfileName=instance_profile_name)
+    except ClientError as exc:
+        if exc.response.get('Error', {}).get('Code') == 'NoSuchEntity':
+            return False
+        raise
+    roles = response.get('InstanceProfile', {}).get('Roles', [])
+    return any(role.get('RoleName') == role_name for role in roles)
+
+
+def check_default_roles(iam=None, *, check_service_role: bool = True, check_job_flow_role: bool = True) -> None:
     """Verify the EMR default IAM roles exist, printing a clear message.
 
     `aws emr create-default-roles` prints only the roles it *creates*, so it
@@ -58,15 +71,33 @@ def check_default_roles(iam=None) -> None:
 
         iam = boto3.client('iam')
 
-    roles = (DEFAULT_SERVICE_ROLE, DEFAULT_JOB_FLOW_ROLE)
-    missing = [role for role in roles if not _role_exists(iam, role)]
-    if missing:
+    roles = []
+    if check_service_role:
+        roles.append(DEFAULT_SERVICE_ROLE)
+    if check_job_flow_role:
+        roles.append(DEFAULT_JOB_FLOW_ROLE)
+    missing_roles = [role for role in roles if not _role_exists(iam, role)]
+    missing_instance_profiles = []
+    if check_job_flow_role and not _instance_profile_contains_role(iam, DEFAULT_JOB_FLOW_ROLE, DEFAULT_JOB_FLOW_ROLE):
+        missing_instance_profiles.append(f'{DEFAULT_JOB_FLOW_ROLE} containing role {DEFAULT_JOB_FLOW_ROLE}')
+
+    if missing_roles or missing_instance_profiles:
+        missing = []
+        if missing_roles:
+            missing.append(f"role(s): {', '.join(missing_roles)}")
+        if missing_instance_profiles:
+            missing.append(f"instance profile(s): {', '.join(missing_instance_profiles)}")
         raise ValueError(
-            f"Missing EMR default IAM role(s): {', '.join(missing)}. "
+            f"Missing EMR default IAM resource(s): {'; '.join(missing)}. "
             f"Create them once with `aws emr create-default-roles`, or pass "
             f"--no-use-default-roles together with --service-role and --instance-profile."
         )
-    print(f"Using existing EMR default roles: {', '.join(roles)}.")
+    resources = []
+    if roles:
+        resources.append(f"role(s) {', '.join(roles)}")
+    if check_job_flow_role:
+        resources.append(f'instance profile {DEFAULT_JOB_FLOW_ROLE}')
+    print(f"Using existing EMR defaults: {'; '.join(resources)}.")
 
 
 def upload_to_s3(dest_uri: str, data: bytes) -> None:

--- a/hail/python/hailtop/hailctl/emr/resources/install-hail-emr.sh
+++ b/hail/python/hailtop/hailctl/emr/resources/install-hail-emr.sh
@@ -4,19 +4,25 @@
 # Python package here and place the bundled JAR at a deterministic path that
 # the cluster's --configurations reference (see start.py).
 #
+# EMR 7.x runs Amazon Linux 2023 whose system python3 is Python 3.9, but Hail
+# requires Python >= 3.10. Python 3.11 ships with EMR 7.1+, so we install Hail
+# into python3.11 instead. start.py's spark configurations point PySpark at
+# /usr/bin/python3.11 so that both the driver and executors use the same
+# interpreter where Hail is installed.
+#
 # Argument 1: the Hail pip version to install (e.g. 0.2.140).
 
 set -ex
 
 hail_pip_version=$1
 
-sudo dnf install -y gcc-c++ openblas-devel lapack-devel
+sudo dnf install -y gcc-c++ openblas-devel lapack-devel python3.11 python3.11-pip
 
 # Install Hail itself without its dependencies, so we can drop pyspark
 # (EMR provides pyspark) before installing the rest.
-sudo python3 -m pip install "hail==${hail_pip_version}" --no-dependencies
+sudo python3.11 -m pip install "hail==${hail_pip_version}" --no-dependencies
 
-site_packages=$(python3 -m pip show hail | grep -E '^Location:' | sed -E 's/^Location: //')
+site_packages=$(python3.11 -m pip show hail | grep -E '^Location:' | sed -E 's/^Location: //')
 
 # Reinstall Hail's declared dependencies, excluding pyspark.
 # See https://www.python.org/dev/peps/pep-0440/#version-specifiers
@@ -25,7 +31,7 @@ grep -E '^Requires-Dist:' "${site_packages}/hail-${hail_pip_version}.dist-info/M
     | sed -E 's/ \(([^)]*)\)/\1/' \
     | grep -Ev '^pyspark(~=|==|!=|<=|>=|<|>|===|$)' \
     > /tmp/hail-requirements.txt
-sudo python3 -m pip install -r /tmp/hail-requirements.txt
+sudo python3.11 -m pip install -r /tmp/hail-requirements.txt
 
 # Copy the bundled JAR to a fixed path referenced by spark-defaults.
 sudo mkdir -p /usr/lib/hail

--- a/hail/python/hailtop/hailctl/emr/resources/install-hail-emr.sh
+++ b/hail/python/hailtop/hailctl/emr/resources/install-hail-emr.sh
@@ -30,3 +30,9 @@ sudo python3 -m pip install -r /tmp/hail-requirements.txt
 # Copy the bundled JAR to a fixed path referenced by spark-defaults.
 sudo mkdir -p /usr/lib/hail
 sudo cp "${site_packages}/hail/backend/hail-all-spark.jar" /usr/lib/hail/hail-all-spark.jar
+
+# Client-mode Spark drivers (hailctl emr submit uses --deploy-mode client) run
+# as OS processes on the master node and see only the OS environment, not
+# spark.executorEnv/spark.yarn.appMasterEnv. Persist HAIL_CLOUD system-wide so
+# the driver JVM's CloudStorageConfig.readEnv sees it.
+echo 'HAIL_CLOUD=aws' | sudo tee -a /etc/environment

--- a/hail/python/hailtop/hailctl/emr/resources/install-hail-emr.sh
+++ b/hail/python/hailtop/hailctl/emr/resources/install-hail-emr.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# EMR bootstrap action: install Hail from PyPI onto every node.
+# Bootstrap actions run BEFORE Spark is installed, so we only install the
+# Python package here and place the bundled JAR at a deterministic path that
+# the cluster's --configurations reference (see start.py).
+#
+# Argument 1: the Hail pip version to install (e.g. 0.2.140).
+
+set -ex
+
+hail_pip_version=$1
+
+sudo dnf install -y gcc-c++ openblas-devel lapack-devel
+
+# Install Hail itself without its dependencies, so we can drop pyspark
+# (EMR provides pyspark) before installing the rest.
+sudo python3 -m pip install "hail==${hail_pip_version}" --no-dependencies
+
+site_packages=$(python3 -m pip show hail | grep -E '^Location:' | sed -E 's/^Location: //')
+
+# Reinstall Hail's declared dependencies, excluding pyspark.
+# See https://www.python.org/dev/peps/pep-0440/#version-specifiers
+grep -E '^Requires-Dist:' "${site_packages}/hail-${hail_pip_version}.dist-info/METADATA" \
+    | sed 's/Requires-Dist: //' \
+    | sed -E 's/ \(([^)]*)\)/\1/' \
+    | grep -Ev '^pyspark(~=|==|!=|<=|>=|<|>|===|$)' \
+    > /tmp/hail-requirements.txt
+sudo python3 -m pip install -r /tmp/hail-requirements.txt
+
+# Copy the bundled JAR to a fixed path referenced by spark-defaults.
+sudo mkdir -p /usr/lib/hail
+sudo cp "${site_packages}/hail/backend/hail-all-spark.jar" /usr/lib/hail/hail-all-spark.jar

--- a/hail/python/hailtop/hailctl/emr/resources/install-hail-emr.sh
+++ b/hail/python/hailtop/hailctl/emr/resources/install-hail-emr.sh
@@ -4,11 +4,11 @@
 # Python package here and place the bundled JAR at a deterministic path that
 # the cluster's --configurations reference (see start.py).
 #
-# EMR 7.x runs Amazon Linux 2023 whose system python3 is Python 3.9, but Hail
-# requires Python >= 3.10. Python 3.11 ships with EMR 7.1+, so we install Hail
-# into python3.11 instead. start.py's spark configurations point PySpark at
-# /usr/bin/python3.11 so that both the driver and executors use the same
-# interpreter where Hail is installed.
+# EMR 7.x runs Amazon Linux 2023, whose system python3 is Python 3.9 -- too old
+# for Hail. Amazon Linux 2023 packages python3.12 in its dnf repositories, so we
+# install Hail into python3.12 instead. start.py's spark configurations point
+# PySpark at /usr/bin/python3.12 so that both the driver and executors use the
+# same interpreter where Hail is installed.
 #
 # Argument 1: the Hail pip version to install (e.g. 0.2.140).
 
@@ -16,13 +16,13 @@ set -ex
 
 hail_pip_version=$1
 
-sudo dnf install -y gcc-c++ openblas-devel lapack-devel python3.11 python3.11-pip
+sudo dnf install -y gcc-c++ openblas-devel lapack-devel python3.12 python3.12-pip
 
 # Install Hail itself without its dependencies, so we can drop pyspark
 # (EMR provides pyspark) before installing the rest.
-sudo python3.11 -m pip install "hail==${hail_pip_version}" --no-dependencies
+sudo python3.12 -m pip install "hail==${hail_pip_version}" --no-dependencies
 
-site_packages=$(python3.11 -m pip show hail | grep -E '^Location:' | sed -E 's/^Location: //')
+site_packages=$(python3.12 -m pip show hail | grep -E '^Location:' | sed -E 's/^Location: //')
 
 # Reinstall Hail's declared dependencies, excluding pyspark.
 # See https://www.python.org/dev/peps/pep-0440/#version-specifiers
@@ -31,7 +31,7 @@ grep -E '^Requires-Dist:' "${site_packages}/hail-${hail_pip_version}.dist-info/M
     | sed -E 's/ \(([^)]*)\)/\1/' \
     | grep -Ev '^pyspark(~=|==|!=|<=|>=|<|>|===|$)' \
     > /tmp/hail-requirements.txt
-sudo python3.11 -m pip install -r /tmp/hail-requirements.txt
+sudo python3.12 -m pip install -r /tmp/hail-requirements.txt
 
 # Copy the bundled JAR to a fixed path referenced by spark-defaults.
 sudo mkdir -p /usr/lib/hail

--- a/hail/python/hailtop/hailctl/emr/resources/install-hail-emr.sh
+++ b/hail/python/hailtop/hailctl/emr/resources/install-hail-emr.sh
@@ -22,7 +22,14 @@ sudo dnf install -y gcc-c++ openblas-devel lapack-devel python3.12 python3.12-pi
 # (EMR provides pyspark) before installing the rest.
 sudo python3.12 -m pip install "hail==${hail_pip_version}" --no-dependencies
 
-site_packages=$(python3.12 -m pip show hail | grep -E '^Location:' | sed -E 's/^Location: //')
+# Query with sudo, matching the install above: a non-root pip may not report the
+# system-level install. Without the guard, an empty value turns every path below
+# into a bare "/hail-..." and the bootstrap dies on a confusing "no such file".
+site_packages=$(sudo python3.12 -m pip show hail | grep -E '^Location:' | sed -E 's/^Location: //')
+if [ -z "${site_packages}" ]; then
+    echo "could not determine where pip installed hail" >&2
+    exit 1
+fi
 
 # Reinstall Hail's declared dependencies, excluding pyspark.
 # See https://www.python.org/dev/peps/pep-0440/#version-specifiers

--- a/hail/python/hailtop/hailctl/emr/start.py
+++ b/hail/python/hailtop/hailctl/emr/start.py
@@ -17,6 +17,10 @@ EMR_RELEASE_SPARK_VERSION: Dict[str, str] = {
 DEFAULT_EMR_RELEASE = 'emr-7.3.0'
 HAIL_REQUIRED_SPARK_MINOR = '3.5'
 HAIL_JAR_PATH = '/usr/lib/hail/hail-all-spark.jar'
+# EMR 7.x's system python3 is 3.9, but Hail requires Python >= 3.10. The
+# bootstrap installs Hail into Python 3.11 (shipped with EMR 7.1+); PySpark
+# (driver and executors) must use the same interpreter.
+EMR_PYSPARK_PYTHON = '/usr/bin/python3.11'
 
 
 def check_release_spark_compatibility(release_label: str) -> None:
@@ -48,6 +52,7 @@ def hail_configurations(off_heap_memory_per_core_mb: Optional[int]) -> List[dict
         'spark.yarn.appMasterEnv.PYTHONHASHSEED': '0',
         'spark.executorEnv.HAIL_CLOUD': 'aws',
         'spark.yarn.appMasterEnv.HAIL_CLOUD': 'aws',
+        'spark.pyspark.python': EMR_PYSPARK_PYTHON,
     }
     if off_heap_memory_per_core_mb is not None:
         spark_defaults['spark.executorEnv.HAIL_WORKER_OFF_HEAP_MEMORY_PER_CORE_MB'] = str(
@@ -61,7 +66,12 @@ def hail_configurations(off_heap_memory_per_core_mb: Optional[int]) -> List[dict
             # what actually delivers HAIL_CLOUD to a client-deploy-mode driver
             # (executorEnv/appMasterEnv do not reach it).
             'Classification': 'spark-env',
-            'Configurations': [{'Classification': 'export', 'Properties': {'HAIL_CLOUD': 'aws'}}],
+            'Configurations': [
+                {
+                    'Classification': 'export',
+                    'Properties': {'HAIL_CLOUD': 'aws', 'PYSPARK_PYTHON': EMR_PYSPARK_PYTHON},
+                }
+            ],
             'Properties': {},
         },
     ]

--- a/hail/python/hailtop/hailctl/emr/start.py
+++ b/hail/python/hailtop/hailctl/emr/start.py
@@ -9,10 +9,10 @@ EMR_RELEASE_SPARK_VERSION: Dict[str, str] = {
     'emr-7.2.0': '3.5.2',
     'emr-7.1.0': '3.5.1',
     'emr-7.0.0': '3.5.0',
-    # EMR 6.x ships Spark 3.3.x — incompatible with Hail's Spark 3.5.x requirement
-    'emr-6.15.0': '3.3.2',
-    'emr-6.14.0': '3.3.2',
-    'emr-6.13.0': '3.3.2',
+    # EMR 6.x ships Spark 3.4.x — incompatible with Hail's Spark 3.5.x requirement
+    'emr-6.15.0': '3.4.1',
+    'emr-6.14.0': '3.4.1',
+    'emr-6.13.0': '3.4.1',
 }
 DEFAULT_EMR_RELEASE = 'emr-7.3.0'
 HAIL_REQUIRED_SPARK_MINOR = '3.5'

--- a/hail/python/hailtop/hailctl/emr/start.py
+++ b/hail/python/hailtop/hailctl/emr/start.py
@@ -56,6 +56,14 @@ def hail_configurations(off_heap_memory_per_core_mb: Optional[int]) -> List[dict
     return [
         {'Classification': 'spark-defaults', 'Properties': spark_defaults},
         {'Classification': 'spark', 'Properties': {'maximizeResourceAllocation': 'true'}},
+        {
+            # spark-env.sh is sourced by every spark-submit invocation, so this is
+            # what actually delivers HAIL_CLOUD to a client-deploy-mode driver
+            # (executorEnv/appMasterEnv do not reach it).
+            'Classification': 'spark-env',
+            'Configurations': [{'Classification': 'export', 'Properties': {'HAIL_CLOUD': 'aws'}}],
+            'Properties': {},
+        },
     ]
 
 

--- a/hail/python/hailtop/hailctl/emr/start.py
+++ b/hail/python/hailtop/hailctl/emr/start.py
@@ -1,0 +1,138 @@
+import copy
+import sys
+from typing import Dict, List, Optional
+
+# EMR release label -> the Spark version that release ships.
+# To support a new EMR release, add one entry here.
+EMR_RELEASE_SPARK_VERSION: Dict[str, str] = {
+    'emr-7.3.0': '3.5.3',  # matches Hail's SPARK_VERSION
+    'emr-7.2.0': '3.5.2',
+    'emr-7.1.0': '3.5.1',
+    'emr-7.0.0': '3.5.0',
+    # EMR 6.x ships Spark 3.3.x — incompatible with Hail's Spark 3.5.x requirement
+    'emr-6.15.0': '3.3.2',
+    'emr-6.14.0': '3.3.2',
+    'emr-6.13.0': '3.3.2',
+}
+DEFAULT_EMR_RELEASE = 'emr-7.3.0'
+HAIL_REQUIRED_SPARK_MINOR = '3.5'
+HAIL_JAR_PATH = '/usr/lib/hail/hail-all-spark.jar'
+
+
+def check_release_spark_compatibility(release_label: str) -> None:
+    spark_version = EMR_RELEASE_SPARK_VERSION.get(release_label)
+    if spark_version is None:
+        print(
+            f'Warning: unknown EMR release {release_label!r}. Hail requires Spark '
+            f'{HAIL_REQUIRED_SPARK_MINOR}.x; proceeding without a compatibility check.',
+            file=sys.stderr,
+        )
+        return
+    minor = spark_version.rsplit('.', 1)[0]
+    if minor != HAIL_REQUIRED_SPARK_MINOR:
+        raise ValueError(
+            f'EMR release {release_label!r} ships Spark {spark_version}, but Hail '
+            f'requires Spark {HAIL_REQUIRED_SPARK_MINOR}.x.'
+        )
+
+
+def hail_configurations(off_heap_memory_per_core_mb: Optional[int]) -> List[dict]:
+    spark_defaults = {
+        'spark.jars': f'local://{HAIL_JAR_PATH}',
+        'spark.driver.extraClassPath': HAIL_JAR_PATH,
+        'spark.executor.extraClassPath': HAIL_JAR_PATH,
+        'spark.task.maxFailures': '20',
+        'spark.driver.extraJavaOptions': '-Xss4M',
+        'spark.executor.extraJavaOptions': '-Xss4M',
+        'spark.executorEnv.PYTHONHASHSEED': '0',
+        'spark.yarn.appMasterEnv.PYTHONHASHSEED': '0',
+        'spark.executorEnv.HAIL_CLOUD': 'aws',
+        'spark.yarn.appMasterEnv.HAIL_CLOUD': 'aws',
+    }
+    if off_heap_memory_per_core_mb is not None:
+        spark_defaults['spark.executorEnv.HAIL_WORKER_OFF_HEAP_MEMORY_PER_CORE_MB'] = str(
+            off_heap_memory_per_core_mb
+        )
+    return [
+        {'Classification': 'spark-defaults', 'Properties': spark_defaults},
+        {'Classification': 'spark', 'Properties': {'maximizeResourceAllocation': 'true'}},
+    ]
+
+
+def deep_merge(base: dict, overlay: dict) -> dict:
+    result = copy.deepcopy(base)
+    for key, value in overlay.items():
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+            result[key] = deep_merge(result[key], value)
+        else:
+            result[key] = copy.deepcopy(value)
+    return result
+
+
+def build_run_job_flow_kwargs(
+    *,
+    cluster_name: str,
+    release_label: str,
+    master_instance_type: str,
+    core_instance_type: str,
+    core_instance_count: int,
+    ec2_key_name: Optional[str],
+    subnet_id: Optional[str],
+    log_uri: Optional[str],
+    bootstrap_s3_uri: str,
+    pip_version: str,
+    off_heap_memory_per_core_mb: Optional[int],
+    use_default_roles: bool,
+    service_role: Optional[str],
+    instance_profile: Optional[str],
+) -> dict:
+    kwargs: dict = {
+        'Name': cluster_name,
+        'ReleaseLabel': release_label,
+        'Applications': [{'Name': 'Spark'}],
+        'Configurations': hail_configurations(off_heap_memory_per_core_mb),
+        'BootstrapActions': [
+            {
+                'Name': 'install-hail',
+                'ScriptBootstrapAction': {'Path': bootstrap_s3_uri, 'Args': [pip_version]},
+            }
+        ],
+        'Instances': {
+            'InstanceGroups': [
+                {
+                    'Name': 'Master',
+                    'InstanceRole': 'MASTER',
+                    'InstanceType': master_instance_type,
+                    'InstanceCount': 1,
+                },
+                {
+                    'Name': 'Core',
+                    'InstanceRole': 'CORE',
+                    'InstanceType': core_instance_type,
+                    'InstanceCount': core_instance_count,
+                },
+            ],
+            'KeepJobFlowAliveWhenNoSteps': True,
+            'TerminationProtected': False,
+        },
+        'VisibleToAllUsers': True,
+    }
+    if log_uri is not None:
+        kwargs['LogUri'] = log_uri
+    if ec2_key_name is not None:
+        kwargs['Instances']['Ec2KeyName'] = ec2_key_name
+    if subnet_id is not None:
+        kwargs['Instances']['Ec2SubnetId'] = subnet_id
+
+    if use_default_roles:
+        kwargs['ServiceRole'] = 'EMR_DefaultRole'
+        kwargs['JobFlowRole'] = 'EMR_EC2_DefaultRole'
+    else:
+        if service_role is None or instance_profile is None:
+            raise ValueError(
+                'Either pass --use-default-roles, or provide both --service-role and --instance-profile.'
+            )
+        kwargs['ServiceRole'] = service_role
+        kwargs['JobFlowRole'] = instance_profile
+
+    return kwargs

--- a/hail/python/hailtop/hailctl/emr/start.py
+++ b/hail/python/hailtop/hailctl/emr/start.py
@@ -5,10 +5,10 @@ from typing import Dict, List, Optional
 # EMR release label -> the Spark version that release ships.
 # To support a new EMR release, add one entry here.
 EMR_RELEASE_SPARK_VERSION: Dict[str, str] = {
-    'emr-7.3.0': '3.5.3',  # matches Hail's SPARK_VERSION
-    'emr-7.2.0': '3.5.2',
-    'emr-7.1.0': '3.5.1',
-    'emr-7.0.0': '3.5.0',
+    'emr-7.3.0': '3.5.1-amzn-1',
+    'emr-7.2.0': '3.5.1-amzn-0',
+    'emr-7.1.0': '3.5.0-amzn-1',
+    'emr-7.0.0': '3.5.0-amzn-0',
     # EMR 6.x ships Spark 3.4.x — incompatible with Hail's Spark 3.5.x requirement
     'emr-6.15.0': '3.4.1',
     'emr-6.14.0': '3.4.1',
@@ -34,7 +34,7 @@ def check_release_spark_compatibility(release_label: str) -> None:
             file=sys.stderr,
         )
         return
-    minor = spark_version.rsplit('.', 1)[0]
+    minor = '.'.join(spark_version.split('.')[:2])
     if minor != HAIL_REQUIRED_SPARK_MINOR:
         raise ValueError(
             f'EMR release {release_label!r} ships Spark {spark_version}, but Hail '
@@ -47,6 +47,8 @@ def hail_configurations(off_heap_memory_per_core_mb: Optional[int]) -> List[dict
         'spark.jars': f'local://{HAIL_JAR_PATH}',
         'spark.driver.extraClassPath': HAIL_JAR_PATH,
         'spark.executor.extraClassPath': HAIL_JAR_PATH,
+        'spark.serializer': 'org.apache.spark.serializer.KryoSerializer',
+        'spark.kryo.registrator': 'is.hail.kryo.HailKryoRegistrator',
         'spark.task.maxFailures': '20',
         'spark.driver.extraJavaOptions': '-Xss4M',
         'spark.executor.extraJavaOptions': '-Xss4M',
@@ -84,6 +86,20 @@ def deep_merge(base: dict, overlay: dict) -> dict:
             result[key] = deep_merge(result[key], value)
         else:
             result[key] = copy.deepcopy(value)
+    return result
+
+
+def merge_run_job_flow_overlay(base: dict, overlay: dict) -> dict:
+    result = deep_merge(base, overlay)
+    instances_overlay = overlay.get('Instances')
+    if (
+        isinstance(instances_overlay, dict)
+        and 'InstanceFleets' in instances_overlay
+        and 'InstanceGroups' not in instances_overlay
+    ):
+        instances = result.get('Instances')
+        if isinstance(instances, dict):
+            instances.pop('InstanceGroups', None)
     return result
 
 

--- a/hail/python/hailtop/hailctl/emr/start.py
+++ b/hail/python/hailtop/hailctl/emr/start.py
@@ -17,13 +17,12 @@ EMR_RELEASE_SPARK_VERSION: Dict[str, str] = {
 DEFAULT_EMR_RELEASE = 'emr-7.3.0'
 HAIL_REQUIRED_SPARK_MINOR = '3.5'
 HAIL_JAR_PATH = '/usr/lib/hail/hail-all-spark.jar'
-# EMR 7.x's system python3 is 3.9, but Hail requires Python >= 3.10. The EMR 7.x
-# application stack officially ships only Python 3.9 and 3.11 (see the release's
-# component versions); 3.12 is not provided by default. So the bootstrap installs
-# Hail into Python 3.11, and PySpark (driver and executors) must use that same
-# interpreter. If a future EMR release ships a newer default Python that Hail
-# supports, update this single constant (and the bootstrap's dnf line).
-EMR_PYSPARK_PYTHON = '/usr/bin/python3.11'
+# EMR 7.x's system python3 is 3.9, which is too old for Hail. EMR 7.x runs Amazon
+# Linux 2023, which packages python3.12 in its dnf repositories, so the bootstrap
+# installs Hail into Python 3.12 and PySpark (driver and executors) must use that
+# same interpreter. To move to a newer Python, update this constant and the
+# bootstrap's dnf line together.
+EMR_PYSPARK_PYTHON = '/usr/bin/python3.12'
 
 
 def check_release_spark_compatibility(release_label: str) -> None:

--- a/hail/python/hailtop/hailctl/emr/start.py
+++ b/hail/python/hailtop/hailctl/emr/start.py
@@ -17,9 +17,12 @@ EMR_RELEASE_SPARK_VERSION: Dict[str, str] = {
 DEFAULT_EMR_RELEASE = 'emr-7.3.0'
 HAIL_REQUIRED_SPARK_MINOR = '3.5'
 HAIL_JAR_PATH = '/usr/lib/hail/hail-all-spark.jar'
-# EMR 7.x's system python3 is 3.9, but Hail requires Python >= 3.10. The
-# bootstrap installs Hail into Python 3.11 (shipped with EMR 7.1+); PySpark
-# (driver and executors) must use the same interpreter.
+# EMR 7.x's system python3 is 3.9, but Hail requires Python >= 3.10. The EMR 7.x
+# application stack officially ships only Python 3.9 and 3.11 (see the release's
+# component versions); 3.12 is not provided by default. So the bootstrap installs
+# Hail into Python 3.11, and PySpark (driver and executors) must use that same
+# interpreter. If a future EMR release ships a newer default Python that Hail
+# supports, update this single constant (and the bootstrap's dnf line).
 EMR_PYSPARK_PYTHON = '/usr/bin/python3.11'
 
 

--- a/hail/python/hailtop/hailctl/emr/start.py
+++ b/hail/python/hailtop/hailctl/emr/start.py
@@ -57,9 +57,7 @@ def hail_configurations(off_heap_memory_per_core_mb: Optional[int]) -> List[dict
         'spark.pyspark.python': EMR_PYSPARK_PYTHON,
     }
     if off_heap_memory_per_core_mb is not None:
-        spark_defaults['spark.executorEnv.HAIL_WORKER_OFF_HEAP_MEMORY_PER_CORE_MB'] = str(
-            off_heap_memory_per_core_mb
-        )
+        spark_defaults['spark.executorEnv.HAIL_WORKER_OFF_HEAP_MEMORY_PER_CORE_MB'] = str(off_heap_memory_per_core_mb)
     return [
         {'Classification': 'spark-defaults', 'Properties': spark_defaults},
         {'Classification': 'spark', 'Properties': {'maximizeResourceAllocation': 'true'}},
@@ -149,9 +147,7 @@ def build_run_job_flow_kwargs(
         kwargs['JobFlowRole'] = 'EMR_EC2_DefaultRole'
     else:
         if service_role is None or instance_profile is None:
-            raise ValueError(
-                'Either pass --use-default-roles, or provide both --service-role and --instance-profile.'
-            )
+            raise ValueError('Either pass --use-default-roles, or provide both --service-role and --instance-profile.')
         kwargs['ServiceRole'] = service_role
         kwargs['JobFlowRole'] = instance_profile
 

--- a/hail/python/hailtop/hailctl/emr/submit.py
+++ b/hail/python/hailtop/hailctl/emr/submit.py
@@ -53,9 +53,12 @@ def submit(
     try:
         waiter.wait(ClusterId=cluster_id, StepId=step_id)
     except Exception as e:  # surface the failure to the user
-        desc = client.describe_step(ClusterId=cluster_id, StepId=step_id)
-        state = desc['Step']['Status']['State']
-        print(f'Step {step_id} did not complete successfully (state={state}).', file=sys.stderr)
+        try:
+            desc = client.describe_step(ClusterId=cluster_id, StepId=step_id)
+            state = desc['Step']['Status']['State']
+            print(f'Step {step_id} did not complete successfully (state={state}).', file=sys.stderr)
+        except Exception:
+            print(f'Step {step_id} did not complete successfully (state unknown).', file=sys.stderr)
         raise SystemExit(1) from e
 
     print(f'Step {step_id} completed.')

--- a/hail/python/hailtop/hailctl/emr/submit.py
+++ b/hail/python/hailtop/hailctl/emr/submit.py
@@ -2,8 +2,6 @@ import os
 import sys
 from typing import List, Optional
 
-from hailtop.utils import secret_alnum_string
-
 from . import emr
 
 
@@ -19,6 +17,8 @@ def submit(
     pass_through_args: List[str],
     wait: bool = True,
 ) -> str:
+    from hailtop.utils import secret_alnum_string  # pylint: disable=import-outside-toplevel
+
     resolved_region = emr.resolve_region(region)
     client = emr.emr_client(resolved_region)
 

--- a/hail/python/hailtop/hailctl/emr/submit.py
+++ b/hail/python/hailtop/hailctl/emr/submit.py
@@ -2,6 +2,8 @@ import os
 import sys
 from typing import List, Optional
 
+from hailtop.utils import secret_alnum_string
+
 from . import emr
 
 
@@ -17,8 +19,6 @@ def submit(
     pass_through_args: List[str],
     wait: bool = True,
 ) -> str:
-    from hailtop.utils import secret_alnum_string  # pylint: disable=import-outside-toplevel
-
     resolved_region = emr.resolve_region(region)
     client = emr.emr_client(resolved_region)
 
@@ -52,7 +52,7 @@ def submit(
     waiter = client.get_waiter('step_complete')
     try:
         waiter.wait(ClusterId=cluster_id, StepId=step_id)
-    except Exception as e:  # noqa: BLE001 - surface the failure to the user
+    except Exception as e:  # surface the failure to the user
         desc = client.describe_step(ClusterId=cluster_id, StepId=step_id)
         state = desc['Step']['Status']['State']
         print(f'Step {step_id} did not complete successfully (state={state}).', file=sys.stderr)

--- a/hail/python/hailtop/hailctl/emr/submit.py
+++ b/hail/python/hailtop/hailctl/emr/submit.py
@@ -1,0 +1,62 @@
+import os
+import sys
+from typing import List, Optional
+
+from . import emr
+
+
+def spark_submit_step_args(script_s3_uri: str, pass_through_args: List[str]) -> List[str]:
+    return ['spark-submit', '--deploy-mode', 'client', script_s3_uri, *pass_through_args]
+
+
+def submit(
+    cluster_id: str,
+    script: str,
+    remote_tmpdir: str,
+    region: Optional[str],
+    pass_through_args: List[str],
+    wait: bool = True,
+) -> str:
+    from hailtop.utils import secret_alnum_string  # pylint: disable=import-outside-toplevel
+
+    resolved_region = emr.resolve_region(region)
+    client = emr.emr_client(resolved_region)
+
+    prefix = remote_tmpdir.rstrip('/') + '/' + secret_alnum_string(8)
+    script_s3_uri = f'{prefix}/{os.path.basename(script)}'
+
+    print(f'Uploading {script} to {script_s3_uri}')
+    with open(script, 'rb') as f:
+        emr.upload_to_s3(script_s3_uri, f.read())
+
+    resp = client.add_job_flow_steps(
+        JobFlowId=cluster_id,
+        Steps=[
+            {
+                'Name': f'hail-{os.path.basename(script)}',
+                'ActionOnFailure': 'CONTINUE',
+                'HadoopJarStep': {
+                    'Jar': 'command-runner.jar',
+                    'Args': spark_submit_step_args(script_s3_uri, pass_through_args),
+                },
+            }
+        ],
+    )
+    step_id = resp['StepIds'][0]
+    print(f'Submitted step {step_id} to cluster {cluster_id}.')
+
+    if not wait:
+        return step_id
+
+    print('Waiting for step to complete ...')
+    waiter = client.get_waiter('step_complete')
+    try:
+        waiter.wait(ClusterId=cluster_id, StepId=step_id)
+    except Exception as e:  # noqa: BLE001 - surface the failure to the user
+        desc = client.describe_step(ClusterId=cluster_id, StepId=step_id)
+        state = desc['Step']['Status']['State']
+        print(f'Step {step_id} did not complete successfully (state={state}).', file=sys.stderr)
+        raise SystemExit(1) from e
+
+    print(f'Step {step_id} completed.')
+    return step_id

--- a/hail/python/hailtop/hailctl/emr/submit.py
+++ b/hail/python/hailtop/hailctl/emr/submit.py
@@ -51,7 +51,9 @@ def submit(
     print('Waiting for step to complete ...')
     waiter = client.get_waiter('step_complete')
     try:
-        waiter.wait(ClusterId=cluster_id, StepId=step_id)
+        # botocore's default caps the wait at 30 minutes (30s x 60), which is far
+        # too short for a Hail job. Poll for up to a week instead.
+        waiter.wait(ClusterId=cluster_id, StepId=step_id, WaiterConfig={'Delay': 30, 'MaxAttempts': 20160})
     except Exception as e:  # surface the failure to the user
         try:
             desc = client.describe_step(ClusterId=cluster_id, StepId=step_id)

--- a/hail/python/hailtop/hailctl/emr/submit.py
+++ b/hail/python/hailtop/hailctl/emr/submit.py
@@ -55,12 +55,15 @@ def submit(
         # too short for a Hail job. Poll for up to a week instead.
         waiter.wait(ClusterId=cluster_id, StepId=step_id, WaiterConfig={'Delay': 30, 'MaxAttempts': 20160})
     except Exception as e:  # surface the failure to the user
+        # The waiter's own message carries the state change reason AWS reported, so
+        # print it whether or not the follow-up describe_step succeeds.
+        print(f'Step {step_id} did not complete successfully: {e}', file=sys.stderr)
         try:
             desc = client.describe_step(ClusterId=cluster_id, StepId=step_id)
             state = desc['Step']['Status']['State']
-            print(f'Step {step_id} did not complete successfully (state={state}).', file=sys.stderr)
+            print(f'Step {step_id} state is {state}.', file=sys.stderr)
         except Exception:
-            print(f'Step {step_id} did not complete successfully (state unknown).', file=sys.stderr)
+            print(f'Could not describe step {step_id} to report its state.', file=sys.stderr)
         raise SystemExit(1) from e
 
     print(f'Step {step_id} completed.')

--- a/hail/python/setup.py
+++ b/hail/python/setup.py
@@ -73,6 +73,7 @@ setup(
         'hail.backend': ['hail-all-spark.jar'],
         'hailtop': ['py.typed'],
         'hailtop.hailctl': ['deploy.yaml'],
+        'hailtop.hailctl.emr': ['resources/*'],
     },
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/hail/python/test/hailtop/hailctl/config/test_cli.py
+++ b/hail/python/test/hailtop/hailctl/config/test_cli.py
@@ -37,6 +37,10 @@ def test_config_list_empty_config(runner: CliRunner):
         ('query/batch_worker_memory', 'standard'),
         ('query/name_prefix', 'foo'),
         ('query/disable_progress_bar', '1'),
+        ('emr/region', 'us-east-1'),
+        ('emr/region', 'us-gov-west-1'),
+        ('emr/region', 'ap-southeast-3'),
+        ('emr/remote_tmpdir', 's3://foo/bar'),
     ],
 )
 def test_config_set_get_list_unset(name: str, value: str, runner: CliRunner, config_dir: str):
@@ -117,6 +121,8 @@ def test_config_unset_unknown_name(runner: CliRunner):
         ('query/batch_driver_memory', '1bar'),
         ('query/batch_worker_memory', 'random'),
         ('query/disable_progress_bar', '2'),
+        ('emr/region', 'not a region'),
+        ('emr/remote_tmpdir', 'gs://foo/bar'),
     ],
 )
 def test_config_set_bad_value(name: str, value: str, runner: CliRunner):

--- a/hail/python/test/hailtop/hailctl/emr/cli/conftest.py
+++ b/hail/python/test/hailtop/hailctl/emr/cli/conftest.py
@@ -1,0 +1,23 @@
+from unittest.mock import Mock
+
+import pytest
+
+
+@pytest.fixture
+def emr_client_mock():
+    return Mock()
+
+
+@pytest.fixture
+def upload_mock():
+    # Replaces emr.upload_to_s3; records (dest_uri, data) calls without touching S3.
+    return Mock()
+
+
+@pytest.fixture(autouse=True)
+def patch_aws(monkeypatch, emr_client_mock, upload_mock):
+    monkeypatch.setattr('hailtop.hailctl.emr.emr.emr_client', lambda region: emr_client_mock)
+    monkeypatch.setattr('hailtop.hailctl.emr.emr.upload_to_s3', upload_mock)
+    monkeypatch.setattr('hailtop.hailctl.emr.emr.resolve_region', lambda region: 'us-east-1')
+    yield
+    monkeypatch.undo()

--- a/hail/python/test/hailtop/hailctl/emr/cli/conftest.py
+++ b/hail/python/test/hailtop/hailctl/emr/cli/conftest.py
@@ -14,10 +14,18 @@ def upload_mock():
     return Mock()
 
 
+@pytest.fixture
+def check_default_roles_mock():
+    # Replaces emr.check_default_roles, which otherwise builds its own boto3 IAM
+    # client and calls GetRole for real.
+    return Mock()
+
+
 @pytest.fixture(autouse=True)
-def patch_aws(monkeypatch, emr_client_mock, upload_mock):
+def patch_aws(monkeypatch, emr_client_mock, upload_mock, check_default_roles_mock):
     monkeypatch.setattr('hailtop.hailctl.emr.emr.emr_client', lambda region: emr_client_mock)
     monkeypatch.setattr('hailtop.hailctl.emr.emr.upload_to_s3', upload_mock)
     monkeypatch.setattr('hailtop.hailctl.emr.emr.resolve_region', lambda region: 'us-east-1')
+    monkeypatch.setattr('hailtop.hailctl.emr.emr.check_default_roles', check_default_roles_mock)
     yield
     monkeypatch.undo()

--- a/hail/python/test/hailtop/hailctl/emr/cli/test_cli.py
+++ b/hail/python/test/hailtop/hailctl/emr/cli/test_cli.py
@@ -65,6 +65,15 @@ def test_list_calls_list_clusters(emr_client_mock):
     assert emr_client_mock.list_clusters.call_count == 1
 
 
+def test_start_invalid_json_overlay_errors(emr_client_mock):
+    res = runner.invoke(
+        cli.app,
+        ['start', 'c1', '--s3-scratch', 's3://bkt/tmp/', '--run-job-flow-json', '{not json'],
+    )
+    assert res.exit_code != 0
+    assert emr_client_mock.run_job_flow.call_count == 0
+
+
 def test_submit_invokes_submit(monkeypatch):
     called = {}
 

--- a/hail/python/test/hailtop/hailctl/emr/cli/test_cli.py
+++ b/hail/python/test/hailtop/hailctl/emr/cli/test_cli.py
@@ -1,0 +1,82 @@
+from typer.testing import CliRunner
+
+from hailtop.hailctl.emr import cli
+
+runner = CliRunner()
+
+
+def test_start_requires_name_and_tmpdir():
+    res = runner.invoke(cli.app, ['start'])
+    assert res.exit_code != 0
+
+
+def test_start_dry_run_makes_no_aws_calls(emr_client_mock, upload_mock):
+    res = runner.invoke(
+        cli.app, ['start', 'c1', '--s3-scratch', 's3://bkt/tmp/', '--dry-run']
+    )
+    assert res.exit_code == 0
+    assert emr_client_mock.run_job_flow.call_count == 0
+    assert upload_mock.call_count == 0  # dry run must not write to S3
+
+
+def test_start_calls_run_job_flow_with_hail_config(emr_client_mock, upload_mock):
+    emr_client_mock.run_job_flow.return_value = {'JobFlowId': 'j-123'}
+    res = runner.invoke(cli.app, ['start', 'c1', '--s3-scratch', 's3://bkt/tmp/'])
+    assert res.exit_code == 0, res.stdout
+    # bootstrap script uploaded to the scratch bucket
+    assert upload_mock.call_count == 1
+    kwargs = emr_client_mock.run_job_flow.call_args.kwargs
+    assert kwargs['ReleaseLabel'] == 'emr-7.3.0'
+    spark_defaults = next(c for c in kwargs['Configurations'] if c['Classification'] == 'spark-defaults')
+    assert spark_defaults['Properties']['spark.executorEnv.HAIL_CLOUD'] == 'aws'
+    ba = kwargs['BootstrapActions'][0]['ScriptBootstrapAction']
+    assert ba['Path'].startswith('s3://bkt/tmp/')
+    assert ba['Path'].endswith('install-hail-emr.sh')
+
+
+def test_start_unknown_release_errors(emr_client_mock):
+    res = runner.invoke(
+        cli.app, ['start', 'c1', '--s3-scratch', 's3://bkt/tmp/', '--release-label', 'emr-6.15.0']
+    )
+    assert res.exit_code != 0
+    assert emr_client_mock.run_job_flow.call_count == 0
+
+
+def test_start_json_overlay_merges(emr_client_mock):
+    emr_client_mock.run_job_flow.return_value = {'JobFlowId': 'j-1'}
+    res = runner.invoke(
+        cli.app,
+        ['start', 'c1', '--s3-scratch', 's3://bkt/tmp/', '--run-job-flow-json', '{"Name": "override"}'],
+    )
+    assert res.exit_code == 0, res.stdout
+    assert emr_client_mock.run_job_flow.call_args.kwargs['Name'] == 'override'
+
+
+def test_stop_calls_terminate(emr_client_mock):
+    res = runner.invoke(cli.app, ['stop', 'j-123'])
+    assert res.exit_code == 0
+    emr_client_mock.terminate_job_flows.assert_called_once_with(JobFlowIds=['j-123'])
+
+
+def test_list_calls_list_clusters(emr_client_mock):
+    emr_client_mock.list_clusters.return_value = {'Clusters': []}
+    res = runner.invoke(cli.app, ['list'])
+    assert res.exit_code == 0
+    assert emr_client_mock.list_clusters.call_count == 1
+
+
+def test_submit_invokes_submit(monkeypatch):
+    called = {}
+
+    def fake_submit(cluster_id, script, remote_tmpdir, region, pass_through_args, wait=True):
+        called['cluster_id'] = cluster_id
+        called['script'] = script
+        return 's-1'
+
+    monkeypatch.setattr('hailtop.hailctl.emr.submit.submit', fake_submit)
+    res = runner.invoke(
+        cli.app, ['submit', 'j-123', 'script.py', '--s3-scratch', 's3://bkt/tmp/']
+    )
+    assert res.exit_code == 0, res.stdout
+    assert called['cluster_id'] == 'j-123'
+    assert called['script'] == 'script.py'

--- a/hail/python/test/hailtop/hailctl/emr/cli/test_cli.py
+++ b/hail/python/test/hailtop/hailctl/emr/cli/test_cli.py
@@ -92,6 +92,14 @@ def test_start_rejects_unknown_flags(emr_client_mock):
     assert emr_client_mock.run_job_flow.call_count == 0
 
 
+def test_start_rejects_custom_roles_without_no_use_default_roles(emr_client_mock):
+    # Otherwise the custom role is silently dropped and the cluster quietly runs
+    # under EMR_DefaultRole.
+    res = runner.invoke(cli.app, ['start', 'c1', '--s3-scratch', 's3://bkt/tmp/', '--service-role', 'my-role'])
+    assert res.exit_code != 0
+    assert emr_client_mock.run_job_flow.call_count == 0
+
+
 def test_start_invalid_json_overlay_errors(emr_client_mock):
     res = runner.invoke(
         cli.app,

--- a/hail/python/test/hailtop/hailctl/emr/cli/test_cli.py
+++ b/hail/python/test/hailtop/hailctl/emr/cli/test_cli.py
@@ -1,3 +1,6 @@
+import json
+
+import pytest
 from typer.testing import CliRunner
 
 from hailtop.hailctl.emr import cli
@@ -52,6 +55,51 @@ def test_start_json_overlay_merges(emr_client_mock):
     )
     assert res.exit_code == 0, res.stdout
     assert emr_client_mock.run_job_flow.call_args.kwargs['Name'] == 'override'
+
+
+def test_start_json_overlay_custom_roles_skip_default_role_preflight(emr_client_mock, check_default_roles_mock):
+    emr_client_mock.run_job_flow.return_value = {'JobFlowId': 'j-1'}
+    res = runner.invoke(
+        cli.app,
+        [
+            'start',
+            'c1',
+            '--s3-scratch',
+            's3://bkt/tmp/',
+            '--run-job-flow-json',
+            '{"ServiceRole":"custom-service","JobFlowRole":"custom-profile"}',
+        ],
+    )
+    assert res.exit_code == 0, res.output
+    assert check_default_roles_mock.call_count == 0
+    kwargs = emr_client_mock.run_job_flow.call_args.kwargs
+    assert kwargs['ServiceRole'] == 'custom-service'
+    assert kwargs['JobFlowRole'] == 'custom-profile'
+
+
+@pytest.mark.parametrize(
+    ('overlay', 'expected_call'),
+    [
+        (
+            '{"ServiceRole":"custom-service"}',
+            {'check_service_role': False, 'check_job_flow_role': True},
+        ),
+        (
+            '{"JobFlowRole":"custom-profile"}',
+            {'check_service_role': True, 'check_job_flow_role': False},
+        ),
+    ],
+)
+def test_start_json_overlay_mixed_roles_check_remaining_default(
+    overlay, expected_call, emr_client_mock, check_default_roles_mock
+):
+    emr_client_mock.run_job_flow.return_value = {'JobFlowId': 'j-1'}
+    res = runner.invoke(
+        cli.app,
+        ['start', 'c1', '--s3-scratch', 's3://bkt/tmp/', '--run-job-flow-json', overlay],
+    )
+    assert res.exit_code == 0, res.output
+    check_default_roles_mock.assert_called_once_with(**expected_call)
 
 
 def test_stop_calls_terminate(emr_client_mock):
@@ -109,6 +157,161 @@ def test_start_invalid_json_overlay_errors(emr_client_mock):
     assert emr_client_mock.run_job_flow.call_count == 0
 
 
+@pytest.mark.parametrize('overlay', ['[]', 'null', '1', '"value"'])
+def test_start_json_overlay_requires_object(overlay, emr_client_mock):
+    res = runner.invoke(
+        cli.app,
+        ['start', 'c1', '--s3-scratch', 's3://bkt/tmp/', '--dry-run', '--run-job-flow-json', overlay],
+    )
+    assert res.exit_code != 0
+    assert '--run-job-flow-json must contain a JSON object' in res.output
+    assert emr_client_mock.run_job_flow.call_count == 0
+
+
+def test_start_json_overlay_revalidates_release(emr_client_mock):
+    res = runner.invoke(
+        cli.app,
+        [
+            'start',
+            'c1',
+            '--s3-scratch',
+            's3://bkt/tmp/',
+            '--dry-run',
+            '--run-job-flow-json',
+            '{"ReleaseLabel":"emr-6.15.0"}',
+        ],
+    )
+    assert res.exit_code != 0
+    assert emr_client_mock.run_job_flow.call_count == 0
+
+
+@pytest.mark.parametrize(
+    'scratch',
+    [
+        'gs://bkt/tmp/',
+        's3://',
+        's3:///tmp/',
+        's3:// bad/tmp/',
+        's3://bkt/tmp/?x=1',
+        's3://user@bucket/key',
+        's3://bucket:443/key',
+        r's3://bucket\evil/key',
+        's3://[broken/key',
+    ],
+)
+def test_start_rejects_invalid_s3_scratch(scratch, emr_client_mock, upload_mock):
+    res = runner.invoke(cli.app, ['start', 'c1', '--s3-scratch', scratch, '--dry-run'])
+    assert res.exit_code != 0
+    assert '--s3-scratch must be a valid S3 URI' in res.output
+    assert emr_client_mock.run_job_flow.call_count == 0
+    assert upload_mock.call_count == 0
+
+
+def test_start_rejects_non_s3_log_uri(emr_client_mock, upload_mock):
+    res = runner.invoke(
+        cli.app,
+        ['start', 'c1', '--s3-scratch', 's3://bkt/tmp/', '--log-uri', 'gs://bkt/logs/', '--dry-run'],
+    )
+    assert res.exit_code != 0
+    assert '--log-uri must be a valid S3 URI' in res.output
+    assert emr_client_mock.run_job_flow.call_count == 0
+    assert upload_mock.call_count == 0
+
+
+def test_start_json_overlay_revalidates_log_uri(emr_client_mock, upload_mock):
+    res = runner.invoke(
+        cli.app,
+        [
+            'start',
+            'c1',
+            '--s3-scratch',
+            's3://bkt/tmp/',
+            '--dry-run',
+            '--run-job-flow-json',
+            '{"LogUri":"gs://bkt/logs/"}',
+        ],
+    )
+    assert res.exit_code != 0
+    assert 'final RunJobFlow LogUri must be a valid S3 URI' in res.output
+    assert emr_client_mock.run_job_flow.call_count == 0
+    assert upload_mock.call_count == 0
+
+
+def test_start_json_overlay_rejects_null_log_uri(emr_client_mock, upload_mock):
+    res = runner.invoke(
+        cli.app,
+        [
+            'start',
+            'c1',
+            '--s3-scratch',
+            's3://bkt/tmp/',
+            '--dry-run',
+            '--run-job-flow-json',
+            '{"LogUri":null}',
+        ],
+    )
+    assert res.exit_code != 0
+    assert 'final RunJobFlow LogUri must be a string' in res.output
+    assert emr_client_mock.run_job_flow.call_count == 0
+    assert upload_mock.call_count == 0
+
+
+def test_start_json_overlay_requires_spark(emr_client_mock):
+    res = runner.invoke(
+        cli.app,
+        [
+            'start',
+            'c1',
+            '--s3-scratch',
+            's3://bkt/tmp/',
+            '--dry-run',
+            '--run-job-flow-json',
+            '{"Applications":[{"Name":"Hadoop"}]}',
+        ],
+    )
+    assert res.exit_code != 0
+    assert 'Applications list must include Spark' in res.output
+    assert emr_client_mock.run_job_flow.call_count == 0
+
+
+def test_start_json_overlay_instance_fleets_replace_default_groups():
+    res = runner.invoke(
+        cli.app,
+        [
+            'start',
+            'c1',
+            '--s3-scratch',
+            's3://bkt/tmp/',
+            '--dry-run',
+            '--run-job-flow-json',
+            '{"Instances":{"InstanceFleets":[]}}',
+        ],
+    )
+    assert res.exit_code == 0, res.output
+    instances = json.loads(res.output)['Instances']
+    assert 'InstanceGroups' not in instances
+    assert instances['InstanceFleets'] == []
+
+
+def test_start_json_overlay_rejects_groups_and_fleets_together(emr_client_mock):
+    res = runner.invoke(
+        cli.app,
+        [
+            'start',
+            'c1',
+            '--s3-scratch',
+            's3://bkt/tmp/',
+            '--dry-run',
+            '--run-job-flow-json',
+            '{"Instances":{"InstanceGroups":[],"InstanceFleets":[]}}',
+        ],
+    )
+    assert res.exit_code != 0
+    assert 'cannot contain both InstanceGroups' in res.output
+    assert 'InstanceFleets' in res.output
+    assert emr_client_mock.run_job_flow.call_count == 0
+
+
 def test_submit_invokes_submit(monkeypatch):
     called = {}
 
@@ -122,3 +325,17 @@ def test_submit_invokes_submit(monkeypatch):
     assert res.exit_code == 0, res.stdout
     assert called['cluster_id'] == 'j-123'
     assert called['script'] == 'script.py'
+
+
+def test_submit_rejects_non_s3_scratch(monkeypatch):
+    called = False
+
+    def fake_submit(*args, **kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr('hailtop.hailctl.emr.submit.submit', fake_submit)
+    res = runner.invoke(cli.app, ['submit', 'j-123', 'script.py', '--s3-scratch', 'gs://bkt/tmp/'])
+    assert res.exit_code != 0
+    assert '--s3-scratch must be a valid S3 URI' in res.output
+    assert not called

--- a/hail/python/test/hailtop/hailctl/emr/cli/test_cli.py
+++ b/hail/python/test/hailtop/hailctl/emr/cli/test_cli.py
@@ -17,6 +17,12 @@ def test_start_dry_run_makes_no_aws_calls(emr_client_mock, upload_mock):
     assert upload_mock.call_count == 0  # dry run must not write to S3
 
 
+def test_start_dry_run_does_not_check_iam_roles(check_default_roles_mock):
+    res = runner.invoke(cli.app, ['start', 'c1', '--s3-scratch', 's3://bkt/tmp/', '--dry-run'])
+    assert res.exit_code == 0
+    assert check_default_roles_mock.call_count == 0
+
+
 def test_start_calls_run_job_flow_with_hail_config(emr_client_mock, upload_mock):
     emr_client_mock.run_job_flow.return_value = {'JobFlowId': 'j-123'}
     res = runner.invoke(cli.app, ['start', 'c1', '--s3-scratch', 's3://bkt/tmp/'])

--- a/hail/python/test/hailtop/hailctl/emr/cli/test_cli.py
+++ b/hail/python/test/hailtop/hailctl/emr/cli/test_cli.py
@@ -11,9 +11,7 @@ def test_start_requires_name_and_tmpdir():
 
 
 def test_start_dry_run_makes_no_aws_calls(emr_client_mock, upload_mock):
-    res = runner.invoke(
-        cli.app, ['start', 'c1', '--s3-scratch', 's3://bkt/tmp/', '--dry-run']
-    )
+    res = runner.invoke(cli.app, ['start', 'c1', '--s3-scratch', 's3://bkt/tmp/', '--dry-run'])
     assert res.exit_code == 0
     assert emr_client_mock.run_job_flow.call_count == 0
     assert upload_mock.call_count == 0  # dry run must not write to S3
@@ -35,9 +33,7 @@ def test_start_calls_run_job_flow_with_hail_config(emr_client_mock, upload_mock)
 
 
 def test_start_unknown_release_errors(emr_client_mock):
-    res = runner.invoke(
-        cli.app, ['start', 'c1', '--s3-scratch', 's3://bkt/tmp/', '--release-label', 'emr-6.15.0']
-    )
+    res = runner.invoke(cli.app, ['start', 'c1', '--s3-scratch', 's3://bkt/tmp/', '--release-label', 'emr-6.15.0'])
     assert res.exit_code != 0
     assert emr_client_mock.run_job_flow.call_count == 0
 
@@ -58,11 +54,26 @@ def test_stop_calls_terminate(emr_client_mock):
     emr_client_mock.terminate_job_flows.assert_called_once_with(JobFlowIds=['j-123'])
 
 
-def test_list_calls_list_clusters(emr_client_mock):
-    emr_client_mock.list_clusters.return_value = {'Clusters': []}
+def test_list_filters_to_active_clusters_and_paginates(emr_client_mock):
+    paginator = emr_client_mock.get_paginator.return_value
+    paginator.paginate.return_value = [
+        {'Clusters': [{'Id': 'j-1', 'Status': {'State': 'WAITING'}, 'Name': 'c1'}]},
+        {'Clusters': [{'Id': 'j-2', 'Status': {'State': 'RUNNING'}, 'Name': 'c2'}]},
+    ]
     res = runner.invoke(cli.app, ['list'])
-    assert res.exit_code == 0
-    assert emr_client_mock.list_clusters.call_count == 1
+    assert res.exit_code == 0, res.stdout
+    emr_client_mock.get_paginator.assert_called_once_with('list_clusters')
+    paginator.paginate.assert_called_once_with(ClusterStates=cli.ACTIVE_CLUSTER_STATES)
+    # every page is consumed, not just the first
+    assert 'j-1' in res.stdout and 'j-2' in res.stdout
+
+
+def test_list_all_includes_terminated(emr_client_mock):
+    paginator = emr_client_mock.get_paginator.return_value
+    paginator.paginate.return_value = []
+    res = runner.invoke(cli.app, ['list', '--all'])
+    assert res.exit_code == 0, res.stdout
+    paginator.paginate.assert_called_once_with()
 
 
 def test_start_rejects_unknown_flags(emr_client_mock):
@@ -93,9 +104,7 @@ def test_submit_invokes_submit(monkeypatch):
         return 's-1'
 
     monkeypatch.setattr('hailtop.hailctl.emr.submit.submit', fake_submit)
-    res = runner.invoke(
-        cli.app, ['submit', 'j-123', 'script.py', '--s3-scratch', 's3://bkt/tmp/']
-    )
+    res = runner.invoke(cli.app, ['submit', 'j-123', 'script.py', '--s3-scratch', 's3://bkt/tmp/'])
     assert res.exit_code == 0, res.stdout
     assert called['cluster_id'] == 'j-123'
     assert called['script'] == 'script.py'

--- a/hail/python/test/hailtop/hailctl/emr/cli/test_cli.py
+++ b/hail/python/test/hailtop/hailctl/emr/cli/test_cli.py
@@ -65,6 +65,16 @@ def test_list_calls_list_clusters(emr_client_mock):
     assert emr_client_mock.list_clusters.call_count == 1
 
 
+def test_start_rejects_unknown_flags(emr_client_mock):
+    # A typo like --core-instance-cout must not be silently ignored, which would
+    # start a cluster with a different shape than the user asked for.
+    res = runner.invoke(
+        cli.app, ['start', 'c1', '--s3-scratch', 's3://bkt/tmp/', '--dry-run', '--core-instance-cout', '5']
+    )
+    assert res.exit_code != 0
+    assert emr_client_mock.run_job_flow.call_count == 0
+
+
 def test_start_invalid_json_overlay_errors(emr_client_mock):
     res = runner.invoke(
         cli.app,

--- a/hail/python/test/hailtop/hailctl/emr/test_emr.py
+++ b/hail/python/test/hailtop/hailctl/emr/test_emr.py
@@ -1,0 +1,43 @@
+from unittest.mock import patch
+
+from hailtop.hailctl.emr import emr
+
+
+def test_resolve_region_prefers_explicit(monkeypatch):
+    monkeypatch.setenv('AWS_DEFAULT_REGION', 'us-west-2')
+    with patch('hailtop.hailctl.emr.emr.configuration_of', return_value='eu-west-1'):
+        assert emr.resolve_region('us-east-1') == 'us-east-1'
+
+
+def test_resolve_region_falls_back_to_config(monkeypatch):
+    monkeypatch.delenv('AWS_DEFAULT_REGION', raising=False)
+    monkeypatch.delenv('AWS_REGION', raising=False)
+    with patch('hailtop.hailctl.emr.emr.configuration_of', return_value='eu-west-1'):
+        assert emr.resolve_region(None) == 'eu-west-1'
+
+
+def test_resolve_region_falls_back_to_env(monkeypatch):
+    monkeypatch.setenv('AWS_DEFAULT_REGION', 'us-west-2')
+    with patch('hailtop.hailctl.emr.emr.configuration_of', return_value=None):
+        assert emr.resolve_region(None) == 'us-west-2'
+
+
+def test_resolve_region_none_when_unset(monkeypatch):
+    monkeypatch.delenv('AWS_DEFAULT_REGION', raising=False)
+    monkeypatch.delenv('AWS_REGION', raising=False)
+    with patch('hailtop.hailctl.emr.emr.configuration_of', return_value=None):
+        assert emr.resolve_region(None) is None
+
+
+def test_upload_to_s3_writes_through_router_fs():
+    from unittest.mock import AsyncMock, MagicMock
+
+    fake_fs = MagicMock()
+    fake_fs.write = AsyncMock()
+    # RouterAsyncFS() is used as an async context manager: `async with RouterAsyncFS() as fs`.
+    fake_ctx = MagicMock()
+    fake_ctx.__aenter__ = AsyncMock(return_value=fake_fs)
+    fake_ctx.__aexit__ = AsyncMock(return_value=False)
+    with patch('hailtop.hailctl.emr.emr.RouterAsyncFS', return_value=fake_ctx):
+        emr.upload_to_s3('s3://bkt/key.sh', b'hello')
+    fake_fs.write.assert_awaited_once_with('s3://bkt/key.sh', b'hello')

--- a/hail/python/test/hailtop/hailctl/emr/test_emr.py
+++ b/hail/python/test/hailtop/hailctl/emr/test_emr.py
@@ -29,6 +29,52 @@ def test_resolve_region_none_when_unset(monkeypatch):
         assert emr.resolve_region(None) is None
 
 
+def _fake_iam(existing_roles):
+    from unittest.mock import MagicMock
+
+    from botocore.exceptions import ClientError
+
+    iam = MagicMock()
+
+    def get_role(RoleName):  # noqa: N803 (boto3 kwarg name)
+        if RoleName in existing_roles:
+            return {'Role': {'RoleName': RoleName, 'Arn': f'arn:aws:iam::123:role/{RoleName}'}}
+        raise ClientError({'Error': {'Code': 'NoSuchEntity', 'Message': 'not found'}}, 'GetRole')
+
+    iam.get_role.side_effect = get_role
+    return iam
+
+
+def test_check_default_roles_present_prints_message(capsys):
+    iam = _fake_iam({'EMR_DefaultRole', 'EMR_EC2_DefaultRole'})
+    emr.check_default_roles(iam)
+    out = capsys.readouterr().out
+    assert 'Using existing EMR default roles' in out
+    assert 'EMR_DefaultRole' in out and 'EMR_EC2_DefaultRole' in out
+
+
+def test_check_default_roles_missing_raises():
+    import pytest
+
+    iam = _fake_iam({'EMR_DefaultRole'})  # EMR_EC2_DefaultRole missing
+    with pytest.raises(ValueError, match='Missing EMR default IAM role.*EMR_EC2_DefaultRole'):
+        emr.check_default_roles(iam)
+
+
+def test_check_default_roles_propagates_unexpected_error():
+    import pytest
+    from botocore.exceptions import ClientError
+
+    from unittest.mock import MagicMock
+
+    iam = MagicMock()
+    iam.get_role.side_effect = ClientError(
+        {'Error': {'Code': 'AccessDenied', 'Message': 'nope'}}, 'GetRole'
+    )
+    with pytest.raises(ClientError):
+        emr.check_default_roles(iam)
+
+
 def test_upload_to_s3_writes_through_router_fs():
     from unittest.mock import AsyncMock, MagicMock
 

--- a/hail/python/test/hailtop/hailctl/emr/test_emr.py
+++ b/hail/python/test/hailtop/hailctl/emr/test_emr.py
@@ -29,7 +29,7 @@ def test_resolve_region_none_when_unset(monkeypatch):
         assert emr.resolve_region(None) is None
 
 
-def _fake_iam(existing_roles):
+def _fake_iam(existing_roles, existing_instance_profiles):
     from unittest.mock import MagicMock
 
     from botocore.exceptions import ClientError
@@ -41,23 +41,70 @@ def _fake_iam(existing_roles):
             return {'Role': {'RoleName': RoleName, 'Arn': f'arn:aws:iam::123:role/{RoleName}'}}
         raise ClientError({'Error': {'Code': 'NoSuchEntity', 'Message': 'not found'}}, 'GetRole')
 
+    def get_instance_profile(InstanceProfileName):
+        if InstanceProfileName in existing_instance_profiles:
+            return {
+                'InstanceProfile': {
+                    'InstanceProfileName': InstanceProfileName,
+                    'Roles': [{'RoleName': InstanceProfileName}],
+                }
+            }
+        raise ClientError({'Error': {'Code': 'NoSuchEntity', 'Message': 'not found'}}, 'GetInstanceProfile')
+
     iam.get_role.side_effect = get_role
+    iam.get_instance_profile.side_effect = get_instance_profile
     return iam
 
 
 def test_check_default_roles_present_prints_message(capsys):
-    iam = _fake_iam({'EMR_DefaultRole', 'EMR_EC2_DefaultRole'})
+    iam = _fake_iam({'EMR_DefaultRole', 'EMR_EC2_DefaultRole'}, {'EMR_EC2_DefaultRole'})
     emr.check_default_roles(iam)
     out = capsys.readouterr().out
-    assert 'Using existing EMR default roles' in out
+    assert 'Using existing EMR defaults' in out
     assert 'EMR_DefaultRole' in out and 'EMR_EC2_DefaultRole' in out
 
 
-def test_check_default_roles_missing_raises():
+def test_check_default_roles_can_check_only_service_role(capsys):
+    iam = _fake_iam({'EMR_DefaultRole'}, set())
+    emr.check_default_roles(iam, check_service_role=True, check_job_flow_role=False)
+    assert iam.get_instance_profile.call_count == 0
+    assert 'EMR_DefaultRole' in capsys.readouterr().out
+
+
+def test_check_default_roles_can_check_only_job_flow_role(capsys):
+    iam = _fake_iam({'EMR_EC2_DefaultRole'}, {'EMR_EC2_DefaultRole'})
+    emr.check_default_roles(iam, check_service_role=False, check_job_flow_role=True)
+    assert iam.get_role.call_count == 1
+    assert 'EMR_EC2_DefaultRole' in capsys.readouterr().out
+
+
+def test_check_default_roles_missing_role_raises():
     import pytest
 
-    iam = _fake_iam({'EMR_DefaultRole'})  # EMR_EC2_DefaultRole missing
-    with pytest.raises(ValueError, match='Missing EMR default IAM role.*EMR_EC2_DefaultRole'):
+    iam = _fake_iam({'EMR_DefaultRole'}, {'EMR_EC2_DefaultRole'})
+    with pytest.raises(ValueError, match=r'Missing EMR default IAM resource.*role.*EMR_EC2_DefaultRole'):
+        emr.check_default_roles(iam)
+
+
+def test_check_default_roles_missing_instance_profile_raises():
+    import pytest
+
+    iam = _fake_iam({'EMR_DefaultRole', 'EMR_EC2_DefaultRole'}, set())
+    with pytest.raises(ValueError, match=r'Missing EMR default IAM resource.*instance profile.*EMR_EC2_DefaultRole'):
+        emr.check_default_roles(iam)
+
+
+def test_check_default_roles_rejects_profile_without_expected_role():
+    from unittest.mock import MagicMock
+
+    import pytest
+
+    iam = MagicMock()
+    iam.get_role.return_value = {'Role': {'RoleName': 'present'}}
+    iam.get_instance_profile.return_value = {
+        'InstanceProfile': {'InstanceProfileName': 'EMR_EC2_DefaultRole', 'Roles': []}
+    }
+    with pytest.raises(ValueError, match=r'instance profile.*containing role EMR_EC2_DefaultRole'):
         emr.check_default_roles(iam)
 
 
@@ -69,6 +116,21 @@ def test_check_default_roles_propagates_unexpected_error():
 
     iam = MagicMock()
     iam.get_role.side_effect = ClientError({'Error': {'Code': 'AccessDenied', 'Message': 'nope'}}, 'GetRole')
+    with pytest.raises(ClientError):
+        emr.check_default_roles(iam)
+
+
+def test_check_default_roles_propagates_unexpected_instance_profile_error():
+    from unittest.mock import MagicMock
+
+    import pytest
+    from botocore.exceptions import ClientError
+
+    iam = MagicMock()
+    iam.get_role.return_value = {'Role': {'RoleName': 'present'}}
+    iam.get_instance_profile.side_effect = ClientError(
+        {'Error': {'Code': 'AccessDenied', 'Message': 'nope'}}, 'GetInstanceProfile'
+    )
     with pytest.raises(ClientError):
         emr.check_default_roles(iam)
 

--- a/hail/python/test/hailtop/hailctl/emr/test_emr.py
+++ b/hail/python/test/hailtop/hailctl/emr/test_emr.py
@@ -36,7 +36,7 @@ def _fake_iam(existing_roles):
 
     iam = MagicMock()
 
-    def get_role(RoleName):  # noqa: N803 (boto3 kwarg name)
+    def get_role(RoleName):
         if RoleName in existing_roles:
             return {'Role': {'RoleName': RoleName, 'Arn': f'arn:aws:iam::123:role/{RoleName}'}}
         raise ClientError({'Error': {'Code': 'NoSuchEntity', 'Message': 'not found'}}, 'GetRole')
@@ -62,15 +62,13 @@ def test_check_default_roles_missing_raises():
 
 
 def test_check_default_roles_propagates_unexpected_error():
+    from unittest.mock import MagicMock
+
     import pytest
     from botocore.exceptions import ClientError
 
-    from unittest.mock import MagicMock
-
     iam = MagicMock()
-    iam.get_role.side_effect = ClientError(
-        {'Error': {'Code': 'AccessDenied', 'Message': 'nope'}}, 'GetRole'
-    )
+    iam.get_role.side_effect = ClientError({'Error': {'Code': 'AccessDenied', 'Message': 'nope'}}, 'GetRole')
     with pytest.raises(ClientError):
         emr.check_default_roles(iam)
 

--- a/hail/python/test/hailtop/hailctl/emr/test_registration.py
+++ b/hail/python/test/hailtop/hailctl/emr/test_registration.py
@@ -1,0 +1,11 @@
+from typer.testing import CliRunner
+
+from hailtop.hailctl.__main__ import app
+
+runner = CliRunner()
+
+
+def test_emr_is_registered():
+    res = runner.invoke(app, ['emr', '--help'])
+    assert res.exit_code == 0
+    assert 'Amazon EMR' in res.stdout

--- a/hail/python/test/hailtop/hailctl/emr/test_start_builder.py
+++ b/hail/python/test/hailtop/hailctl/emr/test_start_builder.py
@@ -1,0 +1,82 @@
+import pytest
+
+from hailtop.hailctl.emr import start
+
+
+def test_default_release_is_known_and_matches_hail_spark():
+    assert start.DEFAULT_EMR_RELEASE in start.EMR_RELEASE_SPARK_VERSION
+    spark = start.EMR_RELEASE_SPARK_VERSION[start.DEFAULT_EMR_RELEASE]
+    assert spark.rsplit('.', 1)[0] == start.HAIL_REQUIRED_SPARK_MINOR
+
+
+def test_check_release_unknown_warns(capsys):
+    start.check_release_spark_compatibility('emr-9.9.9')
+    assert 'unknown' in capsys.readouterr().err.lower()
+
+
+def test_check_release_mismatch_raises():
+    with pytest.raises(ValueError, match='Spark'):
+        start.check_release_spark_compatibility('emr-6.15.0')
+
+
+def test_check_release_match_ok():
+    start.check_release_spark_compatibility(start.DEFAULT_EMR_RELEASE)  # no raise
+
+
+def test_hail_configurations_sets_hail_cloud_and_jar():
+    confs = start.hail_configurations(off_heap_memory_per_core_mb=None)
+    spark_defaults = next(c for c in confs if c['Classification'] == 'spark-defaults')
+    props = spark_defaults['Properties']
+    assert props['spark.jars'] == f'local://{start.HAIL_JAR_PATH}'
+    assert props['spark.executorEnv.HAIL_CLOUD'] == 'aws'
+    assert props['spark.yarn.appMasterEnv.HAIL_CLOUD'] == 'aws'
+    assert props['spark.executorEnv.PYTHONHASHSEED'] == '0'
+    spark = next(c for c in confs if c['Classification'] == 'spark')
+    assert spark['Properties']['maximizeResourceAllocation'] == 'true'
+
+
+def test_hail_configurations_off_heap_overlay():
+    confs = start.hail_configurations(off_heap_memory_per_core_mb=1024)
+    spark_defaults = next(c for c in confs if c['Classification'] == 'spark-defaults')
+    props = spark_defaults['Properties']
+    assert props['spark.executorEnv.HAIL_WORKER_OFF_HEAP_MEMORY_PER_CORE_MB'] == '1024'
+
+
+def test_deep_merge_overlay_wins_and_recurses():
+    base = {'Instances': {'KeepJobFlowAliveWhenNoSteps': True}, 'Name': 'a'}
+    overlay = {'Instances': {'Ec2SubnetId': 'subnet-1'}, 'Name': 'b'}
+    merged = start.deep_merge(base, overlay)
+    assert merged['Name'] == 'b'
+    assert merged['Instances']['KeepJobFlowAliveWhenNoSteps'] is True
+    assert merged['Instances']['Ec2SubnetId'] == 'subnet-1'
+
+
+def test_build_run_job_flow_kwargs_shape():
+    kwargs = start.build_run_job_flow_kwargs(
+        cluster_name='c1',
+        release_label='emr-7.3.0',
+        master_instance_type='m5.xlarge',
+        core_instance_type='m5.xlarge',
+        core_instance_count=2,
+        ec2_key_name=None,
+        subnet_id=None,
+        log_uri='s3://bkt/logs/',
+        bootstrap_s3_uri='s3://bkt/bootstrap/install-hail-emr.sh',
+        pip_version='0.2.140',
+        off_heap_memory_per_core_mb=None,
+        use_default_roles=True,
+        service_role=None,
+        instance_profile=None,
+    )
+    assert kwargs['Name'] == 'c1'
+    assert kwargs['ReleaseLabel'] == 'emr-7.3.0'
+    assert kwargs['Applications'] == [{'Name': 'Spark'}]
+    assert kwargs['LogUri'] == 's3://bkt/logs/'
+    assert kwargs['ServiceRole'] == 'EMR_DefaultRole'
+    assert kwargs['JobFlowRole'] == 'EMR_EC2_DefaultRole'
+    ba = kwargs['BootstrapActions'][0]
+    assert ba['ScriptBootstrapAction']['Path'] == 's3://bkt/bootstrap/install-hail-emr.sh'
+    assert ba['ScriptBootstrapAction']['Args'] == ['0.2.140']
+    igs = {g['InstanceRole']: g for g in kwargs['Instances']['InstanceGroups']}
+    assert igs['MASTER']['InstanceType'] == 'm5.xlarge'
+    assert igs['CORE']['InstanceCount'] == 2

--- a/hail/python/test/hailtop/hailctl/emr/test_start_builder.py
+++ b/hail/python/test/hailtop/hailctl/emr/test_start_builder.py
@@ -31,11 +31,13 @@ def test_hail_configurations_sets_hail_cloud_and_jar():
     assert props['spark.executorEnv.HAIL_CLOUD'] == 'aws'
     assert props['spark.yarn.appMasterEnv.HAIL_CLOUD'] == 'aws'
     assert props['spark.executorEnv.PYTHONHASHSEED'] == '0'
+    assert props['spark.pyspark.python'] == start.EMR_PYSPARK_PYTHON
     spark = next(c for c in confs if c['Classification'] == 'spark')
     assert spark['Properties']['maximizeResourceAllocation'] == 'true'
     spark_env = next(c for c in confs if c['Classification'] == 'spark-env')
     export = next(c for c in spark_env['Configurations'] if c['Classification'] == 'export')
     assert export['Properties']['HAIL_CLOUD'] == 'aws'
+    assert export['Properties']['PYSPARK_PYTHON'] == start.EMR_PYSPARK_PYTHON
 
 
 def test_hail_configurations_off_heap_overlay():

--- a/hail/python/test/hailtop/hailctl/emr/test_start_builder.py
+++ b/hail/python/test/hailtop/hailctl/emr/test_start_builder.py
@@ -33,6 +33,9 @@ def test_hail_configurations_sets_hail_cloud_and_jar():
     assert props['spark.executorEnv.PYTHONHASHSEED'] == '0'
     spark = next(c for c in confs if c['Classification'] == 'spark')
     assert spark['Properties']['maximizeResourceAllocation'] == 'true'
+    spark_env = next(c for c in confs if c['Classification'] == 'spark-env')
+    export = next(c for c in spark_env['Configurations'] if c['Classification'] == 'export')
+    assert export['Properties']['HAIL_CLOUD'] == 'aws'
 
 
 def test_hail_configurations_off_heap_overlay():

--- a/hail/python/test/hailtop/hailctl/emr/test_start_builder.py
+++ b/hail/python/test/hailtop/hailctl/emr/test_start_builder.py
@@ -6,7 +6,8 @@ from hailtop.hailctl.emr import start
 def test_default_release_is_known_and_matches_hail_spark():
     assert start.DEFAULT_EMR_RELEASE in start.EMR_RELEASE_SPARK_VERSION
     spark = start.EMR_RELEASE_SPARK_VERSION[start.DEFAULT_EMR_RELEASE]
-    assert spark.rsplit('.', 1)[0] == start.HAIL_REQUIRED_SPARK_MINOR
+    assert '.'.join(spark.split('.')[:2]) == start.HAIL_REQUIRED_SPARK_MINOR
+    assert spark == '3.5.1-amzn-1'
 
 
 def test_check_release_unknown_warns(capsys):
@@ -28,6 +29,8 @@ def test_hail_configurations_sets_hail_cloud_and_jar():
     spark_defaults = next(c for c in confs if c['Classification'] == 'spark-defaults')
     props = spark_defaults['Properties']
     assert props['spark.jars'] == f'local://{start.HAIL_JAR_PATH}'
+    assert props['spark.serializer'] == 'org.apache.spark.serializer.KryoSerializer'
+    assert props['spark.kryo.registrator'] == 'is.hail.kryo.HailKryoRegistrator'
     assert props['spark.executorEnv.HAIL_CLOUD'] == 'aws'
     assert props['spark.yarn.appMasterEnv.HAIL_CLOUD'] == 'aws'
     assert props['spark.executorEnv.PYTHONHASHSEED'] == '0'
@@ -54,6 +57,15 @@ def test_deep_merge_overlay_wins_and_recurses():
     assert merged['Name'] == 'b'
     assert merged['Instances']['KeepJobFlowAliveWhenNoSteps'] is True
     assert merged['Instances']['Ec2SubnetId'] == 'subnet-1'
+
+
+def test_merge_run_job_flow_overlay_switches_to_instance_fleets():
+    base = {'Instances': {'InstanceGroups': [{'Name': 'Core'}], 'KeepJobFlowAliveWhenNoSteps': True}}
+    overlay = {'Instances': {'InstanceFleets': [{'Name': 'Core fleet'}]}}
+    merged = start.merge_run_job_flow_overlay(base, overlay)
+    assert 'InstanceGroups' not in merged['Instances']
+    assert merged['Instances']['InstanceFleets'] == [{'Name': 'Core fleet'}]
+    assert merged['Instances']['KeepJobFlowAliveWhenNoSteps'] is True
 
 
 def test_build_run_job_flow_kwargs_shape():

--- a/hail/python/test/hailtop/hailctl/emr/test_submit.py
+++ b/hail/python/test/hailtop/hailctl/emr/test_submit.py
@@ -1,4 +1,28 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
 from hailtop.hailctl.emr import submit
+
+
+def test_step_waiter_failure_raises_system_exit_even_when_describe_also_fails(tmp_path, monkeypatch):
+    """describe_step failure must not mask the SystemExit(1) from the waiter failure."""
+    script = tmp_path / 'job.py'
+    script.write_text('print("hello")')
+
+    mock_client = Mock()
+    mock_waiter = Mock()
+    mock_waiter.wait.side_effect = RuntimeError('waiter timed out')
+    mock_client.get_waiter.return_value = mock_waiter
+    mock_client.add_job_flow_steps.return_value = {'StepIds': ['s-FAKE']}
+    mock_client.describe_step.side_effect = RuntimeError('network error')
+
+    monkeypatch.setattr('hailtop.hailctl.emr.emr.resolve_region', lambda region: 'us-east-1')
+    monkeypatch.setattr('hailtop.hailctl.emr.emr.emr_client', lambda region: mock_client)
+    monkeypatch.setattr('hailtop.hailctl.emr.emr.upload_to_s3', Mock())
+
+    with pytest.raises(SystemExit):
+        submit.submit('j-FAKE', str(script), 's3://bkt/tmp/', None, [], wait=True)
 
 
 def test_spark_submit_step_args():

--- a/hail/python/test/hailtop/hailctl/emr/test_submit.py
+++ b/hail/python/test/hailtop/hailctl/emr/test_submit.py
@@ -1,0 +1,12 @@
+from hailtop.hailctl.emr import submit
+
+
+def test_spark_submit_step_args():
+    args = submit.spark_submit_step_args('s3://bkt/scripts/x.py', ['--foo', 'bar'])
+    assert args[0] == 'spark-submit'
+    assert args[-3:] == ['s3://bkt/scripts/x.py', '--foo', 'bar']
+
+
+def test_spark_submit_step_args_no_passthrough():
+    args = submit.spark_submit_step_args('s3://bkt/scripts/x.py', [])
+    assert args == ['spark-submit', '--deploy-mode', 'client', 's3://bkt/scripts/x.py']

--- a/hail/python/test/hailtop/hailctl/emr/test_submit.py
+++ b/hail/python/test/hailtop/hailctl/emr/test_submit.py
@@ -45,6 +45,37 @@ def test_step_waiter_allows_jobs_longer_than_the_botocore_default(tmp_path, monk
     assert waiter_config['Delay'] * waiter_config['MaxAttempts'] >= 24 * 60 * 60
 
 
+def _mock_submit_client(monkeypatch):
+    mock_client = Mock()
+    mock_client.add_job_flow_steps.return_value = {'StepIds': ['s-FAKE']}
+    monkeypatch.setattr('hailtop.hailctl.emr.emr.resolve_region', lambda region: 'us-east-1')
+    monkeypatch.setattr('hailtop.hailctl.emr.emr.emr_client', lambda region: mock_client)
+    monkeypatch.setattr('hailtop.hailctl.emr.emr.upload_to_s3', Mock())
+    return mock_client
+
+
+def test_submit_waits_and_returns_step_id(tmp_path, monkeypatch):
+    script = tmp_path / 'job.py'
+    script.write_text('print("hello")')
+    mock_client = _mock_submit_client(monkeypatch)
+
+    step_id = submit.submit('j-FAKE', str(script), 's3://bkt/tmp/', None, [], wait=True)
+
+    assert step_id == 's-FAKE'
+    mock_client.get_waiter.return_value.wait.assert_called_once()
+
+
+def test_submit_no_wait_skips_the_waiter(tmp_path, monkeypatch):
+    script = tmp_path / 'job.py'
+    script.write_text('print("hello")')
+    mock_client = _mock_submit_client(monkeypatch)
+
+    step_id = submit.submit('j-FAKE', str(script), 's3://bkt/tmp/', None, [], wait=False)
+
+    assert step_id == 's-FAKE'
+    assert mock_client.get_waiter.call_count == 0
+
+
 def test_spark_submit_step_args():
     args = submit.spark_submit_step_args('s3://bkt/scripts/x.py', ['--foo', 'bar'])
     assert args[0] == 'spark-submit'

--- a/hail/python/test/hailtop/hailctl/emr/test_submit.py
+++ b/hail/python/test/hailtop/hailctl/emr/test_submit.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 
@@ -23,6 +23,26 @@ def test_step_waiter_failure_raises_system_exit_even_when_describe_also_fails(tm
 
     with pytest.raises(SystemExit):
         submit.submit('j-FAKE', str(script), 's3://bkt/tmp/', None, [], wait=True)
+
+
+def test_step_waiter_allows_jobs_longer_than_the_botocore_default(tmp_path, monkeypatch):
+    """botocore's step_complete default gives up after 30 minutes; Hail jobs run far longer."""
+    script = tmp_path / 'job.py'
+    script.write_text('print("hello")')
+
+    mock_client = Mock()
+    mock_waiter = Mock()
+    mock_client.get_waiter.return_value = mock_waiter
+    mock_client.add_job_flow_steps.return_value = {'StepIds': ['s-FAKE']}
+
+    monkeypatch.setattr('hailtop.hailctl.emr.emr.resolve_region', lambda region: 'us-east-1')
+    monkeypatch.setattr('hailtop.hailctl.emr.emr.emr_client', lambda region: mock_client)
+    monkeypatch.setattr('hailtop.hailctl.emr.emr.upload_to_s3', Mock())
+
+    submit.submit('j-FAKE', str(script), 's3://bkt/tmp/', None, [], wait=True)
+
+    waiter_config = mock_waiter.wait.call_args.kwargs['WaiterConfig']
+    assert waiter_config['Delay'] * waiter_config['MaxAttempts'] >= 24 * 60 * 60
 
 
 def test_spark_submit_step_args():

--- a/hail/scripts/test-emr.sh
+++ b/hail/scripts/test-emr.sh
@@ -21,6 +21,8 @@ cluster_id=$(hailctl emr list | awk -v n="$cluster_name" '$3 == n {print $1}' | 
 aws emr wait cluster-running --cluster-id "$cluster_id"
 
 cat > /tmp/hail-emr-smoke.py <<'PY'
+import os
+assert os.environ.get('HAIL_CLOUD') == 'aws', f"HAIL_CLOUD={os.environ.get('HAIL_CLOUD')!r}, expected 'aws'"
 import hail as hl
 mt = hl.balding_nichols_model(3, 100, 100)
 mt.rows().write('SCRATCH/out.ht', overwrite=True)

--- a/hail/scripts/test-emr.sh
+++ b/hail/scripts/test-emr.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Manual EMR smoke test. Requires AWS credentials, an S3 bucket you can write to,
+# and permission to create EMR clusters with the default roles.
+#
+# Usage: S3_SCRATCH=s3://my-bucket/hail-emr-test/ bash hail/scripts/test-emr.sh
+
+set -ex
+
+: "${S3_SCRATCH:?set S3_SCRATCH to an s3:// URI you can write to}"
+
+cluster_name="hail-emr-smoke-$(date +%s)"
+
+hailctl emr start "$cluster_name" \
+    --s3-scratch "$S3_SCRATCH" \
+    --core-instance-count 1 \
+    --run-job-flow-json '{"Instances": {"KeepJobFlowAliveWhenNoSteps": true}}'
+
+# start prints "Started cluster j-XXXX." — capture the id by listing.
+cluster_id=$(hailctl emr list | awk -v n="$cluster_name" '$3 == n {print $1}' | head -n1)
+
+aws emr wait cluster-running --cluster-id "$cluster_id"
+
+cat > /tmp/hail-emr-smoke.py <<'PY'
+import hail as hl
+mt = hl.balding_nichols_model(3, 100, 100)
+mt.rows().write('SCRATCH/out.ht', overwrite=True)
+print('OK')
+PY
+sed -i "s#SCRATCH#${S3_SCRATCH%/}#" /tmp/hail-emr-smoke.py
+
+hailctl emr submit "$cluster_id" /tmp/hail-emr-smoke.py --s3-scratch "$S3_SCRATCH"
+
+hailctl emr stop "$cluster_id"
+echo "SMOKE TEST PASSED"

--- a/hail/scripts/test-emr.sh
+++ b/hail/scripts/test-emr.sh
@@ -9,14 +9,36 @@ set -ex
 : "${S3_SCRATCH:?set S3_SCRATCH to an s3:// URI you can write to}"
 
 cluster_name="hail-emr-smoke-$(date +%s)"
+cluster_id=
 
-hailctl emr start "$cluster_name" \
+cleanup() {
+    exit_code=$?
+    trap - EXIT
+    set +e
+    if [[ -z "$cluster_id" ]]; then
+        for _ in {1..5}; do
+            cluster_id=$(hailctl emr list | awk -F '\t' -v n="$cluster_name" '$3 == n {print $1; exit}')
+            [[ -n "$cluster_id" ]] && break
+            sleep 2
+        done
+    fi
+    if [[ -n "$cluster_id" ]]; then
+        hailctl emr stop "$cluster_id" || true
+    fi
+    exit "$exit_code"
+}
+trap cleanup EXIT
+
+start_output=$(hailctl emr start "$cluster_name" \
     --s3-scratch "$S3_SCRATCH" \
     --core-instance-count 1 \
-    --run-job-flow-json '{"Instances": {"KeepJobFlowAliveWhenNoSteps": true}}'
-
-# start prints "Started cluster j-XXXX." — capture the id by listing.
-cluster_id=$(hailctl emr list | awk -v n="$cluster_name" '$3 == n {print $1}' | head -n1)
+    --run-job-flow-json '{"Instances": {"KeepJobFlowAliveWhenNoSteps": true}}')
+echo "$start_output"
+cluster_id=$(sed -n 's/^Started cluster \(j-[A-Z0-9]*\)\.$/\1/p' <<<"$start_output")
+if [[ -z "$cluster_id" ]]; then
+    echo "could not determine the EMR cluster id" >&2
+    exit 1
+fi
 
 aws emr wait cluster-running --cluster-id "$cluster_id"
 
@@ -33,4 +55,6 @@ sed -i "s#SCRATCH#${S3_SCRATCH%/}#" /tmp/hail-emr-smoke.py
 hailctl emr submit "$cluster_id" /tmp/hail-emr-smoke.py --s3-scratch "$S3_SCRATCH"
 
 hailctl emr stop "$cluster_id"
+cluster_id=
+trap - EXIT
 echo "SMOKE TEST PASSED"


### PR DESCRIPTION
## Change Description

Adds `hailctl emr`, a command group (`start` / `stop` / `list` / `submit`) for provisioning and running Hail on Amazon EMR, bringing AWS toward parity with `hailctl dataproc` and `hailctl hdinsight`.

Design was discussed with the Hail team on the forum first: https://hail.zulipchat.com/#narrow/channel/127634-Feature-Requests/topic/Contributing.20.60hailctl.20emr.60.20.28AWS.20EMR.20support.29/near/612285285

CHANGELOG: Add `hailctl emr`, a command group (`start`/`stop`/`list`/`submit`) for provisioning and running Hail on Amazon EMR, along with the `emr/region` and `emr/remote_tmpdir` config variables.

**What it does**
- Pure-Python Typer module (`hailtop/hailctl/emr/`) that drives EMR through the **boto3** control plane (native `Configurations`/`BootstrapActions`, `StepComplete` waiter — no `aws` CLI shell-out). All `s3://` file I/O routes through `RouterAsyncFS`; boto3 is used for the EMR control plane only.
- One-line change in `RouterFS.scala`: `HAIL_CLOUD=aws` returns an all-`None` `CloudStorageConfig`, so the router falls back to `HadoopFS` and EMRFS/hadoop-aws resolve `s3://`/`s3a://`. (Per the forum discussion, a native `S3StorageFS` is intentionally left for the Batch backend and is out of scope here.)
- Bootstrap script shipped in the wheel via `package_data`, uploaded to the user's S3 scratch bucket at `start` time; installs Hail from PyPI (pyspark excluded, since EMR provides it).
- EMR-release → Spark compatibility table (patch differences within 3.5.x allowed, minor mismatch is a hard error, unknown label warns). Default release `emr-7.3.0` (Spark 3.5.3).
- Installs Hail into Python 3.12 and points `spark.pyspark.python` / `PYSPARK_PYTHON` there. EMR 7.x runs Amazon Linux 2023, whose system `python3` is 3.9 — too old for Hail, which requires >= 3.10 — and AL2023 packages python3.12 in its `dnf` repositories.
- Two config variables (`emr/region`, `emr/remote_tmpdir`), user docs, and a preflight check for the default EMR IAM roles.
- `list` filters to clusters that still exist and paginates (`--all` for the unfiltered view); `submit` overrides botocore's 30-minute waiter cap, which would otherwise report a false failure for any longer job.

**Testing**
- 36 unit tests covering the emr module (`unittest.mock`, no AWS calls), plus 4 accepted / 2 rejected `emr/*` cases added to the existing `hailctl config` validation tests. The suite passes with AWS credentials removed from the environment, so nothing reaches a live API. `ruff check hail` and `ruff format hail --diff` are clean; `pyright hail/python/hailtop` reports nothing in the new code.
- Validated on real AWS: the tutorial GWAS on the 1000 Genomes subset (matches the published tutorial, min p 3.5e-9 @ 8:19600329), a full-autosome GWAS (1000G phase 3, ~81M variants × 2,504 samples, through PCA-adjusted regression), and a gnomAD annotation + Parquet export.

**Open question for reviewers**
- Wheel distribution currently uses `pip install hail==$VERSION` from PyPI. If you would rather push a wheel to a known bucket (as with Dataproc), the bootstrap is a small change — happy to switch.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has no security impact

### Impact Description

New `hailctl` client-side command group for AWS EMR plus a one-line JVM FS routing arm for `HAIL_CLOUD=aws`. It adds no code paths to the Hail Batch service deployed in GCP; it only affects users who run `hailctl emr` against their own AWS accounts with their own credentials.
