### PR TITLE
[compiler] StreamAgg{Scan} drops opposite scan/agg env

### DIFF
--- a/hail/hail/src/is/hail/expr/ir/Binds.scala
+++ b/hail/hail/src/is/hail/expr/ir/Binds.scala
@@ -320,6 +320,7 @@ object Bindings {
         Bindings(
           FastSeq(name -> elementType(a.typ)),
           agg = AggEnv.Create(FastSeq(0)),
+          scan = AggEnv.Drop,
         )
       case StreamScan(a, zero, accumName, valueName, _) if i == 2 =>
         Bindings(FastSeq(accumName -> zero.typ, valueName -> elementType(a.typ)))
@@ -328,6 +329,7 @@ object Bindings {
         Bindings(
           FastSeq(name -> eltType),
           eval = FastSeq(0),
+          agg = AggEnv.Drop,
           scan = AggEnv.Create(FastSeq(0)),
         )
       case StreamJoinRightDistinct(ll, rr, _, _, l, r, _, _) if i == 2 =>

--- a/hail/hail/src/is/hail/expr/ir/Env.scala
+++ b/hail/hail/src/is/hail/expr/ir/Env.scala
@@ -71,9 +71,6 @@ case class BindingEnv[V](
     val Bindings(_, _, agg, scan, _, dropEval) = bindings
     var newEnv = this
     if (dropEval) newEnv = newEnv.noEval
-    if (agg.isInstanceOf[AggEnv.Create] || scan.isInstanceOf[AggEnv.Create])
-      newEnv =
-        newEnv.copy(agg = newEnv.agg.map(_ => Env.empty), scan = newEnv.scan.map(_ => Env.empty))
     agg match {
       case AggEnv.Drop => newEnv = newEnv.noAgg
       case AggEnv.Promote =>


### PR DESCRIPTION
StreamAgg{Scan} are the only two operations that don't define the
transition on the opposite env. BindingEnv accounted for this by
clearing the other environment when the other had an AggEnv.Create
transition. This feels somewhat ad-hoc and would be better if we
dropped the other environment entirely, given that Extract does 
not handle aggs inside scans.

This change does not affect the broad-managed batch service in gcp.