### PR TITLE
[query] Add rudimentary arrow type conversions

### DIFF
--- a/hail/hail/src/is/hail/types/arrowextension/Call.scala
+++ b/hail/hail/src/is/hail/types/arrowextension/Call.scala
@@ -1,0 +1,30 @@
+package is.hail.types.arrowextension
+
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.vector.FieldVector
+import org.apache.arrow.vector.types.pojo.{ArrowType, ExtensionTypeRegistry, FieldType}
+
+object Call {
+  val INSTANCE = new Call()
+
+  ExtensionTypeRegistry.register(INSTANCE)
+}
+
+class Call private () extends ArrowType.ExtensionType {
+  override def extensionName(): String = "hail.call"
+
+  override def extensionEquals(other: ArrowType.ExtensionType): Boolean = other.isInstanceOf[Call]
+
+  override def storageType(): ArrowType = new ArrowType.Int(32, false)
+
+  override def serialize(): String = ""
+
+  override def deserialize(storageType: ArrowType, serializedData: String): ArrowType =
+    if (!storageType.equals(this.storageType()))
+      throw new UnsupportedOperationException("bad storage type: " + storageType)
+    else
+      Call.INSTANCE
+
+  override def getNewVector(name: String, fieldType: FieldType, allocator: BufferAllocator)
+    : FieldVector = ???
+}

--- a/hail/hail/src/is/hail/types/arrowextension/Interval.scala
+++ b/hail/hail/src/is/hail/types/arrowextension/Interval.scala
@@ -1,0 +1,31 @@
+package is.hail.types.arrowextension
+
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.vector.FieldVector
+import org.apache.arrow.vector.types.pojo.{ArrowType, ExtensionTypeRegistry, FieldType}
+
+object Interval {
+  val INSTANCE = new Interval()
+
+  ExtensionTypeRegistry.register(INSTANCE)
+}
+
+class Interval private () extends ArrowType.ExtensionType {
+  override def extensionName(): String = "hail.interval"
+
+  override def extensionEquals(other: ArrowType.ExtensionType): Boolean =
+    other.isInstanceOf[Interval]
+
+  override def storageType(): ArrowType = new ArrowType.Struct()
+
+  override def serialize(): String = ""
+
+  override def deserialize(storageType: ArrowType, serializedData: String): ArrowType =
+    if (!storageType.equals(this.storageType()))
+      throw new UnsupportedOperationException("bad storage type: " + storageType)
+    else
+      Interval.INSTANCE
+
+  override def getNewVector(name: String, fieldType: FieldType, allocator: BufferAllocator)
+    : FieldVector = ???
+}

--- a/hail/hail/src/is/hail/types/arrowextension/Locus.scala
+++ b/hail/hail/src/is/hail/types/arrowextension/Locus.scala
@@ -1,0 +1,30 @@
+package is.hail.types.arrowextension
+
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.vector.FieldVector
+import org.apache.arrow.vector.types.pojo.{ArrowType, ExtensionTypeRegistry, FieldType}
+
+object Locus {
+  val INSTANCE = new Locus()
+
+  ExtensionTypeRegistry.register(INSTANCE)
+}
+
+class Locus private () extends ArrowType.ExtensionType {
+  override def extensionName(): String = "hail.locus"
+
+  override def extensionEquals(other: ArrowType.ExtensionType): Boolean = other.isInstanceOf[Locus]
+
+  override def storageType(): ArrowType = new ArrowType.Struct()
+
+  override def serialize(): String = ""
+
+  override def deserialize(storageType: ArrowType, serializedData: String): ArrowType =
+    if (!storageType.equals(this.storageType()))
+      throw new UnsupportedOperationException("bad storage type: " + storageType)
+    else
+      Locus.INSTANCE
+
+  override def getNewVector(name: String, fieldType: FieldType, allocator: BufferAllocator)
+    : FieldVector = ???
+}

--- a/hail/hail/src/is/hail/types/arrowextension/NDArray.scala
+++ b/hail/hail/src/is/hail/types/arrowextension/NDArray.scala
@@ -1,0 +1,31 @@
+package is.hail.types.arrowextension
+
+import org.apache.arrow.memory.BufferAllocator
+import org.apache.arrow.vector.FieldVector
+import org.apache.arrow.vector.types.pojo.{ArrowType, ExtensionTypeRegistry, FieldType}
+
+object NDArray {
+  val INSTANCE = new NDArray()
+
+  ExtensionTypeRegistry.register(INSTANCE)
+}
+
+class NDArray private () extends ArrowType.ExtensionType {
+  override def extensionName(): String = "hail.ndarray"
+
+  override def extensionEquals(other: ArrowType.ExtensionType): Boolean =
+    other.isInstanceOf[NDArray]
+
+  override def storageType(): ArrowType = new ArrowType.Struct()
+
+  override def serialize(): String = ""
+
+  override def deserialize(storageType: ArrowType, serializedData: String): ArrowType =
+    if (!storageType.equals(this.storageType()))
+      throw new UnsupportedOperationException("bad storage type: " + storageType)
+    else
+      NDArray.INSTANCE
+
+  override def getNewVector(name: String, fieldType: FieldType, allocator: BufferAllocator)
+    : FieldVector = ???
+}

--- a/hail/hail/src/is/hail/types/physical/PBaseStruct.scala
+++ b/hail/hail/src/is/hail/types/physical/PBaseStruct.scala
@@ -7,6 +7,8 @@ import is.hail.collection.implicits.toRichIterable
 import is.hail.expr.ir.EmitCodeBuilder
 import is.hail.types.physical.stypes.interfaces.SBaseStructValue
 
+import org.apache.arrow.vector.types.pojo.{Field => ArrowField, Schema => ArrowSchema}
+
 object PBaseStruct {
   def alignment(types: IndexedSeq[PType]): Long =
     if (types.isEmpty)
@@ -60,6 +62,22 @@ abstract class PBaseStruct extends PType {
     types.foreachBetween(ty => sb ++= ty.asIdent)(sb ++= "AND")
     sb ++= "END"
     sb.result()
+  }
+
+  private def arrowFields(): IndexedSeq[ArrowField] = fields.map { case PField(name, typ, _) =>
+    import scala.jdk.CollectionConverters._
+    val children: java.util.List[ArrowField] = typ match {
+      case ps: PBaseStruct => ps.arrowFields().asJava
+      case _ => null
+    }
+
+    new ArrowField(name, typ.arrowFieldType, children)
+  }
+
+  def asArrowSchema(): ArrowSchema = {
+    import scala.jdk.CollectionConverters._
+    val fields: Iterable[ArrowField] = arrowFields()
+    new ArrowSchema(fields.asJava)
   }
 
   def isPrefixOf(other: PBaseStruct): Boolean =

--- a/hail/hail/src/is/hail/types/physical/PType.scala
+++ b/hail/hail/src/is/hail/types/physical/PType.scala
@@ -11,6 +11,7 @@ import is.hail.types.physical.stypes.concrete.SRNGState
 import is.hail.types.virtual._
 import is.hail.utils._
 
+import org.apache.arrow.vector.types.pojo.{FieldType => ArrowFieldType}
 import org.apache.spark.sql.Row
 import org.json4s.CustomSerializer
 import org.json4s.JsonAST.JString
@@ -306,6 +307,9 @@ abstract class PType extends Serializable with Requiredness {
     pretty(sb, 0, true)
     sb.result()
   }
+
+  final def arrowFieldType: ArrowFieldType =
+    new ArrowFieldType(!required, virtualType.arrowType, /*dictionary=*/ null)
 
   def unsafeOrdering(sm: HailStateManager): UnsafeOrdering
 

--- a/hail/hail/src/is/hail/types/virtual/TArray.scala
+++ b/hail/hail/src/is/hail/types/virtual/TArray.scala
@@ -42,6 +42,8 @@ final case class TArray(elementType: Type) extends TContainer {
 
   override def str(a: Annotation): String = JsonMethods.compact(export(a))
 
+  override def arrowType = new org.apache.arrow.vector.types.pojo.ArrowType.List()
+
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
     ExtendedOrdering.iterableOrdering(elementType.ordering(sm), missingEqual)
 

--- a/hail/hail/src/is/hail/types/virtual/TBaseStruct.scala
+++ b/hail/hail/src/is/hail/types/virtual/TBaseStruct.scala
@@ -96,6 +96,8 @@ abstract class TBaseStruct extends Type {
 
   override def str(a: Annotation): String = JsonMethods.compact(export(a))
 
+  override def arrowType = new org.apache.arrow.vector.types.pojo.ArrowType.Struct()
+
   override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double, absolute: Boolean)
     : Boolean =
     a1 == a2 || (a1 != null && a2 != null

--- a/hail/hail/src/is/hail/types/virtual/TBinary.scala
+++ b/hail/hail/src/is/hail/types/virtual/TBinary.scala
@@ -8,6 +8,8 @@ case object TBinary extends Type {
 
   override def _typeCheck(a: Any): Boolean = a.isInstanceOf[Array[Byte]]
 
+  override def arrowType = new org.apache.arrow.vector.types.pojo.ArrowType.Binary()
+
   override def mkOrdering(sm: HailStateManager, _missingEqual: Boolean = true): ExtendedOrdering =
     new ExtendedOrdering {
       val missingEqual = _missingEqual

--- a/hail/hail/src/is/hail/types/virtual/TBoolean.scala
+++ b/hail/hail/src/is/hail/types/virtual/TBoolean.scala
@@ -9,6 +9,8 @@ case object TBoolean extends Type {
   override def pyString(sb: StringBuilder): Unit =
     sb ++= "bool"
 
+  override def arrowType = new org.apache.arrow.vector.types.pojo.ArrowType.Bool()
+
   override def _typeCheck(a: Any): Boolean = a.isInstanceOf[Boolean]
 
   override def _showStr(a: Annotation): String = if (a.asInstanceOf[Boolean]) "True" else "False"

--- a/hail/hail/src/is/hail/types/virtual/TCall.scala
+++ b/hail/hail/src/is/hail/types/virtual/TCall.scala
@@ -17,6 +17,8 @@ case object TCall extends Type {
   override def str(a: Annotation): String =
     if (a == null) "NA" else Call.toString(a.asInstanceOf[Call])
 
+  override def arrowType = is.hail.types.arrowextension.Call.INSTANCE
+
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
     ExtendedOrdering.extendToNull(implicitly[Ordering[Int]], missingEqual)
 

--- a/hail/hail/src/is/hail/types/virtual/TDict.scala
+++ b/hail/hail/src/is/hail/types/virtual/TDict.scala
@@ -58,6 +58,9 @@ final case class TDict(keyType: Type, valueType: Type) extends TContainer {
 
   override def str(a: Annotation): String = JsonMethods.compact(export(a))
 
+  override def arrowType =
+    new org.apache.arrow.vector.types.pojo.ArrowType.Map( /*keysSorted=*/ true)
+
   override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double, absolute: Boolean)
     : Boolean =
     a1 == a2 || (a1 != null && a2 != null &&

--- a/hail/hail/src/is/hail/types/virtual/TFloat32.scala
+++ b/hail/hail/src/is/hail/types/virtual/TFloat32.scala
@@ -5,7 +5,11 @@ import is.hail.backend.HailStateManager
 import is.hail.expr.orderings.compat.FloatOrdering
 import is.hail.utils._
 
+import org.apache.arrow.vector.types.pojo.ArrowType
+
 case object TFloat32 extends TNumeric {
+  override def bitWidth = 32
+
   override def _toPretty = "Float32"
 
   override def pyString(sb: StringBuilder): Unit =
@@ -17,6 +21,9 @@ case object TFloat32 extends TNumeric {
 
   override def str(a: Annotation): String =
     if (a == null) "NA" else "%.5e".format(a.asInstanceOf[Float])
+
+  override def arrowType =
+    new ArrowType.FloatingPoint(org.apache.arrow.vector.types.FloatingPointPrecision.SINGLE)
 
   override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double, absolute: Boolean)
     : Boolean =

--- a/hail/hail/src/is/hail/types/virtual/TFloat64.scala
+++ b/hail/hail/src/is/hail/types/virtual/TFloat64.scala
@@ -5,7 +5,11 @@ import is.hail.backend.HailStateManager
 import is.hail.expr.orderings.compat.DoubleOrdering
 import is.hail.utils._
 
+import org.apache.arrow.vector.types.pojo.ArrowType
+
 case object TFloat64 extends TNumeric {
+  override def bitWidth = 64
+
   override def _toPretty = "Float64"
 
   override def pyString(sb: StringBuilder): Unit =
@@ -17,6 +21,9 @@ case object TFloat64 extends TNumeric {
 
   override def str(a: Annotation): String =
     if (a == null) "NA" else "%.5e".format(a.asInstanceOf[Double])
+
+  override def arrowType =
+    new ArrowType.FloatingPoint(org.apache.arrow.vector.types.FloatingPointPrecision.DOUBLE)
 
   override def valuesSimilar(a1: Annotation, a2: Annotation, tolerance: Double, absolute: Boolean)
     : Boolean =

--- a/hail/hail/src/is/hail/types/virtual/TInt32.scala
+++ b/hail/hail/src/is/hail/types/virtual/TInt32.scala
@@ -4,6 +4,8 @@ import is.hail.annotations._
 import is.hail.backend.HailStateManager
 
 case object TInt32 extends TIntegral {
+  override def bitWidth = 32
+
   override def _toPretty = "Int32"
 
   override def pyString(sb: StringBuilder): Unit =

--- a/hail/hail/src/is/hail/types/virtual/TInt64.scala
+++ b/hail/hail/src/is/hail/types/virtual/TInt64.scala
@@ -4,6 +4,8 @@ import is.hail.annotations._
 import is.hail.backend.HailStateManager
 
 case object TInt64 extends TIntegral {
+  override def bitWidth = 64
+
   override def _toPretty = "Int64"
 
   override def pyString(sb: StringBuilder): Unit =

--- a/hail/hail/src/is/hail/types/virtual/TIntegral.scala
+++ b/hail/hail/src/is/hail/types/virtual/TIntegral.scala
@@ -1,3 +1,7 @@
 package is.hail.types.virtual
 
-abstract class TIntegral extends TNumeric
+import org.apache.arrow.vector.types.pojo.ArrowType
+
+abstract class TIntegral extends TNumeric {
+  override def arrowType = new ArrowType.Int(bitWidth, /*isSigned=*/ true)
+}

--- a/hail/hail/src/is/hail/types/virtual/TInterval.scala
+++ b/hail/hail/src/is/hail/types/virtual/TInterval.scala
@@ -28,6 +28,8 @@ case class TInterval(pointType: Type) extends Type {
     pointType.typeCheck(i.start) && pointType.typeCheck(i.end)
   }
 
+  override def arrowType = is.hail.types.arrowextension.Interval.INSTANCE
+
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =
     Interval.ordering(pointType.ordering(sm), startPrimary = true, missingEqual)
 

--- a/hail/hail/src/is/hail/types/virtual/TLocus.scala
+++ b/hail/hail/src/is/hail/types/virtual/TLocus.scala
@@ -30,6 +30,8 @@ case class TLocus(rgName: String) extends Type {
 
   override def _typeCheck(a: Any): Boolean = a.isInstanceOf[Locus]
 
+  override def arrowType = is.hail.types.arrowextension.Locus.INSTANCE
+
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean = true): ExtendedOrdering =
     sm.referenceGenomes(rgName).extendedLocusOrdering
 

--- a/hail/hail/src/is/hail/types/virtual/TNDArray.scala
+++ b/hail/hail/src/is/hail/types/virtual/TNDArray.scala
@@ -92,6 +92,8 @@ final case class TNDArray(elementType: Type, nDimsBase: NatBase) extends Type {
     }
   }
 
+  override def arrowType = is.hail.types.arrowextension.NDArray.INSTANCE
+
   override def unify(concrete: Type): Boolean =
     concrete match {
       case TNDArray(cElementType, cNDims) =>

--- a/hail/hail/src/is/hail/types/virtual/TNumeric.scala
+++ b/hail/hail/src/is/hail/types/virtual/TNumeric.scala
@@ -2,4 +2,6 @@ package is.hail.types.virtual
 
 abstract class TNumeric extends Type {
   override def canCompare(other: Type): Boolean = other.isInstanceOf[TNumeric]
+
+  def bitWidth: Int
 }

--- a/hail/hail/src/is/hail/types/virtual/TRNGState.scala
+++ b/hail/hail/src/is/hail/types/virtual/TRNGState.scala
@@ -10,6 +10,8 @@ case object TRNGState extends Type {
 
   override def _typeCheck(a: Any): Boolean = ???
 
+  override def arrowType = ???
+
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean)
     : is.hail.annotations.ExtendedOrdering = ???
 

--- a/hail/hail/src/is/hail/types/virtual/TSet.scala
+++ b/hail/hail/src/is/hail/types/virtual/TSet.scala
@@ -45,6 +45,9 @@ final case class TSet(elementType: Type) extends TContainer {
 
   override def str(a: Annotation): String = JsonMethods.compact(export(a))
 
+  override def arrowType =
+    new org.apache.arrow.vector.types.pojo.ArrowType.Map( /*keysSorted=*/ true)
+
   override def valueSubsetter(subtype: Type): Any => Any = {
     assert(elementType == subtype.asInstanceOf[TSet].elementType)
     identity

--- a/hail/hail/src/is/hail/types/virtual/TStream.scala
+++ b/hail/hail/src/is/hail/types/virtual/TStream.scala
@@ -35,6 +35,8 @@ final case class TStream(elementType: Type) extends TIterable {
 
   override def str(a: Annotation): String = JsonMethods.compact(export(a))
 
+  override def arrowType = ???
+
   override def isRealizable = false
 
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =

--- a/hail/hail/src/is/hail/types/virtual/TString.scala
+++ b/hail/hail/src/is/hail/types/virtual/TString.scala
@@ -11,6 +11,8 @@ case object TString extends Type {
 
   override def _showStr(a: Annotation): String = "\"" + a.asInstanceOf[String] + "\""
 
+  override def arrowType = new org.apache.arrow.vector.types.pojo.ArrowType.Utf8()
+
   override def _typeCheck(a: Any): Boolean = a.isInstanceOf[String]
 
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering =

--- a/hail/hail/src/is/hail/types/virtual/TVariable.scala
+++ b/hail/hail/src/is/hail/types/virtual/TVariable.scala
@@ -51,6 +51,8 @@ final case class TVariable(name: String, cond: String = null) extends Type {
   override def pyString(sb: StringBuilder): Unit =
     sb ++= _toPretty
 
+  override def arrowType = ???
+
   override def isRealizable = false
 
   override def _typeCheck(a: Any): Boolean =

--- a/hail/hail/src/is/hail/types/virtual/TVoid.scala
+++ b/hail/hail/src/is/hail/types/virtual/TVoid.scala
@@ -8,6 +8,8 @@ case object TVoid extends Type {
 
   override def pyString(sb: StringBuilder): Unit = sb ++= "void"
 
+  override def arrowType = ???
+
   override def mkOrdering(sm: HailStateManager, missingEqual: Boolean): ExtendedOrdering = null
 
   override def _typeCheck(a: Any): Boolean = a.isInstanceOf[Unit]

--- a/hail/hail/src/is/hail/types/virtual/Type.scala
+++ b/hail/hail/src/is/hail/types/virtual/Type.scala
@@ -7,6 +7,7 @@ import is.hail.expr.{JSONAnnotationImpex, SparkAnnotationImpex}
 import is.hail.expr.ir._
 import is.hail.utils
 
+import org.apache.arrow.vector.types.pojo.ArrowType
 import org.apache.spark.sql.types.DataType
 import org.json4s.{CustomSerializer, JValue}
 import org.json4s.JsonAST.JString
@@ -62,6 +63,8 @@ abstract class Type extends VType with Serializable {
     sb ++= _toPretty
 
   def schema: DataType = SparkAnnotationImpex.exportType(this)
+
+  def arrowType: ArrowType
 
   def str(a: Annotation): String = if (a == null) "NA" else a.toString
 


### PR DESCRIPTION
To explore interoperability with other data systems/file formats, add a mapping from hail types to Apache Arrow types. The primary "entry point" is `asArrowSchema` in PBaseStruct allowing the conversion of a struct type to an arrow Schema. Each virtual type exposes a mapping to the corresponding arrow type, with physical types corresponding to arrow's `FieldType` (where the notion of nullability enters arrow's type system).

Also, add arrow extension types for hail specific types: Call, Interval, Locus, and NDArray. Note that Arrow does have an 'Interval' type as well, but it corresponds to time durations not arbitrary ranges over some ordered set.

## Security Assessment
- Cannot impact GCP deployed hail batch service.