### PR TITLE
[batch] idempotent, order-independent create_job_groups

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1032,6 +1032,10 @@ WHERE batch_id = %s AND job_group_id = %s;
             query_name='insert_job_group_ancestors',
         )
 
+        # a parent contributes at least its self-row, so zero rows copied
+        # means the parent has not been created
+        if n_rows_inserted == 0:
+            raise web.HTTPBadRequest(reason=f'job group parent {parent_job_group_id} does not exist')
         if n_rows_inserted > MAX_JOB_GROUPS_DEPTH:
             raise web.HTTPBadRequest(reason='job group exceeded the maximum level of nesting')
 
@@ -1069,9 +1073,9 @@ async def _create_job_groups(db: Database, batch_id: int, update_id: int, user: 
 
     @transaction(db)
     async def insert(tx):
-        record = await tx.execute_and_fetchone(
+        update = await tx.execute_and_fetchone(
             """
-SELECT `state`, format_version, `committed`, start_job_group_id
+SELECT `state`, format_version, `committed`, start_job_group_id, batch_updates.n_job_groups
 FROM batch_updates
 INNER JOIN batches ON batch_updates.batch_id = batches.id
 WHERE batch_updates.batch_id = %s AND batch_updates.update_id = %s AND `user` = %s AND NOT deleted
@@ -1080,28 +1084,44 @@ LOCK IN SHARE MODE;
             (batch_id, update_id, user),
         )
 
-        if not record:
+        if not update:
             raise web.HTTPNotFound()
-        if record['committed']:
+        if update['committed']:
             raise web.HTTPBadRequest(reason=f'update {update_id} is already committed')
 
-        start_job_group_id = record['start_job_group_id']
+        n_allocated_job_groups = update['n_job_groups']
+        first_in_update_job_group_id = job_group_specs[0]['job_group_id']
+        last_in_update_job_group_id = job_group_specs[-1]['job_group_id']
+        if first_in_update_job_group_id < 1 or last_in_update_job_group_id > n_allocated_job_groups:
+            raise web.HTTPBadRequest(
+                reason=f'job group ids [{first_in_update_job_group_id}, {last_in_update_job_group_id}] are out of range '
+                f'[1, {n_allocated_job_groups}] allocated by update {update_id}'
+            )
 
-        last_inserted_job_group_id = await tx.execute_and_fetchone(
+        start_job_group_id = update['start_job_group_id']
+        first_new_job_group_id = start_job_group_id + first_in_update_job_group_id - 1
+        last_new_job_group_id = start_job_group_id + last_in_update_job_group_id - 1
+
+        # specs are validated to have contiguous ids, so a range count equal to
+        # len(job_group_specs) means every spec in this request was inserted
+        n_existing = await tx.execute_and_fetchone(
             """
-SELECT job_group_id
+SELECT COUNT(*) AS n
 FROM job_groups
-WHERE batch_id = %s
-ORDER BY job_group_id DESC
-LIMIT 1
-FOR UPDATE;
+WHERE batch_id = %s AND update_id = %s AND job_group_id BETWEEN %s AND %s;
 """,
-            (batch_id,),
+            (batch_id, update_id, first_new_job_group_id, last_new_job_group_id),
         )
 
-        next_job_group_id = start_job_group_id + job_group_specs[0]['job_group_id'] - 1
-        if next_job_group_id != last_inserted_job_group_id['job_group_id'] + 1:
-            raise web.HTTPBadRequest(reason='job group specs were not submitted in order')
+        if n_existing['n'] == len(job_group_specs):
+            # the bunch was already inserted (bunches insert atomically); the
+            # client retried after losing the response
+            return web.Response()
+        if n_existing['n'] != 0:
+            raise web.HTTPBadRequest(
+                reason=f'{n_existing["n"]} of {len(job_group_specs)} job groups '
+                f'in this request already exist in update {update_id}'
+            )
 
         now = time_msecs()
 
@@ -1129,14 +1149,23 @@ FOR UPDATE;
                 )
             except asyncio.CancelledError:
                 raise
+            except pymysql.err.IntegrityError:
+                raise
             except Exception as e:
                 raise web.HTTPBadRequest(
                     reason=f'error while inserting job group {spec["job_group_id"]} into batch {batch_id}: {e}'
                 )
 
-    await insert()
+        return web.Response()
 
-    return web.Response()
+    try:
+        return await insert()
+    except pymysql.err.IntegrityError as err:
+        if err.args[0] != 1062:  # ER_DUP_ENTRY
+            raise
+        # lost a race with a concurrent retry of this bunch; re-enter to
+        # observe the winner's rows and no-op
+        return await insert()
 
 
 async def _create_jobs(
@@ -1157,7 +1186,7 @@ async def _create_jobs(
 
     record = await db.select_and_fetchone(
         """
-SELECT `state`, format_version, `committed`, start_job_id, start_job_group_id
+SELECT `state`, format_version, `committed`, start_job_id, start_job_group_id, batch_updates.n_jobs
 FROM batch_updates
 INNER JOIN batches ON batch_updates.batch_id = batches.id
 WHERE batch_updates.batch_id = %s AND batch_updates.update_id = %s AND user = %s AND NOT deleted;
@@ -1173,6 +1202,15 @@ WHERE batch_updates.batch_id = %s AND batch_updates.update_id = %s AND user = %s
     batch_format_version = BatchFormatVersion(record['format_version'])
     update_start_job_id = int(record['start_job_id'])
     update_start_job_group_id = int(record['start_job_group_id'])
+
+    n_allocated_jobs = int(record['n_jobs'])
+    in_update_job_ids = [spec['job_id'] for spec in job_specs]
+    min_in_update_id, max_in_update_id = min(in_update_job_ids), max(in_update_job_ids)
+    if min_in_update_id < 1 or max_in_update_id > n_allocated_jobs:
+        raise web.HTTPBadRequest(
+            reason=f'job ids [{min_in_update_id}, {max_in_update_id}] are out of range '
+            f'[1, {n_allocated_jobs}] allocated by update {update_id}'
+        )
 
     spec_writer = SpecWriter(file_store, batch_id)
 
@@ -2241,6 +2279,20 @@ WHERE batches.user = %s AND batches.id = %s AND batch_updates.update_id = %s AND
 
 async def _commit_update(app: web.Application, batch_id: int, update_id: int, user: str, db: Database):
     client_session = app[CommonAiohttpAppKeys.CLIENT_SESSION]
+
+    record = await db.select_and_fetchone(
+        """
+SELECT n_job_groups,
+  (SELECT COUNT(*) FROM job_groups WHERE batch_id = %s AND update_id = %s) AS n_created
+FROM batch_updates
+WHERE batch_id = %s AND update_id = %s;
+""",
+        (batch_id, update_id, batch_id, update_id),
+    )
+    if record and record['n_created'] != record['n_job_groups']:
+        raise web.HTTPBadRequest(
+            reason=f'wrong number of job groups: expected {record["n_job_groups"]}, actual {record["n_created"]}'
+        )
 
     try:
         now = time_msecs()

--- a/batch/test/test_batch.py
+++ b/batch/test/test_batch.py
@@ -2262,6 +2262,160 @@ async def test_get_and_cancel_job_group_with_unsubmitted_job_group_updates(async
         await b.cancel()
 
 
+async def test_resubmit_job_group_bunch_is_idempotent(async_client: AioBatchClient):
+    b = create_batch(async_client)
+    await b.submit()
+
+    try:
+        n_job_groups = 3
+        for _ in range(n_job_groups):
+            b.create_job_group()
+        update_id = await b._create_update()
+
+        url = f'/api/v1alpha/batches/{b.id}/updates/{update_id}/job-groups/create'
+        specs = [{'job_group_id': i, 'absolute_parent_id': 0} for i in range(1, n_job_groups + 1)]
+        await async_client._post(url, json=specs)
+        # a client that lost the response to a successful submission retries
+        # the same bunch; the resubmission must be a no-op
+        await async_client._post(url, json=specs)
+        await b._commit_update(update_id)
+
+        job_groups = [jg async for jg in b.job_groups()]
+        assert len(job_groups) == n_job_groups, str(await b.debug_info())
+    finally:
+        await b.cancel()
+
+
+async def test_submitting_job_groups_out_of_order_succeeds(async_client: AioBatchClient):
+    b = create_batch(async_client)
+    await b.submit()
+
+    try:
+        b.create_job_group()
+        b.create_job_group()
+        # the update allocates two job groups
+        update_id = await b._create_update()
+
+        url = f'/api/v1alpha/batches/{b.id}/updates/{update_id}/job-groups/create'
+        await async_client._post(url, json=[{'job_group_id': 2, 'absolute_parent_id': 0}])
+        await async_client._post(url, json=[{'job_group_id': 1, 'absolute_parent_id': 0}])
+        await b._commit_update(update_id)
+
+        job_groups = [jg async for jg in b.job_groups()]
+        assert len(job_groups) == 2, str(await b.debug_info())
+    finally:
+        await b.cancel()
+
+
+async def test_interleaved_job_group_updates(async_client: AioBatchClient):
+    b = create_batch(async_client)
+    await b.submit()
+
+    async def create_update() -> int:
+        resp = await async_client._post(
+            f'/api/v1alpha/batches/{b.id}/updates/create',
+            json={'n_jobs': 0, 'n_job_groups': 1, 'token': secrets.token_urlsafe(32)},
+        )
+        return int((await resp.json())['update_id'])
+
+    try:
+        update_a = await create_update()
+        update_b = await create_update()
+
+        # submit and commit the updates in the reverse order of their creation
+        for update_id in (update_b, update_a):
+            await async_client._post(
+                f'/api/v1alpha/batches/{b.id}/updates/{update_id}/job-groups/create',
+                json=[{'job_group_id': 1, 'absolute_parent_id': 0}],
+            )
+            await async_client._patch(f'/api/v1alpha/batches/{b.id}/updates/{update_id}/commit')
+
+        job_groups = [jg async for jg in b.job_groups()]
+        assert len(job_groups) == 2, str(await b.debug_info())
+    finally:
+        await b.cancel()
+
+
+async def test_commit_update_with_missing_job_groups_fails(async_client: AioBatchClient):
+    b = create_batch(async_client)
+    await b.submit()
+
+    try:
+        b.create_job_group()
+        b.create_job_group()
+        # the update allocates two job groups
+        update_id = await b._create_update()
+
+        await async_client._post(
+            f'/api/v1alpha/batches/{b.id}/updates/{update_id}/job-groups/create',
+            json=[{'job_group_id': 1, 'absolute_parent_id': 0}],
+        )
+
+        with pytest.raises(httpx.ClientResponseError, match='wrong number of job groups'):
+            await b._commit_update(update_id)
+    finally:
+        await b.cancel()
+
+
+async def test_create_job_group_with_missing_parent_fails(async_client: AioBatchClient):
+    b = create_batch(async_client)
+    await b.submit()
+
+    try:
+        b.create_job_group()
+        b.create_job_group()
+        # the update allocates two job groups
+        update_id = await b._create_update()
+
+        with pytest.raises(httpx.ClientResponseError, match='does not exist'):
+            await async_client._post(
+                f'/api/v1alpha/batches/{b.id}/updates/{update_id}/job-groups/create',
+                json=[{'job_group_id': 2, 'in_update_parent_id': 1}],
+            )
+    finally:
+        await b.cancel()
+
+
+async def test_submitting_more_job_groups_than_update_allocated_fails(async_client: AioBatchClient):
+    b = create_batch(async_client)
+    await b.submit()
+
+    try:
+        b.create_job_group()
+        # the update allocates exactly one job group
+        update_id = await b._create_update()
+
+        with pytest.raises(httpx.ClientResponseError, match='out of range'):
+            await async_client._post(
+                f'/api/v1alpha/batches/{b.id}/updates/{update_id}/job-groups/create',
+                json=[
+                    {'job_group_id': 1, 'absolute_parent_id': 0},
+                    {'job_group_id': 2, 'absolute_parent_id': 0},
+                ],
+            )
+    finally:
+        await b.cancel()
+
+
+async def test_submitting_more_jobs_than_update_allocated_fails(async_client: AioBatchClient):
+    b = create_batch(async_client)
+    await b.submit()
+
+    try:
+        b.create_job(DOCKER_ROOT_IMAGE, ['true'])
+        # the update allocates exactly one job
+        update_id = await b._create_update()
+
+        spec = b._job_specs[0]
+        with pytest.raises(httpx.ClientResponseError, match='out of range'):
+            await async_client._post(
+                f'/api/v1alpha/batches/{b.id}/updates/{update_id}/jobs/create',
+                json=[spec, {**spec, 'job_id': 2}],
+            )
+    finally:
+        await b.cancel()
+
+
 def test_billing_propogates_upwards(client: BatchClient):
     b = create_batch(client)
     jg = b.create_job_group()


### PR DESCRIPTION
Batch rejected repeat create-job-group requests after that job group had been created, and required job group bunches to arrive in strict batch-wide id order. This broke clients that retry after losing a response, and it serialized job-group creation across updates: an update could not create job groups until every earlier update had created all of its own.

This change makes job-group creation idempotent and order-independent:

- Requests are validated against the update's allocation: in-update ids must lie in `[1, n_job_groups]`. The analogous check is added for jobs against `batch_updates.n_jobs`.
- Duplicate detection is scoped to the update: a request whose id range is already fully present is a no-op (a retry after a lost response); a partially-present range is a 400.
- A concurrent retry of the same bunch that loses the insert race (`ER_DUP_ENTRY`) re-enters the transaction, observes the winner's rows, and no-ops.
- Creating a job group whose parent does not exist fails with a 400 instead of silently producing a group with no ancestry rows.
- Committing an update verifies that all declared job groups were created, mirroring the stored procedure's existing "wrong number of jobs" check.

The batch-wide "job group specs were not submitted in order" check and its `FOR UPDATE` lock on the max `job_group_id` are removed. Job groups in different updates no longer interact, enabling concurrent update submission against a shared batch (e.g. many query-on-batch drivers, each cancellable via its own job group).

Resolves #15568

## Security Assessment

This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP.

### Impact Rating

This change has a low security impact

### Impact Description

- Adds no new attack surface: all new logic runs after the existing user-scoped update lookup.
- Tightens validation: job and job group ids must be within the range their update allocated, so a client can no longer write rows into another update's id range.
- Removes a batch-wide `FOR UPDATE` lock in favour of update-scoped checks; requests for different updates no longer interact or serialize.
- Adds one `COUNT(*)` over a primary-key range per create-job-groups request and one per commit — negligible overhead.
- Caveat: duplicate detection matches on ids, not on the content of the request. A batch owner that retries with different content receives a 200 while the originally-submitted rows are kept, potentially invalidating the integrity of their own batch. This matches the existing behaviour for jobs.

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec

🤖 Generated with [Claude Code](https://claude.com/claude-code)
