### PR TITLE
[appsec] Exclude devbin directory from Codacy analysis

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,3 +1,4 @@
 ---
 exclude_paths:
+  - "**/devbin/**"
   - "**/test/**"


### PR DESCRIPTION
## Change Description

Stops codacy from checking devbin functions

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

