### PR TITLE
[ci] improve tactical retry button layout

### DIFF
--- a/ci/ci/templates/pr.html
+++ b/ci/ci/templates/pr.html
@@ -154,7 +154,7 @@
         <input type="hidden" name="_csrf" value="{{ csrf_token }}"/>
         <button type="submit">Retry</button>
       </form>
-      {% if pr.is_up_to_date() and pr.build_state in ('failure', 'error') %}
+      {% if pr.is_up_to_date() and pr.build_state in ('failure', 'error', 'canceled') %}
       <form action="{{ base_path }}/watched_branches/{{ wb.index }}/pr/{{ pr.number }}/retry" method="post">
         <input type="hidden" name="_csrf" value="{{ csrf_token }}"/>
         <input type="hidden" name="tactical" value="true"/>

--- a/ci/ci/templates/pr.html
+++ b/ci/ci/templates/pr.html
@@ -149,18 +149,20 @@
       <div>labels: {{ pr.labels|join(", ") }}</div>
     </div>
     {% if userdata['system_permissions']['manage_ci'] %}
-    <form action="{{ base_path }}/watched_branches/{{ wb.index }}/pr/{{ pr.number }}/retry" method="post">
-      <input type="hidden" name="_csrf" value="{{ csrf_token }}"/>
-      <button type="submit">Retry</button>
-    </form>
-    {% if pr.is_up_to_date() and pr.build_state in ('failure', 'error') %}
-    <form action="{{ base_path }}/watched_branches/{{ wb.index }}/pr/{{ pr.number }}/retry" method="post">
-      <input type="hidden" name="_csrf" value="{{ csrf_token }}"/>
-      <input type="hidden" name="tactical" value="true"/>
-      <button type="submit">Tactical Retry</button>
-    </form>
-    <i class="material-icons text-icon" title="Retries only the steps that failed in all previous builds (with matching source and target SHAs), plus any dependencies.">help_outline</i>
-    {% endif %}
+    <div style="display: flex; align-items: center; gap: 12px;">
+      <form action="{{ base_path }}/watched_branches/{{ wb.index }}/pr/{{ pr.number }}/retry" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrf_token }}"/>
+        <button type="submit">Retry</button>
+      </form>
+      {% if pr.is_up_to_date() and pr.build_state in ('failure', 'error') %}
+      <form action="{{ base_path }}/watched_branches/{{ wb.index }}/pr/{{ pr.number }}/retry" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrf_token }}"/>
+        <input type="hidden" name="tactical" value="true"/>
+        <button type="submit">Tactical Retry</button>
+      </form>
+      <i class="material-icons text-icon" title="Retries only the steps that failed in all previous builds (with matching source and target SHAs), plus any dependencies.">help_outline</i>
+      {% endif %}
+    </div>
     {% endif %}
 
     {% if logging_queries is not none %}


### PR DESCRIPTION
## Change Description

Shows tactical retry button for canceled batches too. And put the button on the same line as regular retry.

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Layout and gating changes to existing button

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
