### PR TITLE
[ci] Allow PR retries to skip already-previously-passed tests

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -102,7 +102,7 @@ class BuildConfiguration:
         config_str: str,
         scope: str,
         *,
-        requested_step_names: Sequence[str] = (),
+        requested_step_names: Optional[Sequence[str]] = None,
         excluded_step_names: Sequence[str] = (),
         pr_labels: FrozenSet[str] = frozenset(),
     ):
@@ -112,7 +112,7 @@ class BuildConfiguration:
         self.pr_labels = pr_labels
 
         config = yaml.safe_load(config_str)
-        if requested_step_names:
+        if requested_step_names is not None:
             log.info(f"Constructing build configuration with steps: {requested_step_names}")
 
         runnable_steps: List[Step] = []
@@ -123,7 +123,7 @@ class BuildConfiguration:
                 name_step[step.name] = step
                 runnable_steps.append(step)
 
-        if requested_step_names:
+        if requested_step_names is not None:
             # transitively close requested_step_names over dependencies
             visited = set()
 

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -354,7 +354,9 @@ def storage_uri_to_url(uri: str) -> str:
     return uri
 
 
-async def _retry_pr_core(wb: WatchedBranch, pr: PR, app: web.Application, username: str) -> Optional[str]:
+async def _retry_pr_core(
+    wb: WatchedBranch, pr: PR, app: web.Application, username: str, tactical: bool = False
+) -> Optional[str]:
     """Executes the retry logic. Returns an error message on failure, None on success."""
     if pr.batch is None:
         log.info(f'retry cannot be requested for PR #{pr.number} because it has no batch')
@@ -388,7 +390,8 @@ async def _retry_pr_core(wb: WatchedBranch, pr: PR, app: web.Application, userna
             )
 
     await db.execute_insertone('INSERT INTO invalidated_batches (batch_id) VALUES (%s);', batch_id)
-    pr.pending_build_reason = f'retry by {username}'
+    pr.tactical = tactical
+    pr.pending_build_reason = f'{"tactical " if tactical else ""}retry by {username}'
     pr.batch = None
     pr.set_build_state(None)
     await wb.notify_batch_changed(
@@ -400,11 +403,13 @@ async def _retry_pr_core(wb: WatchedBranch, pr: PR, app: web.Application, userna
 
 async def retry_pr(wb: WatchedBranch, pr: PR, request: web.Request, userdata: UserData):
     session = await aiohttp_session.get_session(request)
-    error = await _retry_pr_core(wb, pr, request.app, userdata['username'])
+    post_data = await request.post()
+    tactical = post_data.get('tactical') == 'true'
+    error = await _retry_pr_core(wb, pr, request.app, userdata['username'], tactical=tactical)
     if error:
         set_message(session, error, 'error')
     else:
-        set_message(session, f'Retry requested for PR #{pr.number}.', 'info')
+        set_message(session, f'{"Tactical retry" if tactical else "Retry"} requested for PR #{pr.number}.', 'info')
 
 
 @routes.post('/watched_branches/{watched_branch_index}/pr/{pr_number}/retry')
@@ -1222,7 +1227,11 @@ async def api_retry_pr(request: web.Request, userdata: UserData) -> web.Response
     if not wb.prs or pr_number not in wb.prs:
         raise web.HTTPNotFound()
     pr = wb.prs[pr_number]
-    error = await asyncio.shield(_retry_pr_core(wb, pr, request.app, userdata['username']))
+    params = {}
+    if request.content_type == 'application/json' and request.content_length:
+        params = await json_request(request)
+    tactical = bool(params.get('tactical', False))
+    error = await asyncio.shield(_retry_pr_core(wb, pr, request.app, userdata['username'], tactical=tactical))
     if error:
         raise web.HTTPBadRequest(text=error)
     return web.Response(status=200)

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -1230,7 +1230,7 @@ async def api_retry_pr(request: web.Request, userdata: UserData) -> web.Response
     params = {}
     if request.content_type == 'application/json' and request.content_length:
         params = await json_request(request)
-    tactical = bool(params.get('tactical', False))
+    tactical = params.get('tactical', False)
     error = await asyncio.shield(_retry_pr_core(wb, pr, request.app, userdata['username'], tactical=tactical))
     if error:
         raise web.HTTPBadRequest(text=error)

--- a/ci/ci/ci.py
+++ b/ci/ci/ci.py
@@ -1231,6 +1231,8 @@ async def api_retry_pr(request: web.Request, userdata: UserData) -> web.Response
     if request.content_type == 'application/json' and request.content_length:
         params = await json_request(request)
     tactical = params.get('tactical', False)
+    if not isinstance(tactical, bool):
+        raise web.HTTPBadRequest(text="'tactical' must be a JSON boolean")
     error = await asyncio.shield(_retry_pr_core(wb, pr, request.app, userdata['username'], tactical=tactical))
     if error:
         raise web.HTTPBadRequest(text=error)

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import random
+import re
 import secrets
 import time
 from shlex import quote as shq
@@ -266,6 +267,7 @@ class PR(Code):
         self.build_state: Optional[str] = None
 
         self.pending_build_reason: str = 'unknown'
+        self.tactical: bool = False
 
         self.intended_github_status: GithubStatus = self.github_status_from_build_state()
         self.last_known_github_status: Dict[str, GithubStatus] = {}
@@ -529,6 +531,24 @@ mkdir -p {shq(repo_dir)}
                 requested_steps_set = compute_requested_steps(build_yaml, changed_files, scope='test', cloud=CLOUD)
                 log.info(f'PR #{self.number} selected steps ({len(requested_steps_set)})')
                 requested_step_names = list(requested_steps_set)
+
+            if self.tactical:
+                self.tactical = False
+                assert self.target_branch.sha is not None
+                succeeded_steps: Set[str] = set()
+                async for b in batch_client.list_batches(
+                    f'test=1 pr={self.number} source_sha={self.source_sha} target_sha={self.target_branch.sha} user:ci'
+                ):
+                    async for job in b.jobs():
+                        if job['state'] == 'Success' and job['name']:
+                            step_name = re.sub(r'_\d+$', '', job['name'])
+                            succeeded_steps.add(step_name)
+                skipped = [s for s in requested_step_names if s in succeeded_steps]
+                requested_step_names = [s for s in requested_step_names if s not in succeeded_steps]
+                log.info(
+                    f'PR #{self.number} tactical retry: skipping {len(skipped)} already-succeeded steps: {skipped}'
+                )
+
             config = BuildConfiguration(
                 self,
                 build_yaml,
@@ -536,6 +556,7 @@ mkdir -p {shq(repo_dir)}
                 requested_step_names=requested_step_names,
                 pr_labels=frozenset(self.labels),
             )
+            
             namespace = config.namespace()
             services = config.deployed_services()
             with open(f'{repo_dir}/ci/test/resources/build.yaml', 'r', encoding='utf-8') as f:

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -523,23 +523,22 @@ mkdir -p {shq(repo_dir)}
 
             with open(f'{repo_dir}/build.yaml', 'r', encoding='utf-8') as f:
                 build_yaml = f.read()
-            run_all = RERUN_ALL_TESTS in self.labels or 'build.yaml' in changed_files
-            if run_all:
+            # None means run everything; a list (possibly empty) means run only those steps + label-forced.
+            if RERUN_ALL_TESTS in self.labels or 'build.yaml' in changed_files:
                 log.info(f'PR #{self.number} running full test suite (rerun all tests label or build.yaml changed)')
-                requested_step_names: List[str] = []
+                requested_step_names: Optional[List[str]] = None
             else:
                 requested_steps_set = compute_requested_steps(build_yaml, changed_files, scope='test', cloud=CLOUD)
                 log.info(f'PR #{self.number} selected steps ({len(requested_steps_set)})')
                 requested_step_names = list(requested_steps_set)
 
             tactical_skipped: Dict[str, int] = {}
-            if self.tactical:
+            if self.tactical and requested_step_names is not None:
                 self.tactical = False
                 succeeded_steps: Dict[str, int] = {}
                 async for b in batch_client.list_batches(
                     f'test=1 pr={self.number} source_sha={self.source_sha} target_sha={self.target_branch.sha} user:ci'
                 ):
-                    # Collect all job states per base step name for this batch.
                     step_states: Dict[str, List[str]] = {}
                     async for job in b.jobs():
                         if job['name']:
@@ -556,25 +555,20 @@ mkdir -p {shq(repo_dir)}
                     f'PR #{self.number} tactical retry: skipping {len(tactical_skipped)} already-succeeded steps: {list(tactical_skipped)}'
                 )
 
-            config: Optional[BuildConfiguration] = None
-            namespace: Optional[str] = None
-            services: List[str] = []
-            if requested_step_names or not tactical_skipped:
-                config = BuildConfiguration(
-                    self,
-                    build_yaml,
-                    scope='test',
-                    requested_step_names=requested_step_names,
-                    pr_labels=frozenset(self.labels),
-                )
-                namespace = config.namespace()
-                services = config.deployed_services()
-                with open(f'{repo_dir}/ci/test/resources/build.yaml', 'r', encoding='utf-8') as f:
-                    test_services = BuildConfiguration(self, f.read(), scope='test').deployed_services()
-                services.extend(test_services)
+            config = BuildConfiguration(
+                self,
+                build_yaml,
+                scope='test',
+                requested_step_names=requested_step_names,
+                pr_labels=frozenset(self.labels),
+            )
+            namespace: Optional[str] = config.namespace()
+            services: List[str] = config.deployed_services()
+            with open(f'{repo_dir}/ci/test/resources/build.yaml', 'r', encoding='utf-8') as f:
+                test_services = BuildConfiguration(self, f.read(), scope='test').deployed_services()
+            services.extend(test_services)
 
-            # namespace is None when no service deploy steps are selected (e.g. hail-only PRs)
-            # or when all steps were skipped by tactical retry; in either case skip registering services.
+            # namespace is None when no service deploy steps are selected (e.g. hail-only PRs).
             if namespace is not None:
                 tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
                 await add_deployed_services(db, namespace, services, tomorrow)
@@ -610,8 +604,7 @@ mkdir -p {shq(repo_dir)}
                     always_run=True,
                     regions=[REGION],
                 )
-            if config is not None:
-                config.build(batch, self, scope='test')
+            config.build(batch, self, scope='test')
             await batch.submit()
             self.batch = batch
         except concurrent.futures.CancelledError:

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -533,7 +533,6 @@ mkdir -p {shq(repo_dir)}
                 requested_step_names = list(requested_steps_set)
 
             tactical = self.tactical
-            self.tactical = False
             tactical_skipped: Dict[str, int] = {}
             if tactical and requested_step_names is not None:
                 succeeded_steps: Dict[str, int] = {}
@@ -599,7 +598,7 @@ mkdir -p {shq(repo_dir)}
                 ]
                 skipped_log_text = '\n'.join(skipped_log_lines) + '\n'
                 batch.create_job(
-                    'ubuntu:22.04',
+                    'ubuntu:24.04',
                     command=['python3', '-c', 'import sys; sys.stdout.write(sys.argv[1])', skipped_log_text],
                     attributes={'name': 'Tactical Retry Skipped Test Log'},
                     always_run=True,
@@ -607,6 +606,7 @@ mkdir -p {shq(repo_dir)}
                 )
             config.build(batch, self, scope='test')
             await batch.submit()
+            self.tactical = False
             self.batch = batch
         except concurrent.futures.CancelledError:
             raise

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -535,7 +535,6 @@ mkdir -p {shq(repo_dir)}
             tactical_skipped: Dict[str, int] = {}
             if self.tactical:
                 self.tactical = False
-                assert self.target_branch.sha is not None
                 succeeded_steps: Dict[str, int] = {}
                 async for b in batch_client.list_batches(
                     f'test=1 pr={self.number} source_sha={self.source_sha} target_sha={self.target_branch.sha} user:ci'
@@ -550,22 +549,25 @@ mkdir -p {shq(repo_dir)}
                     f'PR #{self.number} tactical retry: skipping {len(tactical_skipped)} already-succeeded steps: {list(tactical_skipped)}'
                 )
 
-            config = BuildConfiguration(
-                self,
-                build_yaml,
-                scope='test',
-                requested_step_names=requested_step_names,
-                pr_labels=frozenset(self.labels),
-            )
-            
-            namespace = config.namespace()
-            services = config.deployed_services()
-            with open(f'{repo_dir}/ci/test/resources/build.yaml', 'r', encoding='utf-8') as f:
-                test_services = BuildConfiguration(self, f.read(), scope='test').deployed_services()
+            config: Optional[BuildConfiguration] = None
+            namespace: Optional[str] = None
+            services: List[str] = []
+            if requested_step_names or not tactical_skipped:
+                config = BuildConfiguration(
+                    self,
+                    build_yaml,
+                    scope='test',
+                    requested_step_names=requested_step_names,
+                    pr_labels=frozenset(self.labels),
+                )
+                namespace = config.namespace()
+                services = config.deployed_services()
+                with open(f'{repo_dir}/ci/test/resources/build.yaml', 'r', encoding='utf-8') as f:
+                    test_services = BuildConfiguration(self, f.read(), scope='test').deployed_services()
+                services.extend(test_services)
 
-            services.extend(test_services)
-            # namespace is None when no service deploy steps are selected (e.g. hail-only PRs);
-            # in that case there are no deployed services to register.
+            # namespace is None when no service deploy steps are selected (e.g. hail-only PRs)
+            # or when all steps were skipped by tactical retry; in either case skip registering services.
             if namespace is not None:
                 tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
                 await add_deployed_services(db, namespace, services, tomorrow)
@@ -603,7 +605,8 @@ mkdir -p {shq(repo_dir)}
                     always_run=True,
                     regions=[REGION],
                 )
-            config.build(batch, self, scope='test')
+            if config is not None:
+                config.build(batch, self, scope='test')
             await batch.submit()
             self.batch = batch
         except concurrent.futures.CancelledError:

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -536,19 +536,30 @@ mkdir -p {shq(repo_dir)}
             tactical_skipped: Dict[str, int] = {}
             if tactical and requested_step_names is not None:
                 succeeded_steps: Dict[str, int] = {}
+                requested_steps_set = set(requested_step_names)
                 async for b in batch_client.list_batches(
-                    f'test=1 pr={self.number} source_sha={self.source_sha} target_sha={self.target_branch.sha} user:ci'
+                    f'test=1 pr={self.number} source_sha={self.source_sha} target_sha={self.target_branch.sha} user:ci',
+                    limit=50,
                 ):
                     step_states: Dict[str, List[str]] = {}
                     async for job in b.jobs():
                         if job['name']:
-                            step_name = re.sub(r'_\d+$', '', job['name'])
+                            name = job['name']
+                            if name in requested_steps_set:
+                                step_name = name
+                            else:
+                                stripped = re.sub(r'_\d+$', '', name)
+                                if stripped not in requested_steps_set:
+                                    continue
+                                step_name = stripped
                             step_states.setdefault(step_name, []).append(job['state'])
                     # list_batches is newest-first; overwriting on each older batch means we
                     # end up pointing to the oldest batch where every shard of the step passed.
                     for step_name, states in step_states.items():
                         if all(s == 'Success' for s in states):
                             succeeded_steps[step_name] = b.id
+                    if succeeded_steps.keys() >= requested_steps_set:
+                        break
                 tactical_skipped = {s: succeeded_steps[s] for s in requested_step_names if s in succeeded_steps}
                 requested_step_names = [s for s in requested_step_names if s not in succeeded_steps]
                 log.info(

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -1175,7 +1175,7 @@ mkdir -p {shq(repo_dir)}
 (cd {shq(repo_dir)}; {self.checkout_script()})
 """)
             with open(f'{repo_dir}/build.yaml', 'r', encoding='utf-8') as f:
-                config = BuildConfiguration(self, f.read(), requested_step_names=DEPLOY_STEPS, scope='deploy')
+                config = BuildConfiguration(self, f.read(), requested_step_names=DEPLOY_STEPS or None, scope='deploy')
                 namespace = config.namespace()
                 services = config.deployed_services()
             with open(f'{repo_dir}/ci/test/resources/build.yaml', 'r', encoding='utf-8') as f:

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -539,9 +539,16 @@ mkdir -p {shq(repo_dir)}
                 async for b in batch_client.list_batches(
                     f'test=1 pr={self.number} source_sha={self.source_sha} target_sha={self.target_branch.sha} user:ci'
                 ):
+                    # Collect all job states per base step name for this batch.
+                    step_states: Dict[str, List[str]] = {}
                     async for job in b.jobs():
-                        if job['state'] == 'Success' and job['name']:
+                        if job['name']:
                             step_name = re.sub(r'_\d+$', '', job['name'])
+                            step_states.setdefault(step_name, []).append(job['state'])
+                    # list_batches is newest-first; overwriting on each older batch means we
+                    # end up pointing to the oldest batch where every shard of the step passed.
+                    for step_name, states in step_states.items():
+                        if all(s == 'Success' for s in states):
                             succeeded_steps[step_name] = b.id
                 tactical_skipped = {s: succeeded_steps[s] for s in requested_step_names if s in succeeded_steps}
                 requested_step_names = [s for s in requested_step_names if s not in succeeded_steps]
@@ -590,17 +597,15 @@ mkdir -p {shq(repo_dir)}
                 callback=CALLBACK_URL,
             )
             if tactical_skipped:
-                bullets = '\n'.join(
-                    f'  • {step}: {deploy_config.external_url("batch", f"/batches/{batch_id}")}'
+                skipped_log_lines = ['Skipped (already succeeded with matching source and target SHA):']
+                skipped_log_lines += [
+                    f'  * {step}: {deploy_config.external_url("batch", f"/batches/{batch_id}")}'
                     for step, batch_id in sorted(tactical_skipped.items())
-                )
+                ]
+                skipped_log_text = '\n'.join(skipped_log_lines) + '\n'
                 batch.create_job(
                     'ubuntu:22.04',
-                    command=[
-                        'bash',
-                        '-c',
-                        f'printf "Skipped (already succeeded with matching source and target SHA):\\n{bullets}\\n"',
-                    ],
+                    command=['python3', '-c', 'import sys; sys.stdout.write(sys.argv[1])', skipped_log_text],
                     attributes={'name': 'Tactical Retry Skipped Test Log'},
                     always_run=True,
                     regions=[REGION],

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -26,7 +26,7 @@ from hailtop.utils import RETRY_FUNCTION_SCRIPT, check_shell, check_shell_output
 from .build import BuildConfiguration, Code
 from .build_selection import compute_requested_steps
 from .constants import AUTHORIZED_USERS, COMPILER_TEAM, GITHUB_CLONE_URL, GITHUB_STATUS_CONTEXT, SERVICES_TEAM
-from .environment import CLOUD, DEPLOY_STEPS
+from .environment import CLOUD, DEPLOY_STEPS, REGION
 from .globals import is_test_deployment
 from .utils import GithubStatus, add_deployed_services, github_status
 
@@ -532,21 +532,22 @@ mkdir -p {shq(repo_dir)}
                 log.info(f'PR #{self.number} selected steps ({len(requested_steps_set)})')
                 requested_step_names = list(requested_steps_set)
 
+            tactical_skipped: Dict[str, int] = {}
             if self.tactical:
                 self.tactical = False
                 assert self.target_branch.sha is not None
-                succeeded_steps: Set[str] = set()
+                succeeded_steps: Dict[str, int] = {}
                 async for b in batch_client.list_batches(
                     f'test=1 pr={self.number} source_sha={self.source_sha} target_sha={self.target_branch.sha} user:ci'
                 ):
                     async for job in b.jobs():
                         if job['state'] == 'Success' and job['name']:
                             step_name = re.sub(r'_\d+$', '', job['name'])
-                            succeeded_steps.add(step_name)
-                skipped = [s for s in requested_step_names if s in succeeded_steps]
+                            succeeded_steps[step_name] = b.id
+                tactical_skipped = {s: succeeded_steps[s] for s in requested_step_names if s in succeeded_steps}
                 requested_step_names = [s for s in requested_step_names if s not in succeeded_steps]
                 log.info(
-                    f'PR #{self.number} tactical retry: skipping {len(skipped)} already-succeeded steps: {skipped}'
+                    f'PR #{self.number} tactical retry: skipping {len(tactical_skipped)} already-succeeded steps: {list(tactical_skipped)}'
                 )
 
             config = BuildConfiguration(
@@ -586,6 +587,22 @@ mkdir -p {shq(repo_dir)}
                 },
                 callback=CALLBACK_URL,
             )
+            if tactical_skipped:
+                bullets = '\n'.join(
+                    f'  • {step}: {deploy_config.external_url("batch", f"/batches/{batch_id}")}'
+                    for step, batch_id in sorted(tactical_skipped.items())
+                )
+                batch.create_job(
+                    'ubuntu:22.04',
+                    command=[
+                        'bash',
+                        '-c',
+                        f'printf "Skipped (already succeeded with matching source and target SHA):\\n{bullets}\\n"',
+                    ],
+                    attributes={'name': 'Tactical Retry Skipped Test Log'},
+                    always_run=True,
+                    regions=[REGION],
+                )
             config.build(batch, self, scope='test')
             await batch.submit()
             self.batch = batch

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -532,9 +532,10 @@ mkdir -p {shq(repo_dir)}
                 log.info(f'PR #{self.number} selected steps ({len(requested_steps_set)})')
                 requested_step_names = list(requested_steps_set)
 
+            tactical = self.tactical
+            self.tactical = False
             tactical_skipped: Dict[str, int] = {}
-            if self.tactical and requested_step_names is not None:
-                self.tactical = False
+            if tactical and requested_step_names is not None:
                 succeeded_steps: Dict[str, int] = {}
                 async for b in batch_client.list_batches(
                     f'test=1 pr={self.number} source_sha={self.source_sha} target_sha={self.target_branch.sha} user:ci'

--- a/ci/ci/templates/pr.html
+++ b/ci/ci/templates/pr.html
@@ -153,6 +153,14 @@
       <input type="hidden" name="_csrf" value="{{ csrf_token }}"/>
       <button type="submit">Retry</button>
     </form>
+    {% if pr.batch_is_up_to_date and pr.build_state in ('failure', 'error') %}
+    <form action="{{ base_path }}/watched_branches/{{ wb.index }}/pr/{{ pr.number }}/retry" method="post">
+      <input type="hidden" name="_csrf" value="{{ csrf_token }}"/>
+      <input type="hidden" name="tactical" value="true"/>
+      <button type="submit">Tactical Retry</button>
+    </form>
+    <i class="material-icons text-icon" title="Retries only the steps that failed in all previous builds (with matching source and target SHAs), plus any dependencies.">help_outline</i>
+    {% endif %}
     {% endif %}
 
     {% if logging_queries is not none %}

--- a/ci/ci/templates/pr.html
+++ b/ci/ci/templates/pr.html
@@ -153,7 +153,7 @@
       <input type="hidden" name="_csrf" value="{{ csrf_token }}"/>
       <button type="submit">Retry</button>
     </form>
-    {% if pr.batch_is_up_to_date and pr.build_state in ('failure', 'error') %}
+    {% if pr.is_up_to_date() and pr.build_state in ('failure', 'error') %}
     <form action="{{ base_path }}/watched_branches/{{ wb.index }}/pr/{{ pr.number }}/retry" method="post">
       <input type="hidden" name="_csrf" value="{{ csrf_token }}"/>
       <input type="hidden" name="tactical" value="true"/>


### PR DESCRIPTION
## Change Description

Adds a secondary retry mode which bypasses tests which already previously passed (requiring the same source and target sha, to avoid bypassing tests after genuine code changes)

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Changes which PR tests CI automatically selects during retry

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
