### PR TITLE
[ci] use ci to control release batch, not job-internal gates

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -949,11 +949,9 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /test-dataproc-service-account-key
-    scopes:
-      - deploy
-      - dev
     forceIfLabeled:
       - run-dataproc-tests
+    onlyIfRelease: true
     clouds:
       - gcp
   - kind: runImage
@@ -3745,12 +3743,6 @@ steps:
   #     gcloud config set project hail-vdc
   #     gcloud config set dataproc/region us-central1
 
-  #     if git ls-remote --exit-code --tags origin $(cat hail/env/HAIL_PIP_VERSION)
-  #     then
-  #         echo "tag $HAIL_PIP_VERSION already exists"
-  #         exit 0
-  #     fi
-
   #     cd hail
   #     make test-dataproc-37 HAIL_BUILD_MODE=Release \
   #         -o $(ls build/deploy/dist/hail-*-py3-none-any.whl)
@@ -3770,11 +3762,9 @@ steps:
   #       namespace:
   #         valueFrom: default_ns.name
   #       mountPath: /test-dataproc-service-account-key
-  #   scopes:
-  #     - deploy
-  #     - dev
   #   forceIfLabeled:
   #     - run-dataproc-tests
+  #   onlyIfRelease: true
   #   clouds:
   #     - gcp
   # - kind: runImage
@@ -3791,12 +3781,6 @@ steps:
   #     gcloud auth activate-service-account --key-file=/test-dataproc-service-account-key/test-dataproc-service-account-key.json
   #     gcloud config set project hail-vdc
   #     gcloud config set dataproc/region us-central1
-
-  #     if git ls-remote --exit-code --tags origin $(cat hail/env/HAIL_PIP_VERSION)
-  #     then
-  #         echo "tag $HAIL_PIP_VERSION already exists"
-  #         exit 0
-  #     fi
 
   #     cd hail
   #     make test-dataproc-38 HAIL_BUILD_MODE=Release \
@@ -3817,11 +3801,9 @@ steps:
   #       namespace:
   #         valueFrom: default_ns.name
   #       mountPath: /test-dataproc-service-account-key
-  #   scopes:
-  #     - deploy
-  #     - dev
   #   forceIfLabeled:
   #     - run-dataproc-tests
+  #   onlyIfRelease: true
   #   clouds:
   #     - gcp
   - kind: runImage
@@ -4076,13 +4058,6 @@ steps:
       cd /io/repo/hail
       export HAIL_PIP_VERSION=$(cat env/HAIL_PIP_VERSION)
 
-      if git ls-remote --exit-code --tags origin $HAIL_PIP_VERSION
-      then
-          echo "tag $HAIL_PIP_VERSION already exists"
-          echo '0' > /io/release-hail-flag
-          exit 0
-      fi
-
       # #14452 - must build wheel with release `hailtop/hailctl/deploy.yaml`
       # use `-o` to prevent `mill` from rebuilding the "SHADOW_JAR"
       make upload-artifacts HAIL_BUILD_MODE=Release DEPLOY_REMOTE=origin \
@@ -4104,8 +4079,6 @@ steps:
       HAIL_GENETICS_VEP_GRCH38_95_IMAGE=docker://{{ hailgenetics_vep_grch38_95_image.image }} \
       WEBSITE_TAR=/io/www.tar.gz \
       bash scripts/release.sh
-
-      echo '1' > /io/release-hail-flag
     inputs:
       - from: /repo
         to: /io/repo
@@ -4113,9 +4086,6 @@ steps:
         to: /io/repo/hail/out/hail/2.12/assembly.dest/out.jar
       - from: /www.tar.gz
         to: /io/www.tar.gz
-    outputs:
-      - from: /io/release-hail-flag
-        to: /release-hail-flag
     secrets:
       - name: pypi-credentials
         namespace:
@@ -4133,9 +4103,7 @@ steps:
         namespace:
           valueFrom: default_ns.name
         mountPath: /hail-ci-0-1-github-oauth-token
-    scopes:
-      - deploy
-      - dev
+    onlyIfRelease: true
     dependsOn:
       - default_ns
       - ci_utils_image
@@ -4163,9 +4131,7 @@ steps:
       - gcp
   - kind: runImage
     name: start_hail_benchmark
-    scopes:
-      - deploy
-      - dev
+    onlyIfRelease: true
     clouds:
       - gcp
     dependsOn:
@@ -4181,17 +4147,8 @@ steps:
         to: /io/repo/hail/env
       - from: /repo/hail/scripts/benchmark_in_batch.py
         to: /io/repo/hail/scripts/benchmark_in_batch.py
-      - from: /release-hail-flag
-        to: /io/release-hail-flag
     script: |
       set -ex
-
-      # only run benchmarks iff we've published a new release
-      if [[ $(< /io/release-hail-flag) != '1' ]]
-      then
-          echo 'Skipping benchmarks (no new release published).'
-          exit 0
-      fi
 
       pushd /io/repo/hail
 

--- a/build.yaml
+++ b/build.yaml
@@ -27,8 +27,8 @@ steps:
       cd repo
       {{ code.checkout_script }}
       make -C hail python-version-info HAIL_BUILD_MODE=Release MILLOPTS=--no-daemon
-      {% if code.pip_version %}
-      [[ "$(cat hail/env/HAIL_PIP_VERSION)" == "{{ code.pip_version }}" ]] || { echo "HAIL_PIP_VERSION mismatch: CI parsed {{ code.pip_version }} from Makefile but make produced $(cat hail/env/HAIL_PIP_VERSION)"; exit 1; }
+      {% if code.get('pip_version') %}
+      [[ "$(cat hail/env/HAIL_PIP_VERSION)" == "{{ code.get('pip_version') }}" ]] || { echo "HAIL_PIP_VERSION mismatch: CI parsed {{ code.get('pip_version') }} from Makefile but make produced $(cat hail/env/HAIL_PIP_VERSION)"; exit 1; }
       {% endif %}
     outputs:
       - from: /io/repo/

--- a/build.yaml
+++ b/build.yaml
@@ -3769,6 +3769,9 @@ steps:
   #       namespace:
   #         valueFrom: default_ns.name
   #       mountPath: /test-dataproc-service-account-key
+  #   scopes:
+  #     - deploy
+  #     - dev
   #   forceIfLabeled:
   #     - run-dataproc-tests
   #   onlyIfRelease: true
@@ -3808,6 +3811,9 @@ steps:
   #       namespace:
   #         valueFrom: default_ns.name
   #       mountPath: /test-dataproc-service-account-key
+  #   scopes:
+  #     - deploy
+  #     - dev
   #   forceIfLabeled:
   #     - run-dataproc-tests
   #   onlyIfRelease: true

--- a/build.yaml
+++ b/build.yaml
@@ -956,6 +956,9 @@ steps:
     forceIfLabeled:
       - run-dataproc-tests
     onlyIfRelease: true
+    scopes:
+      - deploy
+      - dev
     clouds:
       - gcp
   - kind: runImage
@@ -4108,6 +4111,9 @@ steps:
           valueFrom: default_ns.name
         mountPath: /hail-ci-0-1-github-oauth-token
     onlyIfRelease: true
+    scopes:
+      - deploy
+      - dev
     dependsOn:
       - default_ns
       - ci_utils_image
@@ -4136,6 +4142,9 @@ steps:
   - kind: runImage
     name: start_hail_benchmark
     onlyIfRelease: true
+    scopes:
+      - deploy
+      - dev
     clouds:
       - gcp
     dependsOn:

--- a/build.yaml
+++ b/build.yaml
@@ -27,6 +27,9 @@ steps:
       cd repo
       {{ code.checkout_script }}
       make -C hail python-version-info HAIL_BUILD_MODE=Release MILLOPTS=--no-daemon
+      {% if code.pip_version %}
+      [[ "$(cat hail/env/HAIL_PIP_VERSION)" == "{{ code.pip_version }}" ]] || { echo "HAIL_PIP_VERSION mismatch: CI parsed {{ code.pip_version }} from Makefile but make produced $(cat hail/env/HAIL_PIP_VERSION)"; exit 1; }
+      {% endif %}
     outputs:
       - from: /io/repo/
         to: /repo

--- a/build.yaml
+++ b/build.yaml
@@ -28,7 +28,8 @@ steps:
       {{ code.checkout_script }}
       make -C hail python-version-info HAIL_BUILD_MODE=Release MILLOPTS=--no-daemon
       {% if code.get('pip_version') %}
-      [[ "$(cat hail/env/HAIL_PIP_VERSION)" == "{{ code.get('pip_version') }}" ]] || { echo "HAIL_PIP_VERSION mismatch: CI parsed {{ code.get('pip_version') }} from Makefile but make produced $(cat hail/env/HAIL_PIP_VERSION)"; exit 1; }
+      _make_pip_version=$(cat hail/env/HAIL_PIP_VERSION)
+      [[ "$_make_pip_version" == "{{ code.get('pip_version') }}" ]] || { echo "HAIL_PIP_VERSION mismatch: CI parsed {{ code.get('pip_version') }} from Makefile but make produced $_make_pip_version"; exit 1; }
       {% endif %}
     outputs:
       - from: /io/repo/

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -84,11 +84,12 @@ class Code(abc.ABC):
 
 
 class StepParameters:
-    def __init__(self, code, scope, json, name_step):
+    def __init__(self, code, scope, json, name_step, is_release: bool = False):
         self.code = code
         self.scope = scope
         self.json = json
         self.name_step = name_step
+        self.is_release = is_release
 
 
 class BuildConfigurationError(Exception):
@@ -105,12 +106,14 @@ class BuildConfiguration:
         requested_step_names: Optional[Sequence[str]] = None,
         excluded_step_names: Sequence[str] = (),
         pr_labels: FrozenSet[str] = frozenset(),
+        is_release: bool = False,
     ):
         if len(excluded_step_names) > 0 and scope != 'dev':
             raise BuildConfigurationError('Excluding build steps is only permitted in a dev scope')
 
         self.pr_labels = pr_labels
 
+        self.is_release = is_release
         config = yaml.safe_load(config_str)
         if requested_step_names is not None:
             log.info(f"Constructing build configuration with steps: {requested_step_names}")
@@ -118,7 +121,7 @@ class BuildConfiguration:
         runnable_steps: List[Step] = []
         name_step: Dict[str, Step] = {}
         for step_config in config['steps']:
-            step = Step.from_json(StepParameters(code, scope, step_config, name_step))
+            step = Step.from_json(StepParameters(code, scope, step_config, name_step, is_release))
             if step.name not in excluded_step_names and step.can_run_in_current_cloud():
                 name_step[step.name] = step
                 runnable_steps.append(step)
@@ -144,7 +147,10 @@ class BuildConfiguration:
             self.steps = [step for step in runnable_steps if step in visited]
         else:
             self.steps = [
-                step for step in runnable_steps if not step.run_if_requested or step.is_forced_by_labels(pr_labels)
+                step
+                for step in runnable_steps
+                if step.is_forced_by_labels(pr_labels)
+                or (not step.run_if_requested and (not step.only_if_release or (is_release and scope == 'deploy')))
             ]
 
     def build(self, batch, code, scope):
@@ -205,6 +211,8 @@ class Step(abc.ABC):
         self.clouds = json.get('clouds')
         self.run_if_requested = json.get('runIfRequested', False)
         self.force_if_labeled: List[str] = json.get('forceIfLabeled', [])
+        self.only_if_release = json.get('onlyIfRelease', False)
+        self.is_release = params.is_release
 
         self.token = generate_token()
 
@@ -214,6 +222,7 @@ class Step(abc.ABC):
         config['token'] = self.token
         config['deploy'] = scope == 'deploy'
         config['scope'] = scope
+        config['is_release'] = self.is_release
         config['code'] = code.config()
         config['ci_storage_uri'] = STORAGE_URI
         if self.deps:

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -144,7 +144,16 @@ class BuildConfiguration:
             for step in runnable_steps:
                 if step.is_forced_by_labels(pr_labels):
                     visit_dependent(step)
-            self.steps = [step for step in runnable_steps if step in visited]
+            self.steps = [
+                step
+                for step in runnable_steps
+                if step in visited
+                and (
+                    not step.only_if_release
+                    or step.is_forced_by_labels(pr_labels)
+                    or (is_release and scope == 'deploy')
+                )
+            ]
         else:
             self.steps = [
                 step

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -1223,8 +1223,11 @@ mkdir -p {shq(repo_dir)}
                 await check_shell_output(
                     f'git -C {shq(repo_dir)} ls-remote --exit-code --tags origin {shq(pip_version)}'
                 )
-            except CalledProcessError:
-                is_release = True
+            except CalledProcessError as e:
+                if e.returncode == 2:
+                    is_release = True
+                else:
+                    raise
             log.info(f'deploy for {self.branch.short_str()} @ {self.sha[:8]}: is_release={is_release}')
 
             with open(f'{repo_dir}/build.yaml', 'r', encoding='utf-8') as f:

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -230,6 +230,32 @@ fi
 """
 
 
+def _read_pip_version(repo_dir: str) -> Optional[str]:
+    makefile_path = f'{repo_dir}/hail/Makefile'
+    try:
+        with open(makefile_path, 'r', encoding='utf-8') as f:
+            makefile = f.read()
+    except FileNotFoundError:
+        return None
+
+    major_minor_m = re.search(r'^HAIL_MAJOR_MINOR_VERSION\s*:=\s*(\S+)', makefile, re.MULTILINE)
+    patch_m = re.search(r'^HAIL_PATCH_VERSION\s*:=\s*(\S+)', makefile, re.MULTILINE)
+    if not major_minor_m or not patch_m:
+        raise ValueError(f'could not parse HAIL_PIP_VERSION from {makefile_path}')
+    pip_version = f'{major_minor_m.group(1)}.{patch_m.group(1)}'
+
+    generated_path = f'{repo_dir}/hail/env/HAIL_PIP_VERSION'
+    if os.path.exists(generated_path):
+        with open(generated_path, 'r', encoding='utf-8') as f:
+            generated = f.read().strip()
+        if generated != pip_version:
+            raise ValueError(
+                f'HAIL_PIP_VERSION mismatch: Makefile says {pip_version!r}, generated file says {generated!r}'
+            )
+
+    return pip_version
+
+
 class PR(Code):
     def __init__(
         self,
@@ -268,6 +294,8 @@ class PR(Code):
 
         self.pending_build_reason: str = 'unknown'
         self.tactical: bool = False
+
+        self.pip_version: Optional[str] = None
 
         self.intended_github_status: GithubStatus = self.github_status_from_build_state()
         self.last_known_github_status: Dict[str, GithubStatus] = {}
@@ -395,6 +423,7 @@ class PR(Code):
             'checkout_script': self.checkout_script(),
             'developers': self.developers,
             'number': self.number,
+            'pip_version': self.pip_version or '',
             'source_repo': source_repo.short_str(),
             'source_repo_url': source_repo.url,
             'source_sha': self.source_sha,
@@ -510,6 +539,8 @@ set -ex
 mkdir -p {shq(repo_dir)}
 (cd {shq(repo_dir)}; {self.checkout_script()})
 """)
+
+            self.pip_version = _read_pip_version(repo_dir)
 
             sha_out, _ = await check_shell_output(f'git -C {shq(repo_dir)} rev-parse HEAD')
             self.sha = sha_out.decode('utf-8').strip()
@@ -892,6 +923,8 @@ class WatchedBranch(Code):
         self.prs: Dict[int, PR] = {}
         self.sha: Optional[str] = None
 
+        self.pip_version: Optional[str] = None
+
         self.deploy_batch: Union[Batch, MergeFailureBatch, None] = None
         # success, failure, pending
         self._deploy_state: Optional[str] = None
@@ -927,6 +960,7 @@ class WatchedBranch(Code):
         return {
             'checkout_script': self.checkout_script(),
             'branch': self.branch.name,
+            'pip_version': self.pip_version or '',
             'repo': self.branch.repo.short_str(),
             'repo_url': self.branch.repo.url,
             'sha': self.sha,
@@ -1180,13 +1214,15 @@ url: {url}
 mkdir -p {shq(repo_dir)}
 (cd {shq(repo_dir)}; {self.checkout_script()})
 """)
-            with open(f'{repo_dir}/hail/env/HAIL_PIP_VERSION', 'r', encoding='utf-8') as f:
-                pip_version = f.read().strip()
+            self.pip_version = _read_pip_version(repo_dir)
+            pip_version = self.pip_version
+            if pip_version is None:
+                raise ValueError(f'could not determine HAIL_PIP_VERSION: hail/Makefile not found in {repo_dir}')
+            is_release = False
             try:
                 await check_shell_output(
                     f'git -C {shq(repo_dir)} ls-remote --exit-code --tags origin {shq(pip_version)}'
                 )
-                is_release = False
             except CalledProcessError:
                 is_release = True
             log.info(f'deploy for {self.branch.short_str()} @ {self.sha[:8]}: is_release={is_release}')

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -21,7 +21,7 @@ from gidgethub import aiohttp as gh_aiohttp
 from gear import Database, UserData
 from hailtop.batch_client.aioclient import Batch, BatchClient
 from hailtop.config import get_deploy_config
-from hailtop.utils import RETRY_FUNCTION_SCRIPT, check_shell, check_shell_output
+from hailtop.utils import RETRY_FUNCTION_SCRIPT, CalledProcessError, check_shell, check_shell_output
 
 from .build import BuildConfiguration, Code
 from .build_selection import compute_requested_steps
@@ -1180,8 +1180,21 @@ url: {url}
 mkdir -p {shq(repo_dir)}
 (cd {shq(repo_dir)}; {self.checkout_script()})
 """)
+            with open(f'{repo_dir}/hail/env/HAIL_PIP_VERSION', 'r', encoding='utf-8') as f:
+                pip_version = f.read().strip()
+            try:
+                await check_shell_output(
+                    f'git -C {shq(repo_dir)} ls-remote --exit-code --tags origin {shq(pip_version)}'
+                )
+                is_release = False
+            except CalledProcessError:
+                is_release = True
+            log.info(f'deploy for {self.branch.short_str()} @ {self.sha[:8]}: is_release={is_release}')
+
             with open(f'{repo_dir}/build.yaml', 'r', encoding='utf-8') as f:
-                config = BuildConfiguration(self, f.read(), requested_step_names=DEPLOY_STEPS or None, scope='deploy')
+                config = BuildConfiguration(
+                    self, f.read(), requested_step_names=DEPLOY_STEPS or None, scope='deploy', is_release=is_release
+                )
                 namespace = config.namespace()
                 services = config.deployed_services()
             with open(f'{repo_dir}/ci/test/resources/build.yaml', 'r', encoding='utf-8') as f:
@@ -1192,14 +1205,17 @@ mkdir -p {shq(repo_dir)}
             await add_deployed_services(db, namespace, services, None)
 
             log.info(f'creating deploy batch for {self.branch.short_str()}')
+            batch_name = f'Deploy {self.branch.name} @ {self.sha[:8]}'
+            if is_release:
+                batch_name += f' / Release {pip_version}'
             deploy_batch = batch_client.create_batch(
                 attributes={
                     'token': secrets.token_hex(16),
                     'deploy': '1',
                     'target_branch': self.branch.short_str(),
                     'sha': self.sha,
-                    'name': f'Deploy {self.branch.name} @ {self.sha[:8]}',
-                    'batch_type': 'ci/deploy/prod',
+                    'name': batch_name,
+                    'batch_type': 'ci/release/prod' if is_release else 'ci/deploy/prod',
                 },
                 callback=CALLBACK_URL,
             )


### PR DESCRIPTION
## Change Description

Removes per-task "is this a release" gating (with side effect of having to pass a flag file around because the release has already happened by the time we get to the later tasks)

Replaces with: CI determiness upfront "is this a release" and includes the appropriate, clearly labeled release tasks, instead.

Motivation:
- More explicit build script
- Less confusing deploy "but really a release" build history
- CI controls which jobs run based on its own determination of conditions
- Allows #15664 to actually run dataproc tests, not just add them to be skipped by their gate check

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Small change to job selection for releases

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
