### PR TITLE
[batch|ui] Improved inactivity error messages

### DIFF
--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -944,6 +944,34 @@ async def rest_logout(request: web.Request, _) -> web.Response:
     return web.Response(status=200)
 
 
+async def check_inactive_user_from_login_id_or_hail_identity_id(db: Database, login_id_or_hail_identity_uid: str) -> Optional[UserData]:
+    users = [x async for x in db.select_and_fetchall(
+        "SELECT * FROM users WHERE (login_id = %s OR hail_identity_uid = %s) AND state = 'inactive';",
+        (login_id_or_hail_identity_uid, login_id_or_hail_identity_uid),
+    )]
+    if len(users) != 1:
+        log.info('Unknown login id')
+        return None
+    return None
+
+
+async def check_inactive_user_from_hail_session_id(db: Database, session_id: str) -> Optional[UserData]:
+    users = [x async for x in db.select_and_fetchall(
+        """
+SELECT users.*
+FROM users
+INNER JOIN sessions ON users.id = sessions.user_id
+WHERE users.state = 'inactive' AND sessions.session_id = %s
+  AND (ISNULL(sessions.max_age_secs) OR (NOW() < TIMESTAMPADD(SECOND, sessions.max_age_secs, sessions.created)));
+""",
+        session_id,
+    )]
+    if len(users) != 1:
+        log.info('Unknown Hail session')
+        return None
+    return None
+
+
 async def get_userinfo(request: web.Request, auth_token: str) -> UserData:
     flow_client = request.app[AppKeys.FLOW_CLIENT]
     client_session = request.app[AppKeys.CLIENT_SESSION]
@@ -976,9 +1004,14 @@ WHERE id = %s;
 
 
 async def get_userinfo_from_login_id_or_hail_identity_id(
-    request: web.Request, login_id_or_hail_idenity_uid: str
+    request: web.Request, login_id_or_hail_identity_uid: str
 ) -> UserData:
     db = request.app[AppKeys.DB]
+
+    inactive_user = await check_inactive_user_from_login_id_or_hail_identity_id(db, login_id_or_hail_identity_uid)
+    if inactive_user:
+        log.info(f'Inactive user {inactive_user["username"]} found for login id or Hail identity id {login_id_or_hail_identity_uid}.')
+        raise web.HTTPUnauthorized(text='Your Hail account is inactive. Please contact a Hail administrator to reactivate.')
 
     users = [
         x
@@ -988,12 +1021,12 @@ SELECT users.*
 FROM users
 WHERE (users.login_id = %s OR users.hail_identity_uid = %s) AND users.state = 'active'
 """,
-            (login_id_or_hail_idenity_uid, login_id_or_hail_idenity_uid),
+            (login_id_or_hail_identity_uid, login_id_or_hail_identity_uid),
         )
     ]
 
     if len(users) != 1:
-        log.info('Unknown login id')
+        log.info('Unknown login id or hail identity')
         raise web.HTTPUnauthorized()
 
     user = users[0]
@@ -1027,6 +1060,11 @@ async def get_userinfo_from_hail_session_id(request: web.Request, session_id: st
         return None
 
     db = request.app[AppKeys.DB]
+    inactive_user = await check_inactive_user_from_hail_session_id(db, session_id)
+    if inactive_user:
+        log.info(f'Inactive user {inactive_user["username"]} found for Hail session.')
+        raise web.HTTPUnauthorized(text='Your Hail account is inactive. Please contact a Hail administrator to reactivate.')
+
     users = [
         x
         async for x in db.select_and_fetchall(

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -944,32 +944,42 @@ async def rest_logout(request: web.Request, _) -> web.Response:
     return web.Response(status=200)
 
 
-async def check_inactive_user_from_login_id_or_hail_identity_id(db: Database, login_id_or_hail_identity_uid: str) -> Optional[UserData]:
-    users = [x async for x in db.select_and_fetchall(
-        "SELECT * FROM users WHERE (login_id = %s OR hail_identity_uid = %s) AND state = 'inactive';",
-        (login_id_or_hail_identity_uid, login_id_or_hail_identity_uid),
-    )]
+async def check_inactive_user_from_login_id_or_hail_identity_id(
+    db: Database, login_id_or_hail_identity_uid: str
+) -> Optional[UserData]:
+    users = [
+        x
+        async for x in db.select_and_fetchall(
+            "SELECT * FROM users WHERE (login_id = %s OR hail_identity_uid = %s) AND state = 'inactive';",
+            (login_id_or_hail_identity_uid, login_id_or_hail_identity_uid),
+        )
+    ]
     if len(users) != 1:
-        log.info('Unknown login id')
         return None
-    return None
+    userdata = dict(users[0])
+    userdata['system_permissions'] = {}
+    return typing.cast(UserData, userdata)
 
 
 async def check_inactive_user_from_hail_session_id(db: Database, session_id: str) -> Optional[UserData]:
-    users = [x async for x in db.select_and_fetchall(
-        """
+    users = [
+        x
+        async for x in db.select_and_fetchall(
+            """
 SELECT users.*
 FROM users
 INNER JOIN sessions ON users.id = sessions.user_id
 WHERE users.state = 'inactive' AND sessions.session_id = %s
   AND (ISNULL(sessions.max_age_secs) OR (NOW() < TIMESTAMPADD(SECOND, sessions.max_age_secs, sessions.created)));
 """,
-        session_id,
-    )]
+            session_id,
+        )
+    ]
     if len(users) != 1:
-        log.info('Unknown Hail session')
         return None
-    return None
+    userdata = dict(users[0])
+    userdata['system_permissions'] = {}
+    return typing.cast(UserData, userdata)
 
 
 async def get_userinfo(request: web.Request, auth_token: str) -> UserData:
@@ -1009,9 +1019,13 @@ async def get_userinfo_from_login_id_or_hail_identity_id(
     db = request.app[AppKeys.DB]
 
     inactive_user = await check_inactive_user_from_login_id_or_hail_identity_id(db, login_id_or_hail_identity_uid)
-    if inactive_user:
-        log.info(f'Inactive user {inactive_user["username"]} found for login id or Hail identity id {login_id_or_hail_identity_uid}.')
-        raise web.HTTPUnauthorized(text='Your Hail account is inactive. Please contact a Hail administrator to reactivate.')
+    if inactive_user is not None:
+        log.info(
+            f'Inactive user {inactive_user["username"]} found for login id or Hail identity id {login_id_or_hail_identity_uid}.'
+        )
+        raise web.HTTPUnauthorized(
+            text='Your Hail account is inactive. Please contact a Hail administrator to reactivate.'
+        )
 
     users = [
         x
@@ -1061,9 +1075,11 @@ async def get_userinfo_from_hail_session_id(request: web.Request, session_id: st
 
     db = request.app[AppKeys.DB]
     inactive_user = await check_inactive_user_from_hail_session_id(db, session_id)
-    if inactive_user:
+    if inactive_user is not None:
         log.info(f'Inactive user {inactive_user["username"]} found for Hail session.')
-        raise web.HTTPUnauthorized(text='Your Hail account is inactive. Please contact a Hail administrator to reactivate.')
+        raise web.HTTPUnauthorized(
+            text='Your Hail account is inactive. Please contact a Hail administrator to reactivate.'
+        )
 
     users = [
         x

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -1027,7 +1027,8 @@ async def get_userinfo_from_login_id_or_hail_identity_id(
             f'Inactive user {inactive_user["username"]} found for login id or Hail identity id {login_id_or_hail_identity_uid}.'
         )
         raise web.HTTPForbidden(
-            text='Your Hail account is inactive. Please contact a Hail administrator to reactivate.'
+            text='Your Hail account is inactive. Please contact a Hail administrator to reactivate.',
+            headers={'X-Hail-Auth-Reason': 'inactive-account'},
         )
 
     users = [
@@ -1081,7 +1082,8 @@ async def get_userinfo_from_hail_session_id(request: web.Request, session_id: st
     if inactive_user is not None:
         log.info(f'Inactive user {inactive_user["username"]} found for Hail session.')
         raise web.HTTPForbidden(
-            text='Your Hail account is inactive. Please contact a Hail administrator to reactivate.'
+            text='Your Hail account is inactive. Please contact a Hail administrator to reactivate.',
+            headers={'X-Hail-Auth-Reason': 'inactive-account'},
         )
 
     users = [

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -480,8 +480,11 @@ async def callback(request) -> web.Response:
             'login_id': user['login_id'],
             'inactive_timeout_days': INACTIVE_USER_TIMEOUT_DAYS,
         }
+        userdata = dict(user)
+        userdata['system_permissions'] = {}
+        userdata = typing.cast(UserData, userdata)
         return await render_template(
-            'auth', request, user, 'account-error.html', page_context, status_code=web.HTTPUnauthorized.status_code
+            'auth', request, userdata, 'account-error.html', page_context, status_code=web.HTTPUnauthorized.status_code
         )
 
     if user['state'] == 'creating':

--- a/auth/auth/auth.py
+++ b/auth/auth/auth.py
@@ -1026,7 +1026,7 @@ async def get_userinfo_from_login_id_or_hail_identity_id(
         log.info(
             f'Inactive user {inactive_user["username"]} found for login id or Hail identity id {login_id_or_hail_identity_uid}.'
         )
-        raise web.HTTPUnauthorized(
+        raise web.HTTPForbidden(
             text='Your Hail account is inactive. Please contact a Hail administrator to reactivate.'
         )
 
@@ -1080,7 +1080,7 @@ async def get_userinfo_from_hail_session_id(request: web.Request, session_id: st
     inactive_user = await check_inactive_user_from_hail_session_id(db, session_id)
     if inactive_user is not None:
         log.info(f'Inactive user {inactive_user["username"]} found for Hail session.')
-        raise web.HTTPUnauthorized(
+        raise web.HTTPForbidden(
             text='Your Hail account is inactive. Please contact a Hail administrator to reactivate.'
         )
 

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -144,6 +144,8 @@ class AuthServiceAuthenticator(Authenticator):
             return await impersonate_user_and_get_info(session_id=session_id, client_session=client_session)
         except asyncio.CancelledError:
             raise
+        except web.HTTPException:
+            raise
         except aiohttp.ClientResponseError as e:
             log.exception('unknown exception getting userinfo')
             raise web.HTTPInternalServerError() from e

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -229,6 +229,9 @@ async def impersonate_user(session_id: str, client_session: httpx.ClientSession,
         return await retry_transient_errors(client_session.get_read_json, url, headers=headers)
     except aiohttp.ClientResponseError as err:
         if err.status == 401:
+            body = getattr(err, 'body', None)
+            if body:
+                raise web.HTTPUnauthorized(text=body)
             return None
         raise
 

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -231,6 +231,8 @@ async def impersonate_user(session_id: str, client_session: httpx.ClientSession,
         return await retry_transient_errors(client_session.get_read_json, url, headers=headers)
     except aiohttp.ClientResponseError as err:
         if err.status == 401:
+            return None
+        if err.status == 403:
             body = getattr(err, 'body', None)
             if body:
                 raise web.HTTPUnauthorized(text=body)

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -235,7 +235,7 @@ async def impersonate_user(session_id: str, client_session: httpx.ClientSession,
         if err.status == 403:
             body = getattr(err, 'body', None)
             if body:
-                raise web.HTTPUnauthorized(text=body)
+                raise web.HTTPForbidden(text=body)
             return None
         raise
 

--- a/gear/gear/auth.py
+++ b/gear/gear/auth.py
@@ -234,7 +234,7 @@ async def impersonate_user(session_id: str, client_session: httpx.ClientSession,
             return None
         if err.status == 403:
             body = getattr(err, 'body', None)
-            if body:
+            if body and (err.headers or {}).get('X-Hail-Auth-Reason') == 'inactive-account':
                 raise web.HTTPForbidden(text=body)
             return None
         raise


### PR DESCRIPTION
## Change Description

Users are meant to receive an informative error message if they attempt to use Hail while their account has been marked as inactive. Currently, the intended error message does not make its way to users for a variety of reasons (for example, users are attempting to use Hail in a session id-based setting like a Jupyter notebook, or the error message is swallowed by other auth checks we make along the way).

This PR adds explicit inactive user checks for i) login id and hail identity id and ii) session id, whereby we're now able to handle and raise appropriate errors if a user is inactive.

### Testing
Error message successfully propagated in the CLI after attempting to submit a job while inactive:
```bash
ClientResponseError: 403, message='Forbidden', url=URL('https://internal.hail.is/grohlice/auth/api/v1alpha/userinfo') body='Your Hail account is inactive. Please contact a Hail 
administrator to reactivate.'
```
Error message presented to inactive users attempting to log in via the web UI:
<img width="653" height="232" alt="image" src="https://github.com/user-attachments/assets/6e132b4b-90d4-495b-bae3-d96b423d1e7b" />


## Security Assessment
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating
- This change has a low security impact

### Impact Description
This PR adds new auth checks specific to inactive users. However, nothing has been removed from our already existing checks (relating to `get_userinfo()`), and users should still be subject to the same authentication scrutiny as before.

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
