### PR TITLE
[ui] bug fix for free text search box

### DIFF
--- a/batch/batch/front_end/templates/table_search.html
+++ b/batch/batch/front_end/templates/table_search.html
@@ -8,8 +8,11 @@
     <!-- Search criteria container (rows are stamped from the templates below by table_search.js) -->
     <div id='search-criteria-container' class='min-h-24 w-full p-4 bg-slate-200 rounded space-y-3'></div>
 
-    <!-- Textbox mode (hidden by default) -->
-    <div id='search-textbox-container' class='min-h-32 w-full p-4 bg-slate-200 rounded' style='display: none;'>
+    <!-- Textbox mode (hidden by default). Use Tailwind's `hidden` class rather than
+         an inline `style='display: none;'`; the batches page CSP omits `'unsafe-inline'`
+         from `style-src`, so an inline style attribute here is dropped by the browser
+         and the textbox container would render visible on first paint. -->
+    <div id='search-textbox-container' class='min-h-32 w-full p-4 bg-slate-200 rounded hidden'>
       <textarea id='search-input-box' class='h-32 w-full p-4 bg-white rounded resize whitespace-pre border'
         spellcheck="false" autocorrect="off" placeholder='Enter search query (e.g., "cost > 5.00")'>{% if q %}{{ q }}{% endif %}</textarea>
     </div>


### PR DESCRIPTION
## Change Description

Minor bugfix to search UI introduced in https://github.com/hail-is/hail/pull/15590. Free text search box will no longer render in dropdown mode upon page load

## Security Assessment
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP
  - The Impact Rating, Impact Description, and Appsec Review sections are required


### Impact Rating
- This change has a low security impact

### Impact Description
Minor ui bugfix

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
