### PR TITLE
[batch] Spinner replacing repeated log lines in gcp-create-worker-image.sh

### DIFF
--- a/batch/gcp-create-worker-image.sh
+++ b/batch/gcp-create-worker-image.sh
@@ -87,13 +87,36 @@ create_worker_image() {
         --zone=${ZONE}
 }
 
+wait_for_vm() {
+    local -a frames=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')
+    local i=0 last_poll=0 vm_status='RUNNING'
+    local start=$SECONDS
+
+    while [ "$vm_status" == "RUNNING" ]; do
+        if (( SECONDS - last_poll >= 5 )); then
+            vm_status=$(gcloud compute instances describe "$BUILDER" \
+                --project "$PROJECT" --zone "$ZONE" --format='value(status)' 2>/dev/null) || true
+            last_poll=$SECONDS
+        fi
+        local elapsed=$(( SECONDS - start ))
+        printf '\r  %s %s [%s] %dm %02ds  ' \
+            "${frames[i % ${#frames[@]}]}" "$BUILDER" "$vm_status" \
+            "$(( elapsed / 60 ))" "$(( elapsed % 60 ))"
+        i=$(( i + 1 ))
+        sleep 0.1
+    done
+
+    local elapsed=$(( SECONDS - start ))
+    printf '\r  ✓ %s done in %dm %02ds%30s\n' \
+        "$BUILDER" "$(( elapsed / 60 ))" "$(( elapsed % 60 ))" ''
+}
+
 main() {
     set -x
     create_build_image_instance
-    while [ "$(gcloud compute instances describe ${BUILDER} --project ${PROJECT} --zone ${ZONE} --format='value(status)')" == "RUNNING" ];
-    do
-        sleep 5
-    done
+    set +x
+    wait_for_vm
+    set -x
     create_worker_image
 }
 


### PR DESCRIPTION
## Change Description

Replaces a repeated log line with a wait_for_vm function that prints a basic spinner and then records how long the operation took in total.

Example of what the spinner looks like, replacing the old "every 5 second" printout:

<img width="400" height="24" alt="image" src="https://github.com/user-attachments/assets/241b6ebc-911f-485d-a50f-1f10562ae560" />


## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP
