### PR TITLE
[query] make Py4JBackend resilient to interrupts and dead JVMs

### DIFF
--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -6,6 +6,7 @@ from py4j.java_gateway import JavaGateway, JavaObject, Py4JJavaError
 from hail.backend.backend import fatal_error_from_java_error_triplet
 from hail.backend.py4j_backend import (
     Py4JBackend,
+    _log_suppress_shutdown_exceptions,
     raise_when_mismatched_hail_versions,
     start_py4j_gateway,
 )
@@ -73,5 +74,7 @@ class LocalBackend(Py4JBackend):
         super().__init__(jgateway.jvm, jbackend, flags, copy_log_on_error)
 
     def stop(self):
-        super().stop()
-        self._gateway.shutdown()
+        try:
+            super().stop()
+        finally:
+            _log_suppress_shutdown_exceptions(self._gateway.shutdown)

--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -1,15 +1,18 @@
 import abc
+import functools
 import glob
 import http.client
 import logging
 import sys
 import warnings
-from typing import Any, Dict, Mapping
+from typing import Any, Callable, Dict, Mapping
 
 import orjson
 import py4j
+import py4j.clientserver
 import requests
 from py4j.java_gateway import (
+    GatewayConnection,
     GatewayParameters,
     JavaGateway,
     JavaObject,
@@ -38,6 +41,47 @@ http.client._MAXLINE = 2**20
 
 _installed = False
 _original = None
+
+
+def _make_interrupt_safe(cls) -> None:
+    # An interrupt raised while blocked reading a py4j response (e.g.
+    # KeyboardInterrupt, or pytest-timeout's Failed, both BaseExceptions)
+    # leaves that response unread on the socket. py4j cleans up after
+    # Exception and KeyboardInterrupt only, so any other interrupt returns the
+    # connection to the pool (or leaves it bound to the thread under pyspark's
+    # ClientServer) and every subsequent command on it reads a stale,
+    # mismatched response. Closing the connection instead makes py4j open a
+    # fresh one for the next command.
+    original = cls.send_command
+    if getattr(original, '_hail_interrupt_safe', False):
+        return
+
+    @functools.wraps(original)
+    def send_command(self, command):
+        try:
+            return original(self, command)
+        except Exception:
+            raise
+        except BaseException:
+            self.close(reset=True)
+            raise
+
+    setattr(send_command, '_hail_interrupt_safe', True)
+    cls.send_command = send_command
+
+
+_make_interrupt_safe(GatewayConnection)
+_make_interrupt_safe(py4j.clientserver.ClientServerConnection)
+
+
+def _log_suppress_shutdown_exceptions(action: Callable[[], None]) -> None:
+    # Failures while tearing down a dead or unreachable JVM must not prevent
+    # the remaining shutdown steps from running, otherwise global state is
+    # left pointing at the defunct JVM and re-initialization is impossible.
+    try:
+        action()
+    except Exception:
+        logging.warning('ignoring error during Hail shutdown', exc_info=True)
 
 
 def start_py4j_gateway(*, max_heap_size: str | None = None) -> JavaGateway:
@@ -195,7 +239,7 @@ class Py4JBackend(Backend):
         install_exception_handler()
 
         self._initialize_flags(flags)
-        self._jhttp_server = self._jbackend.pyHttpServer()
+        self._jhttp_server = self._new_jhttp_server()
 
     def jvm(self) -> JVMView:
         return self._jvm
@@ -273,6 +317,15 @@ class Py4JBackend(Backend):
 
             raise err
 
+    def _new_jhttp_server(self) -> JavaObject:
+        server = self._jbackend.pyHttpServer()
+        if not isinstance(server, JavaObject):
+            raise FatalError(
+                'The Hail JVM is unreachable or its py4j connection is corrupted. '
+                'Call hl.stop() and hl.init() to recover.'
+            )
+        return server
+
     def _rpc(self, action, payload) -> bytes:
         data = orjson.dumps(payload)
         path = action_routes[action]
@@ -280,10 +333,11 @@ class Py4JBackend(Backend):
         def go():
             port = self._jhttp_server.port()
             try:
-                return requests.post(f'http://localhost:{port}{path}', data=data)
+                # No read timeout: queries may legitimately run for a long time.
+                return requests.post(f'http://localhost:{port}{path}', data=data, timeout=(5, None))
             except requests.exceptions.ConnectionError:
                 self._stop_jhttp_server()
-                self._jhttp_server = self._jbackend.pyHttpServer()
+                self._jhttp_server = self._new_jhttp_server()
                 raise
 
         resp = sync_retry_transient_errors(go)
@@ -355,14 +409,11 @@ class Py4JBackend(Backend):
         return self._parse_blockmatrix_ir(self._render_ir(ir))
 
     def _stop_jhttp_server(self):
-        try:
-            self._jhttp_server.close()
-        except requests.exceptions.ConnectionError:
-            pass
+        _log_suppress_shutdown_exceptions(lambda: self._jhttp_server.close())
 
     def stop(self):
         super().stop()
         self._stop_jhttp_server()
-        self._jbackend.close()
+        _log_suppress_shutdown_exceptions(lambda: self._jbackend.close())
         uninstall_exception_handler()
         self.fs = None

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -23,7 +23,7 @@ from hailtop.utils import async_to_blocking
 
 from ..fs.hadoop_fs import HadoopFS
 from .backend import local_jar_information
-from .py4j_backend import Py4JBackend, raise_when_mismatched_hail_versions
+from .py4j_backend import Py4JBackend, _log_suppress_shutdown_exceptions, raise_when_mismatched_hail_versions
 
 
 def _modify_spark_conf(conf: pyspark.SparkConf, key: str, update: Callable[[str | None], str]):
@@ -239,20 +239,23 @@ class SparkBackend(Py4JBackend):
         self.router_fs = None
 
     def stop(self):
-        if self._hail_managed_spark:
-            self._spark.stop()
-            super().stop()
-            SparkContext._gateway.shutdown()
+        try:
+            if self._hail_managed_spark:
+                _log_suppress_shutdown_exceptions(self._spark.stop)
+                super().stop()
+                _log_suppress_shutdown_exceptions(lambda: SparkContext._gateway.shutdown())
 
-            # clean up pyspark's global state to support
-            # re-init with different spark conf
-            with pyspark.SparkContext._lock:
-                pyspark.SparkContext._gateway = None
-                pyspark.SparkContext._jvm = None
-        else:
-            super().stop()
-
-        self.router_fs = None
+                # clean up pyspark's global state to support
+                # re-init with different spark conf; pyspark only does this
+                # itself when the JVM is still reachable
+                with pyspark.SparkContext._lock:
+                    pyspark.SparkContext._active_spark_context = None
+                    pyspark.SparkContext._gateway = None
+                    pyspark.SparkContext._jvm = None
+            else:
+                super().stop()
+        finally:
+            self.router_fs = None
 
     def from_spark(self, df, key):
         result_tuple = self._jbackend.pyFromDF(df._jdf, key)

--- a/hail/python/hail/context.py
+++ b/hail/python/hail/context.py
@@ -148,12 +148,13 @@ class HailContext(object):
 
     def stop(self):
         assert self._backend
-        self._backend.stop()
-        self._backend = None
-        Env._hc = None
-        Env._dummy_table = None
-        Env._seed_generator = None
-        hail.ir.clear_session_functions()
+        try:
+            self._backend.stop()
+        finally:
+            self._backend = None
+            Env._hc = None
+            Env._dummy_table = None
+            hail.ir.clear_session_functions()
 
 
 @typecheck(

--- a/hail/python/test/hail/backend/test_py4j_backend.py
+++ b/hail/python/test/hail/backend/test_py4j_backend.py
@@ -1,0 +1,85 @@
+import py4j.clientserver
+import pytest
+from py4j.java_gateway import GatewayConnection
+
+from hail.backend.py4j_backend import _log_suppress_shutdown_exceptions, _make_interrupt_safe
+
+pytestmark = pytest.mark.uninitialized
+
+
+class Interrupt(BaseException):
+    # Like pytest-timeout's Failed or KeyboardInterrupt: not an Exception,
+    # so it bypasses py4j's error handling in send_command.
+    pass
+
+
+def interrupt(*ignored):
+    raise Interrupt
+
+
+def fake_connection(handler):
+    # a fresh class per call: _make_interrupt_safe patches the class itself
+    class FakeConnection:
+        def __init__(self):
+            self.closed_with_reset = None
+
+        def send_command(self, command):
+            return handler(command)
+
+        def close(self, reset=False):
+            self.closed_with_reset = reset
+
+    _make_interrupt_safe(FakeConnection)
+    return FakeConnection()
+
+
+def test_interrupt_propagates():
+    connection = fake_connection(interrupt)
+    with pytest.raises(Interrupt):
+        connection.send_command('command')
+
+
+def test_interrupt_closes_the_connection():
+    connection = fake_connection(interrupt)
+    with pytest.raises(Interrupt):
+        connection.send_command('command')
+    assert connection.closed_with_reset is True
+
+
+def test_exceptions_do_not_close_the_connection():
+    def raise_value_error(command):
+        raise ValueError(command)
+
+    connection = fake_connection(raise_value_error)
+    with pytest.raises(ValueError):
+        connection.send_command('command')
+    assert connection.closed_with_reset is None
+
+
+def test_successful_commands_pass_through():
+    connection = fake_connection(lambda command: f'!yv{command}')
+    assert connection.send_command('command') == '!yvcommand'
+
+
+def test_patching_is_idempotent():
+    cls = type(fake_connection(lambda command: command))
+    patched = cls.send_command
+    _make_interrupt_safe(cls)
+    assert cls.send_command is patched
+
+
+@pytest.mark.parametrize('cls', [GatewayConnection, py4j.clientserver.ClientServerConnection])
+def test_py4j_connections_are_interrupt_safe(cls):
+    assert getattr(cls.send_command, '_hail_interrupt_safe', False)
+
+
+def test_log_suppress_shutdown_exceptions_swallows_exceptions():
+    def raise_value_error():
+        raise ValueError
+
+    _log_suppress_shutdown_exceptions(raise_value_error)
+
+
+def test_log_suppress_shutdown_exceptions_propagates_interrupts():
+    with pytest.raises(Interrupt):
+        _log_suppress_shutdown_exceptions(interrupt)

--- a/hail/python/test/hail/conftest.py
+++ b/hail/python/test/hail/conftest.py
@@ -104,6 +104,26 @@ def reset_global_randomness():
     Env.reset_global_randomness()
 
 
+def jvm_is_alive() -> bool:
+    # A verifiable round-trip: fails if the JVM is dead and returns a wrong
+    # answer if the py4j connection is desynchronized (e.g. by an interrupted
+    # test leaving an unread response on the socket).
+    try:
+        return Env.backend()._jvm.java.lang.Math.floorDiv(1729, 42) == 41
+    except Exception:
+        return False
+
+
+@pytest.fixture(autouse=True)
+def revive_dead_jvm(request):
+    from hail.backend.py4j_backend import Py4JBackend
+
+    if Env.is_fully_initialized() and isinstance(Env.backend(), Py4JBackend) and not jvm_is_alive():
+        log.warning('the Hail JVM died or its connection was corrupted; reinitializing')
+        hl_stop_for_test()
+        hl_init_for_test(backend=choose_backend(), app_name=request.node.name)
+
+
 test_results_key = StashKey[Dict[str, CollectReport]]()
 
 


### PR DESCRIPTION
I was fed-up-enough of timeouts in pytests when using a py4j backend that
I pointed claude at a test log. The result is a less noisy test log.
Timeouts may still happen, but the subsequent failures should be reduced.

Here's what claude came up with:

When an interrupt that is not a KeyboardInterrupt (e.g. pytest-timeout's
Failed, a plain BaseException) fires while python is blocked reading a
py4j response, py4j leaves the connection registered with the unread 
response still owed on the socket. Under pyspark's ClientServer, the main
thread then reuses that connection and every subsequent command reads a
stale, shifted response: java calls return values belonging to earlier
calls, manifesting as nonsense like "AttributeError: 'int' object has no
attribute 'port'" and "Py4JError: ... SparkSession does not exist in the
JVM". This is how one timed-out test poisons an entire pytest run.

- Patch GatewayConnection and ClientServerConnection so that any
  BaseException escaping send_command closes the connection; py4j
  transparently opens a fresh one for the next command.
- Make teardown best-effort: HailContext.stop() always clears global state,
  SparkBackend/LocalBackend/Py4JBackend.stop() log and ignore JVM-side
  failures so that hl.stop(); hl.init() can always recover from a dead
  or corrupted JVM.
- Fail fast with an actionable FatalError when pyHttpServer() returns
  garbage instead of a JavaObject, and add a connect timeout to the
  backend http requests.

This change does not affect the broad-managed batch service in gcp.