### PR TITLE
[batch] add DB test framework: real-migration db fixture and smoke test

### DIFF
--- a/batch/test/conftest.py
+++ b/batch/test/conftest.py
@@ -1,14 +1,61 @@
 import hashlib
 import logging
 import os
+import sys
 
+import aiomysql
 import pytest
+import pytest_asyncio
 
+from gear import Database
 from hailtop.batch_client import aioclient
 from hailtop.batch_client.client import BatchClient
 from hailtop.config import get_remote_tmpdir
 
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_TEST_DB_NAME = 'test_billing'
+
 log = logging.getLogger(__name__)
+
+
+@pytest_asyncio.fixture(scope='session')
+async def db():
+    """Spin up a real migrated batch DB and yield it; drop it on teardown."""
+    sys.path.insert(0, os.path.join(_REPO_ROOT, 'ci'))
+    import warnings as _warnings  # pylint: disable=import-outside-toplevel
+
+    from create_local_database import async_main  # pylint: disable=import-outside-toplevel
+
+    conn = await aiomysql.connect(host='localhost', port=3306, user='root', password='pw')
+    try:
+        async with conn.cursor() as cur:
+            with _warnings.catch_warnings():
+                _warnings.simplefilter('ignore')
+                await cur.execute(f'DROP DATABASE IF EXISTS `{_TEST_DB_NAME}`')
+            await cur.execute('SET GLOBAL log_bin_trust_function_creators = 1')
+        await conn.commit()
+    finally:
+        conn.close()
+
+    orig_dir = os.getcwd()
+    os.chdir(_REPO_ROOT)
+    os.environ.pop('HAIL_SQL_DATABASE', None)
+    try:
+        await async_main('batch', _TEST_DB_NAME)
+    finally:
+        os.chdir(orig_dir)
+    database = Database()
+    await database.async_init()
+    yield database
+    await database.async_exit_stack.aclose()
+
+    conn = await aiomysql.connect(host='localhost', port=3306, user='root', password='pw')
+    try:
+        async with conn.cursor() as cur:
+            await cur.execute(f'DROP DATABASE IF EXISTS `{_TEST_DB_NAME}`')
+        await conn.commit()
+    finally:
+        conn.close()
 
 
 @pytest.fixture(autouse=True)

--- a/batch/test/test_db_framework.py
+++ b/batch/test/test_db_framework.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_db_fixture_is_live(db):
+    """db fixture must yield a real migrated batch database."""
+    rows = await db.execute_and_fetchall('SHOW TABLES')
+    table_names = {next(iter(row.values())) for row in rows}
+    assert 'billing_projects' in table_names

--- a/build.yaml
+++ b/build.yaml
@@ -2911,6 +2911,44 @@ steps:
       - hail_ubuntu_image
       - gpu_image
   - kind: runImage
+    name: test_billing
+    numSplits: 1
+    image:
+      valueFrom: batch_image.image
+    script: |
+      set -ex
+
+      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
+      export HAIL_CLOUD="{{ global.cloud }}"
+
+      hail-pip-install -r /io/dev-requirements.txt
+
+      # Install and start MySQL ad-hoc — not baked into the batch image.
+      DEBIAN_FRONTEND=noninteractive apt-get install -y -qq mysql-server
+      mysqld --user=root --daemonize --log-error=/tmp/mysqld.log
+      until mysqladmin --user=root ping --silent 2>/dev/null; do sleep 1; done
+      mysql --user=root -e "ALTER USER 'root'@'localhost' IDENTIFIED BY 'pw'; FLUSH PRIVILEGES;"
+
+      python3 -m pytest \
+              --log-cli-level=INFO \
+              -s \
+              -r A \
+              -vv \
+              --instafail \
+              --durations=50 \
+              --timeout=120 \
+              /io/test/test_db_framework.py
+    inputs:
+      - from: /repo/batch/test
+        to: /io/test
+      - from: /repo/hail/python/dev/pinned-requirements.txt
+        to: /io/dev-requirements.txt
+    port: 5000
+    timeout: 300
+    dependsOn:
+      - merge_code
+      - batch_image
+  - kind: runImage
     name: test_batch_job_private_machines
     numSplits: 1
     image:


### PR DESCRIPTION
## Change Description

Adds a framework for modular testing of SQL access components. For now just a placeholder test, to be replaced later.

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

New test scenario and single test case

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>