### PR TITLE
[appsec] fix codacy devbin skip rule

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,4 +1,4 @@
 ---
 exclude_paths:
-  - "**/devbin/**"
+  - "devbin/**"
   - "**/test/**"


### PR DESCRIPTION
## Change Description

Follow up to #15681. Fixes the incorrect glob - because devbin is at project root and has no preceding path to match `**/` at the start

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

