### PR TITLE
[hailctl] update dataproc to 3.0.x images

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3771,90 +3771,90 @@ steps:
       - create_ci_test_repo
       - deploy_ci
       - test_ci
-  # - kind: runImage
-  #   name: test_dataproc-37
-  #   image:
-  #     valueFrom: ci_utils_image.image
-  #   resources:
-  #     preemptible: False
-  #   script: |
-  #     set -ex
+  - kind: runImage
+    name: test_dataproc-37
+    image:
+      valueFrom: ci_utils_image.image
+    resources:
+      preemptible: False
+    script: |
+      set -ex
 
-  #     cd /io/repo
+      cd /io/repo
 
-  #     gcloud auth activate-service-account --key-file=/test-dataproc-service-account-key/test-dataproc-service-account-key.json
-  #     gcloud config set project hail-vdc
-  #     gcloud config set dataproc/region us-central1
+      gcloud auth activate-service-account --key-file=/test-dataproc-service-account-key/test-dataproc-service-account-key.json
+      gcloud config set project hail-vdc
+      gcloud config set dataproc/region us-central1
 
-  #     cd hail
-  #     make test-dataproc-37 HAIL_BUILD_MODE=Release \
-  #         -o $(ls build/deploy/dist/hail-*-py3-none-any.whl)
-  #   dependsOn:
-  #     - ci_utils_image
-  #     - default_ns
-  #     - build_hail_jar_and_wheel
-  #     - test_install_in_isolation_python3_12
-  #     - upload_temporary_hailctl_artifacts
-  #   inputs:
-  #     - from: /repo
-  #       to: /io/repo
-  #     - from: /derived/release/hail/build/deploy/dist
-  #       to: /io/repo/hail/build/deploy/dist
-  #   secrets:
-  #     - name: test-dataproc-service-account-key
-  #       namespace:
-  #         valueFrom: default_ns.name
-  #       mountPath: /test-dataproc-service-account-key
-  #   scopes:
-  #     - deploy
-  #     - dev
-  #   forceIfLabeled:
-  #     - run-dataproc-tests
-  #   onlyIfRelease: true
-  #   clouds:
-  #     - gcp
-  # - kind: runImage
-  #   name: test_dataproc-38
-  #   image:
-  #     valueFrom: ci_utils_image.image
-  #   resources:
-  #     preemptible: False
-  #   script: |
-  #     set -ex
+      cd hail
+      make test-dataproc-37 HAIL_BUILD_MODE=Release \
+          -o $(ls build/deploy/dist/hail-*-py3-none-any.whl)
+    dependsOn:
+      - ci_utils_image
+      - default_ns
+      - build_hail_jar_and_wheel
+      - test_install_in_isolation_python3_12
+      - upload_temporary_hailctl_artifacts
+    inputs:
+      - from: /repo
+        to: /io/repo
+      - from: /derived/release/hail/build/deploy/dist
+        to: /io/repo/hail/build/deploy/dist
+    secrets:
+      - name: test-dataproc-service-account-key
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /test-dataproc-service-account-key
+    scopes:
+      - deploy
+      - dev
+    forceIfLabeled:
+      - run-dataproc-tests
+    onlyIfRelease: true
+    clouds:
+      - gcp
+  - kind: runImage
+    name: test_dataproc-38
+    image:
+      valueFrom: ci_utils_image.image
+    resources:
+      preemptible: False
+    script: |
+      set -ex
 
-  #     cd /io/repo
+      cd /io/repo
 
-  #     gcloud auth activate-service-account --key-file=/test-dataproc-service-account-key/test-dataproc-service-account-key.json
-  #     gcloud config set project hail-vdc
-  #     gcloud config set dataproc/region us-central1
+      gcloud auth activate-service-account --key-file=/test-dataproc-service-account-key/test-dataproc-service-account-key.json
+      gcloud config set project hail-vdc
+      gcloud config set dataproc/region us-central1
 
-  #     cd hail
-  #     make test-dataproc-38 HAIL_BUILD_MODE=Release \
-  #         -o $(ls build/deploy/dist/hail-*-py3-none-any.whl)
-  #   dependsOn:
-  #     - ci_utils_image
-  #     - default_ns
-  #     - build_hail_jar_and_wheel
-  #     - test_install_in_isolation_python3_12
-  #     - upload_temporary_hailctl_artifacts
-  #   inputs:
-  #     - from: /repo
-  #       to: /io/repo
-  #     - from: /derived/release/hail/build/deploy/dist
-  #       to: /io/repo/hail/build/deploy/dist
-  #   secrets:
-  #     - name: test-dataproc-service-account-key
-  #       namespace:
-  #         valueFrom: default_ns.name
-  #       mountPath: /test-dataproc-service-account-key
-  #   scopes:
-  #     - deploy
-  #     - dev
-  #   forceIfLabeled:
-  #     - run-dataproc-tests
-  #   onlyIfRelease: true
-  #   clouds:
-  #     - gcp
+      cd hail
+      make test-dataproc-38 HAIL_BUILD_MODE=Release \
+          -o $(ls build/deploy/dist/hail-*-py3-none-any.whl)
+    dependsOn:
+      - ci_utils_image
+      - default_ns
+      - build_hail_jar_and_wheel
+      - test_install_in_isolation_python3_12
+      - upload_temporary_hailctl_artifacts
+    inputs:
+      - from: /repo
+        to: /io/repo
+      - from: /derived/release/hail/build/deploy/dist
+        to: /io/repo/hail/build/deploy/dist
+    secrets:
+      - name: test-dataproc-service-account-key
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /test-dataproc-service-account-key
+    scopes:
+      - deploy
+      - dev
+    forceIfLabeled:
+      - run-dataproc-tests
+    onlyIfRelease: true
+    clouds:
+      - gcp
   - kind: runImage
     name: mirror_hailgenetics_images
     image: quay.io/skopeo/stable:v1.13.2

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -7,6 +7,7 @@ import orjson
 import pyspark
 import pyspark.sql
 from pyspark import SparkConf, SparkContext
+from pyspark.find_spark_home import _find_spark_home
 from pyspark.sql import SparkSession
 
 from hail.expr.table_type import ttable
@@ -35,14 +36,26 @@ def _append_delimited(*xs: str, sep: str) -> Callable[[str | None], str]:
     return lambda csv: sep.join(xs if csv is None else (csv, *xs))
 
 
+def _sparkmonitor_listener_jar() -> str:
+    from sparkmonitor import kernelextension
+
+    # sparkmonitor selects its listener jar by inspecting the jars in SPARK_HOME,
+    # which pip installations of pyspark don't always export
+    os.environ.setdefault('SPARK_HOME', _find_spark_home())
+    jar = kernelextension.get_listener_jar_path(*kernelextension.get_spark_versions())
+    if not jar:
+        raise ValueError(
+            f"sparkmonitor has no listener jar compatible with the Spark installation at '{os.environ['SPARK_HOME']}'"
+        )
+    return jar
+
+
 def _configure_spark_classpath(conf: SparkConf):
     info = local_jar_information()
     classpath = [info.hail_jar, *info.extra_classpath]
 
     if os.environ.get('HAIL_SPARK_MONITOR') or os.environ.get('AZURE_SPARK') == '1':
-        import sparkmonitor
-
-        classpath.append(os.path.join(os.path.dirname(sparkmonitor.__file__), 'listener.jar'))
+        classpath.append(_sparkmonitor_listener_jar())
         _modify_spark_conf(
             conf,
             'spark.extraListeners',
@@ -86,19 +99,20 @@ def _get_or_create_pyspark_session(
     # How we source and apply sparkconf depends on the execution environment.
     #
     # If hail is running in a python shell then we need to configure the driver
-    # and worker classpath before starting the jvm. Note that defaults are read
-    # after jvm initialisation and so specifying `loadDefaults=True` here has
-    # no effect.
+    # and worker classpath before starting the jvm: defaults are read after jvm
+    # initialisation; specifying `loadDefaults=True` here has no effect.
     #
     # If hail is running as a spark-submit job within a managed spark service
     # like dataproc, then the jvm has already been started and conf passed to
-    # `_ensure_initialized` is ignored.
+    # `_ensure_initialized` is ignored: Only jvm-launch settings (spark.jars,
+    # driver classpath, jvm options, etc) are fixed: conf applied at
+    # `SparkSession.Builder.getOrCreate` below still takes effect as the spark
+    # context does not exist yet.
     #
-    # Once the jvm has been initialised, we can load default values and apply
-    # configuration defined in python and scala. While we don't ship a
-    # spark-defaults.conf file with hail, users are free to supply and edit
-    # one. This is the mechanism used by the install_gcs_connector script to
-    # configure hadoop fs auth.
+    # If a spark context already exists (a pyspark-shell-based kernel), none of
+    # this conf applies and hail works only if the cluster's spark-defaults.conf
+    # carries hail's classpath. While we don't ship a spark-defaults.conf file
+    # with hail, users are free to supply and edit one, e.g. for hadoop fs auth.
     conf = SparkConf(loadDefaults=False).setAll(list((spark_conf or dict()).items()))
     _configure_spark_classpath(conf)
     SparkContext._ensure_initialized(conf=conf)

--- a/hail/python/hailtop/hailctl/dataproc/cli.py
+++ b/hail/python/hailtop/hailctl/dataproc/cli.py
@@ -80,7 +80,7 @@ def start(
     ctx: typer.Context,
     name: str,
     # arguments with default parameters
-    master_machine_type: Ann[str, Opt('--master-machine-type', '--master', '-m')] = 'n1-highmem-8',
+    master_machine_type: Ann[str, Opt('--master-machine-type', '--master', '-m')] = 'n2-highmem-8',
     master_memory_fraction: Ann[
         float,
         Opt(
@@ -106,7 +106,7 @@ def start(
         Opt(
             '--worker-machine-type',
             '--worker',
-            help='Worker machine type (default: n1-standard-8, or n1-highmem-8 with --vep).',
+            help='Worker machine type (default: n2-standard-8, or n2-highmem-8 with --vep).',
         ),
     ] = None,
     region: Ann[Optional[str], Opt(help='Compute region for the cluster.')] = None,
@@ -287,15 +287,14 @@ def connect(
     service: DataprocConnectService,
     pass_through_args: Ann[Optional[List[str]], Arg()] = None,
     project: ProjectOption = None,
-    port: Ann[str, Opt(help='Local port to use for SSH tunnel to leader (master) node')] = '10000',
     zone: ZoneOption = None,
     dry_run: DryRunOption = False,
 ):
     """
-    Connect to a running Dataproc cluster with name NAME and start
-    the web service SERVICE.
+    Connect to a running Dataproc cluster with name NAME and open
+    the web service SERVICE in a browser.
     """
-    dataproc_connect(name, service, project, port, zone, dry_run, pass_through_args or [])
+    dataproc_connect(name, service, project, zone, dry_run, pass_through_args or [])
 
 
 @app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})

--- a/hail/python/hailtop/hailctl/dataproc/connect.py
+++ b/hail/python/hailtop/hailctl/dataproc/connect.py
@@ -1,10 +1,6 @@
-import os
-import platform
-import shutil
-import subprocess
-import tempfile
+import json
+import webbrowser
 from enum import Enum
-from typing import List, Optional
 
 from . import gcloud
 
@@ -28,119 +24,60 @@ class DataprocConnectService(str, Enum):
         return self
 
 
-def get_datadir_path():
-    from hailtop.utils import secret_alnum_string  # pylint: disable=import-outside-toplevel
-
-    system = platform.system()
-    release = platform.uname().release
-    is_wsl = system == 'Linux' and ('Microsoft' in release or 'microsoft' in release)
-
-    if not is_wsl:
-        return os.path.join(tempfile.mkdtemp('hailctl-dataproc-connect-'))
-    return 'C:\\Temp\\hailctl-' + secret_alnum_string(5)
-
-
-def get_chrome_path():
-    system = platform.system()
-
-    if system == 'Darwin':
-        return '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
-
-    release = platform.uname().release
-    is_wsl = 'Microsoft' in release or 'microsoft' in release
-
-    if system == 'Linux' and not is_wsl:
-        for c in ['chromium', 'chromium-browser', 'chrome.exe']:
-            chrome = shutil.which(c)
-            if chrome:
-                return chrome
-
-        raise EnvironmentError("cannot find 'chromium', 'chromium-browser', or 'chrome.exe' on path")
-
-    if system == 'Windows' or (system == 'Linux' and is_wsl):
-        # https://stackoverflow.com/questions/40674914/google-chrome-path-in-windows-10
-        fnames = [
-            '/mnt/c/Program Files/Google/Chrome/Application/chrome.exe',
-            '/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe',
-            '/mnt/c/Program Files(x86)/Google/Chrome/Application/chrome.exe',
-            '/mnt/c/ProgramFiles(x86)/Google/Chrome/Application/chrome.exe',
-        ]
-
-        for fname in fnames:
-            if os.path.exists(fname):
-                return fname
-
-    raise ValueError(f"unsupported system: {system}, set environment variable HAILCTL_CHROME to a chrome executable")
+# component gateway endpoint and query string for each service; the spark ui
+# is the history server listing incomplete (running) applications
+GATEWAY_ENDPOINTS = {
+    DataprocConnectService.NOTEBOOK: ('JupyterLab', ''),
+    DataprocConnectService.SPARK_UI: ('Spark History Server', '?showIncomplete=true'),
+    DataprocConnectService.SPARK_HISTORY: ('Spark History Server', ''),
+}
 
 
 def connect(
     name: str,
     service: DataprocConnectService,
-    project: Optional[str],
-    port: str,
-    zone: Optional[str],
+    project: str | None,
+    zone: str | None,
     dry_run: bool,
-    pass_through_args: List[str],
+    pass_through_args: list[str],
 ):
-    service = service.shortcut()
+    endpoint, query = GATEWAY_ENDPOINTS[service.shortcut()]
 
-    # Dataproc port mapping
-    dataproc_port_and_path = {
-        DataprocConnectService.SPARK_UI: '18080/?showIncomplete=true',
-        DataprocConnectService.SPARK_HISTORY: '18080',
-        DataprocConnectService.NOTEBOOK: '8123',
-    }
-    connect_port_and_path = dataproc_port_and_path[service]
-
-    zone = zone if zone else gcloud.get_config("compute/zone")
-    if not zone:
-        raise RuntimeError(
-            "Could not determine compute zone. Use --zone argument to hailctl, or use `gcloud config set compute/zone <my-zone>` to set a default."
-        )
-
-    account = gcloud.get_config("account")
-    if account:
-        account = account[0 : account.find('@')]
-        ssh_login = '{}@{}-m'.format(account, name)
+    # component gateway urls are authenticated https; no ssh tunnel or
+    # browser proxy configuration is required
+    zone = zone if zone is not None else gcloud.get_config('compute/zone')
+    if zone is not None:
+        region = zone.rsplit('-', 1)[0]
     else:
-        ssh_login = '{}-m'.format(name)
+        region = gcloud.get_config('dataproc/region')
+        if region is None:
+            raise RuntimeError(
+                'Could not determine dataproc region.'
+                'Use `gcloud config set dataproc/region <my-region>` to set a default.'
+            )
 
     cmd = [
-        'compute',
-        'ssh',
-        ssh_login,
-        '--zone={}'.format(zone),
-        '--ssh-flag=-D {}'.format(port),
-        '--ssh-flag=-N',
-        '--ssh-flag=-f',
-        '--ssh-flag=-n',
+        'dataproc',
+        'clusters',
+        'describe',
+        name,
+        f'--region={region}',
+        '--format=json(config.endpointConfig.httpPorts)',
         *pass_through_args,
     ]
-
     if project:
-        cmd.append(f"--project={project}")
+        cmd.append(f'--project={project}')
 
-    print('gcloud command:')
-    print(' '.join(cmd[:4]) + ' \\\n    ' + ' \\\n    '.join([f"'{x}'" for x in cmd[4:]]))
+    print('gcloud ' + ' '.join(cmd))
+    if dry_run:
+        return
 
-    if not dry_run:
-        print("Connecting to cluster '{}'...".format(name))
-
-        # open SSH tunnel to master node
-        gcloud.run(cmd)
-
-        chrome = os.environ.get('HAILCTL_CHROME') or get_chrome_path()
-        data_dir = os.environ.get('HAILCTL_CHROME_DATA_DIR') or get_datadir_path()
-
-        # open Chrome with SOCKS proxy configuration
-        with subprocess.Popen(
-            [  # pylint: disable=consider-using-with
-                chrome,
-                f'http://{name}-m:{connect_port_and_path}',
-                f'--proxy-server=socks5://localhost:{port}',
-                f'--user-data-dir={data_dir}',
-            ],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        ):
-            pass
+    described = json.loads(gcloud.output(cmd)) or {}
+    http_ports = described.get('config', {}).get('endpointConfig', {}).get('httpPorts', {})
+    url = http_ports.get(endpoint)
+    if not url:
+        raise RuntimeError(
+            f"Could not find the '{endpoint}' component gateway url for cluster '{name}'. "
+            "Was the cluster created with --enable-component-gateway?"
+        )
+    webbrowser.open(url + query)

--- a/hail/python/hailtop/hailctl/dataproc/gcloud.py
+++ b/hail/python/hailtop/hailctl/dataproc/gcloud.py
@@ -1,12 +1,43 @@
 import json
+import re
 import subprocess
 import sys
 from typing import List, Optional, Tuple
+
+CUSTOM_MACHINE_TYPE = re.compile(r"(?:[a-z0-9]+-)?custom-(\d+)-(\d+)(?:-ext)?")
 
 
 def run(command: List[str]):
     """Run a gcloud command."""
     return subprocess.check_call(["gcloud", *command])
+
+
+def output(command: List[str]) -> str:
+    """Run a gcloud command and return its stdout."""
+    return subprocess.check_output(["gcloud", *command]).decode()
+
+
+def get_machine_type_info(machine_type: str) -> Tuple[int, float]:
+    """Get the vCPU count and advertised memory (GiB) of a machine type."""
+    custom = CUSTOM_MACHINE_TYPE.fullmatch(machine_type)
+    if custom:
+        return int(custom.group(1)), int(custom.group(2)) / 1024
+    output = subprocess.check_output(
+        [
+            "gcloud",
+            "compute",
+            "machine-types",
+            "list",
+            f"--filter=name={machine_type}",
+            "--limit=1",
+            "--format=json",
+        ],
+        stderr=subprocess.DEVNULL,
+    )
+    machine_types = json.loads(output)
+    if not machine_types:
+        raise RuntimeError(f"machine type '{machine_type}' not found")
+    return machine_types[0]["guestCpus"], machine_types[0]["memoryMb"] / 1024
 
 
 def get_config(setting: str) -> Optional[str]:

--- a/hail/python/hailtop/hailctl/dataproc/modify.py
+++ b/hail/python/hailtop/hailctl/dataproc/modify.py
@@ -86,12 +86,13 @@ def modify(
                 '--zone={}'.format(zone),
                 '--',
                 f'sudo gsutil cp {wheel} /tmp/ && '
-                'sudo /opt/conda/default/bin/pip uninstall -y hail && '
-                f'sudo /opt/conda/default/bin/pip install --no-dependencies /tmp/{wheelfile} && '
+                'python3=$(command -v python3) && '
+                'sudo "$python3" -m pip uninstall -y hail && '
+                f'sudo "$python3" -m pip install --no-dependencies /tmp/{wheelfile} && '
                 f"unzip /tmp/{wheelfile} && "
                 "requirements_file=$(mktemp) && "
                 "grep 'Requires-Dist: ' hail*dist-info/METADATA | sed 's/Requires-Dist: //' | sed 's/ (//' | sed 's/)//' | grep -v 'pyspark' >$requirements_file &&"
-                "/opt/conda/default/bin/pip install -r $requirements_file",
+                '"$python3" -m pip install -r $requirements_file',
             ])
         else:
             cmds.extend([
@@ -102,12 +103,13 @@ def modify(
                     f'{name}-m',
                     f'--zone={zone}',
                     '--',
-                    'sudo /opt/conda/default/bin/pip uninstall -y hail && '
-                    f'sudo /opt/conda/default/bin/pip install --no-dependencies /tmp/{wheelfile} && '
+                    'python3=$(command -v python3) && '
+                    'sudo "$python3" -m pip uninstall -y hail && '
+                    f'sudo "$python3" -m pip install --no-dependencies /tmp/{wheelfile} && '
                     f"unzip /tmp/{wheelfile} && "
                     "requirements_file=$(mktemp) && "
                     "grep 'Requires-Dist: ' hail*dist-info/METADATA | sed 's/Requires-Dist: //' | sed 's/ (//' | sed 's/)//' | grep -v 'pyspark' >$requirements_file &&"
-                    "/opt/conda/default/bin/pip install -r $requirements_file",
+                    '"$python3" -m pip install -r $requirements_file',
                 ],
             ])
 

--- a/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
+++ b/hail/python/hailtop/hailctl/dataproc/resources/init_notebook.py
@@ -4,9 +4,16 @@ import json
 import os
 import subprocess as sp
 import sys
-from subprocess import check_output
+import sysconfig
+import urllib.request
 
-assert sys.version_info > (3, 0), sys.version_info
+assert sys.version_info > (3, 12), sys.version_info
+
+# Dataproc 3.0 images manage the default Python environment with pixi rather
+# than conda, and neither layout is a documented interface. Derive every path
+# from the interpreter running this init action instead of hard-coding either.
+python_exe = os.path.realpath(sys.executable)
+env_prefix = sys.prefix
 
 
 def safe_call(*args, **kwargs):
@@ -17,8 +24,12 @@ def safe_call(*args, **kwargs):
         raise e
 
 
+def pip_install(*args):
+    safe_call(python_exe, '-m', 'pip', 'install', *args)
+
+
 def get_metadata(key):
-    return check_output(['/usr/share/google/get_metadata_value', 'attributes/{}'.format(key)]).decode()
+    return sp.check_output(['/usr/share/google/get_metadata_value', f'attributes/{key}']).decode()
 
 
 def mkdir_if_not_exists(path):
@@ -29,32 +40,49 @@ def mkdir_if_not_exists(path):
             raise
 
 
+# netlib's bundled jni shims link the system blas, lapack and arpack; the
+# image ships openblas but not arpack, so jvm eigensolvers fall back to java
+safe_call('apt-get', 'update', '-qq')
+safe_call('apt-get', 'install', '-qq', '-y', 'libarpack2')
+
 # get role of machine (master or worker)
 role = get_metadata('dataproc-role')
 
 if role == 'Master':
-    # additional packages to install
-    pip_pkgs = [
-        'mkl',
-        'lxml',
-        'https://github.com/hail-is/jgscm/archive/v0.1.13+hail.zip',
-        'ipykernel==6.29.2',
-        'jupyter-console==6.6.3',
-        'qtconsole==5.6.1',
-    ]
+    # install hail's dependencies and user-requested packages
+    pkgs = get_metadata('PKGS').split('|')
+    print(f'pip packages are {pkgs}')
+    pip_install(*pkgs)
 
-    # add user-requested packages
-    try:
-        user_pkgs = get_metadata('PKGS')
-    except Exception:
-        pass
-    else:
-        pip_pkgs.extend(user_pkgs.split('|'))
+    # sparkmonitor renders spark job progress in jupyter notebooks. Its kernel
+    # extension crashes if spark events arrive before the jupyterlab frontend
+    # opens its comm channel; apply the proposed patch until it is released.
+    pip_install('sparkmonitor==3.3.0')
+    urllib.request.urlretrieve(
+        'https://github.com/swan-cern/sparkmonitor/commit/28e39fc0d6ee910dc40c791528f9e3a23ea543ad.patch',
+        '/tmp/sparkmonitor.patch',
+    )
+    safe_call(
+        'git',
+        'apply',
+        '--include=sparkmonitor/*',
+        '/tmp/sparkmonitor.patch',
+        cwd=sysconfig.get_paths()['purelib'],
+    )
 
-    print('pip packages are {}'.format(pip_pkgs))
-    command = ['pip', 'install']
-    command.extend(pip_pkgs)
-    safe_call(*command)
+    # gcs-jupyter-plugin adds a cloud storage browser to jupyterlab, listing
+    # the project's buckets and writing edits back to gcs. its stale pins
+    # (aiohttp~=3.9.5, pydantic~=1.10, ...) conflict with hail's requirements
+    # but newer versions satisfy it in practice, so skip dependency resolution
+    pip_install('google-cloud-jupyter-config')
+    pip_install('--no-deps', 'gcs-jupyter-plugin')
+
+    # the cloud storage browser requires gcloud be configured with an account,
+    # project and region; dataproc images configure all but the region
+    zone = sp.check_output(['/usr/share/google/get_metadata_value', 'zone']).decode().rsplit('/', 1)[-1]
+    region = zone.rsplit('-', 1)[0]
+    safe_call('gcloud', 'config', 'set', 'compute/region', region)
+    safe_call('gcloud', 'config', 'set', 'dataproc/region', region)
 
     print('getting metadata')
 
@@ -64,19 +92,17 @@ if role == 'Master':
     print('copying wheel')
     safe_call('gcloud', 'storage', 'cp', wheel_path, f'/home/hail/{wheel_name}')
 
-    safe_call('pip', 'install', '--no-dependencies', f'/home/hail/{wheel_name}')
+    pip_install('--no-dependencies', f'/home/hail/{wheel_name}')
 
     print('setting environment')
 
-    spark_lib_base = '/usr/lib/spark/python/lib/'
-    files_to_add = [os.path.join(spark_lib_base, x) for x in os.listdir(spark_lib_base) if x.endswith('.zip')]
+    # dataproc images install spark at /usr/lib/spark; prefer SPARK_HOME when
+    # the environment provides it
+    spark_home = os.environ.get('SPARK_HOME', '/usr/lib/spark').rstrip('/')
 
     env_to_set = {
         'PYTHONHASHSEED': '0',
-        'PYTHONPATH': ':'.join(files_to_add),
-        'SPARK_HOME': '/usr/lib/spark/',
-        'PYSPARK_PYTHON': '/opt/conda/default/bin/python',
-        'PYSPARK_DRIVER_PYTHON': '/opt/conda/default/bin/python',
+        'PYSPARK_PYTHON': python_exe,
         'HAIL_LOG_DIR': '/home/hail',
         'HAIL_DATAPROC': '1',
     }
@@ -89,31 +115,31 @@ if role == 'Master':
     else:
         env_to_set["VEP_CONFIG_URI"] = vep_config_uri
 
-    print('setting environment')
+    # spark-env.sh is sourced by spark-submit, delivering these to jobs;
+    # /etc/environment is read by pam for ssh sessions
+    with open(os.path.join(spark_home, 'conf', 'spark-env.sh'), 'a') as f:
+        f.writelines(f'export {e}={value}\n' for e, value in env_to_set.items())
 
-    for e, value in env_to_set.items():
-        safe_call(
-            '/bin/sh',
-            '-c',
-            'set -ex; echo "export {}={}" | tee -a /etc/environment /usr/lib/spark/conf/spark-env.sh'.format(e, value),
-        )
+    # /etc/environment entries must be KEY=VALUE
+    with open('/etc/environment', 'a') as f:
+        f.writelines(f'{e}={value}\n' for e, value in env_to_set.items())
 
-    hail_jar = (
-        sp.check_output(['/bin/sh', '-c', 'set -ex; python3 -m pip show hail | grep Location | sed "s/Location: //"'])
-        .decode('ascii')
-        .strip()
-        + '/hail/backend/hail-all-spark.jar'
+    hail_location = next(
+        line.removeprefix('Location: ').strip()
+        for line in sp.check_output([python_exe, '-m', 'pip', 'show', 'hail']).decode().splitlines()
+        if line.startswith('Location: ')
     )
+
+    hail_jar = hail_location + '/hail/backend/hail-all-spark.jar'
 
     if not os.path.exists(hail_jar):
         raise ValueError(f'{hail_jar} must exist')
 
     conf_to_set = [
         'spark.executorEnv.PYTHONHASHSEED=0',
-        'spark.app.name=Hail',
         # the below are necessary to make 'submit' work
-        'spark.jars={}'.format(hail_jar),
-        'spark.driver.extraClassPath={}'.format(hail_jar),
+        f'spark.jars={hail_jar}',
+        f'spark.driver.extraClassPath={hail_jar}',
         'spark.executor.extraClassPath=./hail-all-spark.jar',
     ]
 
@@ -127,84 +153,44 @@ if role == 'Master':
 
     # Update python3 kernel spec with the environment variables and the hail
     # spark monitor
+    kernels_dir = os.path.join(env_prefix, 'share', 'jupyter', 'kernels')
     try:
-        with open('/opt/conda/default/share/jupyter/kernels/python3/kernel.json', 'r') as f:
+        with open(os.path.join(kernels_dir, 'python3', 'kernel.json'), 'r') as f:
             python3_kernel = json.load(f)
+            assert isinstance(python3_kernel, dict)
     except:
         python3_kernel = {
-            'argv': ['/opt/conda/default/bin/python', '-m', 'ipykernel', '-f', '{connection_file}'],
+            'argv': [python_exe, '-m', 'ipykernel', '-f', '{connection_file}'],
             'display_name': 'Python 3',
             'language': 'python',
         }
+
+    spark_lib_base = os.path.join(spark_home, 'python', 'lib')
+    files_to_add = [os.path.join(spark_lib_base, x) for x in os.listdir(spark_lib_base) if x.endswith('.zip')]
     python3_kernel['env'] = {
         **python3_kernel.get('env', dict()),
         **env_to_set,
+        # spark constructs PYTHONPATH for the python processes it launches;
+        # the kernel is a plain python process, so needs pyspark on its path
+        'PYTHONPATH': ':'.join(files_to_add),
         'HAIL_SPARK_MONITOR': '1',
-        'SPARK_MONITOR_UI': 'http://localhost:8088/proxy/%APP_ID%',
     }
 
     # write python3 kernel spec file to default Jupyter kernel directory
-    mkdir_if_not_exists('/opt/conda/default/share/jupyter/kernels/python3/')
-    with open('/opt/conda/default/share/jupyter/kernels/python3/kernel.json', 'w') as f:
+    mkdir_if_not_exists(os.path.join(kernels_dir, 'python3'))
+    with open(os.path.join(kernels_dir, 'python3', 'kernel.json'), 'w') as f:
         json.dump(python3_kernel, f)
 
-    # some old notebooks use the "Hail" kernel, so create that too
-    hail_kernel = {**python3_kernel, 'display_name': 'Hail'}
-    mkdir_if_not_exists('/opt/conda/default/share/jupyter/kernels/hail/')
-    with open('/opt/conda/default/share/jupyter/kernels/hail/kernel.json', 'w') as f:
-        json.dump(hail_kernel, f)
+    # sparkmonitor's frontend is a prebuilt jupyterlab extension, active on
+    # install; the kernel side must be enabled in the ipython kernel config.
+    # /etc/ipython applies whatever user the kernel runs as
+    mkdir_if_not_exists('/etc/ipython')
+    with open('/etc/ipython/ipython_kernel_config.py', 'a') as f:
+        f.write("c.InteractiveShellApp.extensions.append('sparkmonitor.kernelextension')\n")
 
-    # create Jupyter configuration file
-    mkdir_if_not_exists('/opt/conda/default/etc/jupyter/')
-    with open('/opt/conda/default/etc/jupyter/jupyter_notebook_config.py', 'w') as f:
-        opts = [
-            'c.Application.log_level = "DEBUG"',
-            'c.NotebookApp.ip = "0.0.0.0"',
-            'c.NotebookApp.open_browser = False',
-            'c.NotebookApp.port = 8123',
-            'c.NotebookApp.token = ""',
-            'c.NotebookApp.contents_manager_class = "jgscm.GoogleStorageContentManager"',
-        ]
-        f.write('\n'.join(opts) + '\n')
-
-    print('copying spark monitor')
-    spark_monitor_gs = (
-        'gs://hail-common/sparkmonitor-c1289a19ac117336fec31ec08a2b13afe7e420cf/sparkmonitor-0.0.12-py3-none-any.whl'
-    )
-    spark_monitor_wheel = '/home/hail/' + spark_monitor_gs.split('/')[-1]
-    safe_call('gcloud', 'storage', 'cp', spark_monitor_gs, spark_monitor_wheel)
-    safe_call('pip', 'install', spark_monitor_wheel)
-
-    # setup jupyter-spark extension
-    safe_call('/opt/conda/default/bin/jupyter', 'serverextension', 'enable', '--user', '--py', 'sparkmonitor')
-    safe_call('/opt/conda/default/bin/jupyter', 'nbextension', 'install', '--user', '--py', 'sparkmonitor')
-    safe_call('/opt/conda/default/bin/jupyter', 'nbextension', 'enable', '--user', '--py', 'sparkmonitor')
-    safe_call('/opt/conda/default/bin/jupyter', 'nbextension', 'enable', '--user', '--py', 'widgetsnbextension')
-    safe_call(
-        """ipython profile create && echo "c.InteractiveShellApp.extensions.append('sparkmonitor.kernelextension')" >> $(ipython profile locate default)/ipython_kernel_config.py""",
-        shell=True,
-    )
-
-    # create systemd service file for Jupyter notebook server process
-    with open('/lib/systemd/system/jupyter.service', 'w') as f:
-        opts = [
-            '[Unit]',
-            'Description=Jupyter Notebook',
-            'After=hadoop-yarn-resourcemanager.service',
-            '[Service]',
-            'Type=simple',
-            'User=root',
-            'Group=root',
-            'WorkingDirectory=/home/hail/',
-            'ExecStart=/opt/conda/default/bin/python /opt/conda/default/bin/jupyter notebook --allow-root',
-            'Restart=always',
-            'RestartSec=1',
-            '[Install]',
-            'WantedBy=multi-user.target',
-        ]
-        f.write('\n'.join(opts) + '\n')
-
-    # add Jupyter service to autorun and start it
-    safe_call('systemctl', 'daemon-reload')
-    safe_call('systemctl', 'enable', 'jupyter')
-    safe_call('service', 'jupyter', 'start')
+    # the jupyter optional component's server starts before init actions run;
+    # restart it to pick up the hail kernel specs and sparkmonitor labextension
+    try:
+        safe_call('systemctl', 'restart', 'jupyter')
+    except sp.CalledProcessError:
+        print('warning: failed to restart the jupyter component service')

--- a/hail/python/hailtop/hailctl/dataproc/start.py
+++ b/hail/python/hailtop/hailctl/dataproc/start.py
@@ -20,116 +20,14 @@ DEFAULT_PROPERTIES = {
     'spark:spark.speculation': 'true',
     "hdfs:dfs.replication": "1",
     'dataproc:dataproc.logging.stackdriver.enable': 'false',
-    'dataproc:dataproc.monitoring.stackdriver.enable': 'false',
 }
 
-# leadre (master) machine type to memory map, used for setting
-# spark.driver.memory property
-MACHINE_MEM = {
-    'n1-standard-1': 3.75,
-    'n1-standard-2': 7.5,
-    'n1-standard-4': 15,
-    'n1-standard-8': 30,
-    'n1-standard-16': 60,
-    'n1-standard-32': 120,
-    'n1-standard-64': 240,
-    'n1-highmem-2': 13,
-    'n1-highmem-4': 26,
-    'n1-highmem-8': 52,
-    'n1-highmem-16': 104,
-    'n1-highmem-32': 208,
-    'n1-highmem-64': 416,
-    'n1-highcpu-2': 1.8,
-    'n1-highcpu-4': 3.6,
-    'n1-highcpu-8': 7.2,
-    'n1-highcpu-16': 14.4,
-    'n1-highcpu-32': 28.8,
-    'n1-highcpu-64': 57.6,
-    'n2-standard-2': 8,
-    'n2-standard-4': 16,
-    'n2-standard-8': 32,
-    'n2-standard-16': 64,
-    'n2-standard-32': 128,
-    'n2-standard-48': 192,
-    'n2-standard-64': 256,
-    'n2-standard-80': 320,
-    'n2-highmem-2': 16,
-    'n2-highmem-4': 32,
-    'n2-highmem-8': 64,
-    'n2-highmem-16': 128,
-    'n2-highmem-32': 256,
-    'n2-highmem-48': 384,
-    'n2-highmem-64': 512,
-    'n2-highmem-80': 640,
-    'n2-highcpu-2': 2,
-    'n2-highcpu-4': 4,
-    'n2-highcpu-8': 8,
-    'n2-highcpu-16': 16,
-    'n2-highcpu-32': 32,
-    'n2-highcpu-48': 48,
-    'n2-highcpu-64': 64,
-    'n2-highcpu-80': 80,
-    'n2d-standard-2': 8,
-    'n2d-standard-4': 16,
-    'n2d-standard-8': 32,
-    'n2d-standard-16': 64,
-    'n2d-standard-32': 128,
-    'n2d-standard-48': 192,
-    'n2d-standard-64': 256,
-    'n2d-standard-80': 320,
-    'n2d-standard-96': 384,
-    'n2d-standard-128': 512,
-    'n2d-standard-224': 896,
-    'n2d-highmem-2': 16,
-    'n2d-highmem-4': 32,
-    'n2d-highmem-8': 64,
-    'n2d-highmem-16': 128,
-    'n2d-highmem-32': 256,
-    'n2d-highmem-48': 384,
-    'n2d-highmem-64': 512,
-    'n2d-highmem-80': 640,
-    'n2d-highmem-96': 786,
-    'n2d-highcpu-2': 2,
-    'n2d-highcpu-4': 4,
-    'n2d-highcpu-8': 8,
-    'n2d-highcpu-16': 16,
-    'n2d-highcpu-32': 32,
-    'n2d-highcpu-48': 48,
-    'n2d-highcpu-64': 64,
-    'n2d-highcpu-80': 80,
-    'n2d-highcpu-96': 96,
-    'n2d-highcpu-128': 128,
-    'n2d-highcpu-224': 224,
-    'e2-standard-2': 8,
-    'e2-standard-4': 16,
-    'e2-standard-8': 32,
-    'e2-standard-16': 64,
-    'e2-highmem-2': 16,
-    'e2-highmem-4': 32,
-    'e2-highmem-8': 64,
-    'e2-highmem-16': 128,
-    'e2-highcpu-2': 2,
-    'e2-highcpu-4': 4,
-    'e2-highcpu-8': 8,
-    'e2-highcpu-16': 16,
-    'm1-ultramem-40': 961,
-    'm1-ultramem-80': 1922,
-    'm1-ultramem-160': 3844,
-    'm1-megamem-96': 1433,
-    'm2-ultramem-2084': 5888,
-    'm2-ultramem-4164': 11776,
-    'c2-standard-4': 16,
-    'c2-standard-8': 32,
-    'c2-standard-16': 64,
-    'c2-standard-30': 120,
-    'c2-standard-60': 240,
-}
 
 VEP_SUPPORTED_REGIONS = {'us-central1', 'europe-west1', 'europe-west2', 'australia-southeast1'}
 
 ANNOTATION_DB_BUCKETS = ["hail-datasets-us-central1", "hail-datasets-europe-west1"]
 
-IMAGE_VERSION = '2.3.17-debian12'
+IMAGE_VERSION = '3.0.1-debian13'
 
 
 def start(
@@ -181,6 +79,10 @@ def start(
     conf = ClusterConfig()
     conf.extend_flag('image-version', IMAGE_VERSION)
 
+    # the jupyter component serves jupyterlab through the component gateway
+    # and persists notebooks in the cluster's staging bucket
+    conf.flags['optional-components'] = 'JUPYTER'
+
     deploy_metadata = get_deploy_metadata()
 
     conf.extend_flag('properties', DEFAULT_PROPERTIES)
@@ -198,7 +100,7 @@ def start(
 
     # default to highmem machines if using VEP
     if not worker_machine_type:
-        worker_machine_type = 'n1-highmem-8' if vep else 'n1-standard-8'
+        worker_machine_type = 'n2-highmem-8' if vep else 'n2-standard-8'
 
     # default initialization script to start up cluster with
     conf.extend_flag('initialization-actions', [deploy_metadata['init_notebook.py']])
@@ -287,17 +189,17 @@ def start(
             size = max(size, 200)
         return str(size) + 'GB'
 
-    def jvm_heap_size_gib(machine_type: str, memory_fraction: float) -> int:
-        advertised_memory_gib = MACHINE_MEM[machine_type]
+    def jvm_heap_size_gib(advertised_memory_gib: float, memory_fraction: float) -> int:
         # 1. GCE only provides 51 GiB for an n1-highmem-8 (advertised as 52 GiB)
         # 2. System daemons use ~10 GiB based on syslog "earlyoom" log statements during VM startup
         actual_available_memory_gib = advertised_memory_gib - 11
         jvm_heap_size = actual_available_memory_gib * memory_fraction
         return int(jvm_heap_size)
 
+    _, master_memory_gib = gcloud.get_machine_type_info(master_machine_type)
     conf.extend_flag(
         'properties',
-        {"spark:spark.driver.memory": f"{jvm_heap_size_gib(master_machine_type, master_memory_fraction)}g"},
+        {"spark:spark.driver.memory": f"{jvm_heap_size_gib(master_memory_gib, master_memory_fraction)}g"},
     )
     conf.flags['master-machine-type'] = master_machine_type
     conf.flags['master-boot-disk-size'] = '{}GB'.format(master_boot_disk_size)
@@ -310,7 +212,7 @@ def start(
     conf.flags['worker-machine-type'] = worker_machine_type
 
     if not no_off_heap_memory:
-        worker_memory = MACHINE_MEM[worker_machine_type]
+        cores_per_machine, worker_memory = gcloud.get_machine_type_info(worker_machine_type)
 
         # A Google support engineer recommended the strategy of passing the YARN
         # config params, and the default value of 95% of machine memory to give to YARN.
@@ -318,7 +220,6 @@ def start(
         # yarn.scheduler.maximum-allocation-mb - max memory to allocate to each container
         available_memory_fraction = yarn_memory_fraction
         available_memory_mb = int(worker_memory * available_memory_fraction * 1024)
-        cores_per_machine = int(worker_machine_type.split('-')[-1])
         executor_cores = min(cores_per_machine, 4)
         available_memory_per_core_mb = available_memory_mb // cores_per_machine
 
@@ -397,6 +298,7 @@ def start(
         cmd.append('--service-account={}'.format(service_account))
 
     cmd.append('--public-ip-address')
+    cmd.append('--enable-component-gateway')
 
     cmd.extend(pass_through_args)
 

--- a/hail/python/test/hailtop/hailctl/dataproc/conftest.py
+++ b/hail/python/test/hailtop/hailctl/dataproc/conftest.py
@@ -21,10 +21,30 @@ def gcloud_run():
     return Mock()
 
 
+@pytest.fixture
+def gcloud_output():
+    return Mock(return_value="")
+
+
+@pytest.fixture
+def machine_type_info():
+    """Fixture for (vCPUs, memory GiB) of machine types used in tests."""
+    return {
+        "n4-standard-8": (8, 32),
+        "n4-standard-16": (16, 64),
+        "n4-standard-32": (32, 128),
+        "n4-highmem-8": (8, 64),
+        "n4-highmem-16": (16, 128),
+        "n2-standard-8": (8, 32),
+        "n2-highmem-8": (8, 64),
+    }
+
+
 @pytest.fixture(autouse=True)
-def patch_gcloud(monkeypatch, gcloud_run, gcloud_config):
+def patch_gcloud(monkeypatch, gcloud_run, gcloud_output, gcloud_config, machine_type_info):
     """Automatically replace gcloud functions with mocks."""
     monkeypatch.setattr("hailtop.hailctl.dataproc.gcloud.run", gcloud_run)
+    monkeypatch.setattr("hailtop.hailctl.dataproc.gcloud.output", gcloud_output)
     monkeypatch.setattr(
         "hailtop.hailctl.dataproc.gcloud.get_version", Mock(return_value=MINIMUM_REQUIRED_GCLOUD_VERSION)
     )
@@ -33,6 +53,11 @@ def patch_gcloud(monkeypatch, gcloud_run, gcloud_config):
         return gcloud_config.get(setting, None)
 
     monkeypatch.setattr("hailtop.hailctl.dataproc.gcloud.get_config", mock_gcloud_get_config)
+
+    def mock_get_machine_type_info(machine_type):
+        return machine_type_info[machine_type]
+
+    monkeypatch.setattr("hailtop.hailctl.dataproc.gcloud.get_machine_type_info", mock_get_machine_type_info)
 
     yield
 

--- a/hail/python/test/hailtop/hailctl/dataproc/test_connect.py
+++ b/hail/python/test/hailtop/hailctl/dataproc/test_connect.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import Mock
 
 import pytest
@@ -7,17 +8,31 @@ from hailtop.hailctl.dataproc import cli
 
 runner = CliRunner()
 
+JUPYTERLAB_URL = "https://abc123-dot-us-central1.dataproc.googleusercontent.com/gateway/default/jupyter/lab/"
+SPARK_HISTORY_URL = "https://abc123-dot-us-central1.dataproc.googleusercontent.com/sparkhistory/"
+
+DESCRIBE_OUTPUT = {
+    "config": {
+        "endpointConfig": {
+            "httpPorts": {
+                "JupyterLab": JUPYTERLAB_URL,
+                "Spark History Server": SPARK_HISTORY_URL,
+            },
+        },
+    },
+}
+
 
 @pytest.fixture
-def subprocess():
+def webbrowser():
     return Mock()
 
 
 @pytest.fixture(autouse=True)
-def patch_subprocess(monkeypatch, subprocess):
-    """Automatically mock subprocess module."""
-    monkeypatch.setattr("hailtop.hailctl.dataproc.connect.subprocess", subprocess)
-    monkeypatch.setattr("hailtop.hailctl.dataproc.connect.get_chrome_path", Mock(return_value="chromium"))
+def patch_webbrowser(monkeypatch, webbrowser, gcloud_output):
+    """Automatically mock the webbrowser module and the gateway url lookup."""
+    monkeypatch.setattr("hailtop.hailctl.dataproc.connect.webbrowser", webbrowser)
+    gcloud_output.return_value = json.dumps(DESCRIBE_OUTPUT)
     yield
     monkeypatch.undo()
 
@@ -32,92 +47,70 @@ def test_cluster_and_service_required(gcloud_run):
     assert gcloud_run.call_count == 0
 
 
-def test_dry_run(gcloud_run, subprocess):
+def test_dry_run(gcloud_output, webbrowser):
     res = runner.invoke(cli.app, ['connect', 'test-cluster', 'notebook', '--dry-run'])
     assert res.exit_code == 0
-    assert gcloud_run.call_count == 0
-    assert subprocess.Popen.call_count == 0
+    assert gcloud_output.call_count == 0
+    assert webbrowser.open.call_count == 0
 
 
-def test_connect(gcloud_run, subprocess):
-    runner.invoke(cli.app, ['connect', 'test-cluster', 'notebook'])
+@pytest.mark.parametrize("service", ["notebook", "nb", "spark-ui", "ui", "spark-history", "hist"])
+def test_connect_describes_cluster(gcloud_output, service):
+    runner.invoke(cli.app, ['connect', 'test-cluster', service])
 
-    gcloud_args = gcloud_run.call_args[0][0]
-    assert gcloud_args[:2] == ["compute", "ssh"]
-    assert gcloud_args[2][(gcloud_args[2].find("@") + 1) :] == "test-cluster-m"
-
-    assert "--ssh-flag=-D 10000" in gcloud_args
-    assert "--ssh-flag=-N" in gcloud_args
-    assert "--ssh-flag=-f" in gcloud_args
-    assert "--ssh-flag=-n" in gcloud_args
-
-    popen_args = subprocess.Popen.call_args[0][0]
-    assert popen_args[0] == "chromium"
-    assert popen_args[1].startswith("http://test-cluster-m")
-
-    assert "--proxy-server=socks5://localhost:10000" in popen_args
-    assert any(arg.startswith("--user-data-dir=") for arg in popen_args)
+    gcloud_args = gcloud_output.call_args[0][0]
+    assert gcloud_args[:4] == ["dataproc", "clusters", "describe", "test-cluster"]
+    assert "--format=json(config.endpointConfig.httpPorts)" in gcloud_args
 
 
 @pytest.mark.parametrize(
-    "service,expected_port_and_path",
+    "service,expected_url",
     [
-        ("spark-ui", "18080/?showIncomplete=true"),
-        ("ui", "18080/?showIncomplete=true"),
-        ("spark-history", "18080"),
-        ("hist", "18080"),
-        ("notebook", "8123"),
-        ("nb", "8123"),
+        ("notebook", JUPYTERLAB_URL),
+        ("nb", JUPYTERLAB_URL),
+        ("spark-ui", SPARK_HISTORY_URL + "?showIncomplete=true"),
+        ("ui", SPARK_HISTORY_URL + "?showIncomplete=true"),
+        ("spark-history", SPARK_HISTORY_URL),
+        ("hist", SPARK_HISTORY_URL),
     ],
 )
-def test_service_port_and_path(subprocess, service, expected_port_and_path):
+def test_connect_opens_gateway_url(webbrowser, service, expected_url):
     runner.invoke(cli.app, ['connect', 'test-cluster', service])
-
-    popen_args = subprocess.Popen.call_args[0][0]
-    assert popen_args[1] == f"http://test-cluster-m:{expected_port_and_path}"
+    webbrowser.open.assert_called_once_with(expected_url)
 
 
-def test_hailctl_chrome(subprocess, monkeypatch):
-    monkeypatch.setattr(
-        "hailtop.hailctl.dataproc.connect.get_chrome_path", Mock(side_effect=Exception("Unable to find chrome"))
-    )
-    monkeypatch.setenv("HAILCTL_CHROME", "/path/to/chrome.exe")
+def test_connect_region_from_config(gcloud_output, gcloud_config):
+    gcloud_config["dataproc/region"] = "europe-north1"
+    gcloud_config["compute/zone"] = None
 
     runner.invoke(cli.app, ['connect', 'test-cluster', 'notebook'])
-    popen_args = subprocess.Popen.call_args[0][0]
-    assert popen_args[0] == "/path/to/chrome.exe"
+    assert "--region=europe-north1" in gcloud_output.call_args[0][0]
 
 
-def test_port(gcloud_run):
-    runner.invoke(cli.app, ['connect', 'test-cluster', 'notebook', '--port=8000'])
-    assert "--ssh-flag=-D 8000" in gcloud_run.call_args[0][0]
-
-
-def test_connect_zone(gcloud_run, gcloud_config):
-    gcloud_config["compute/zone"] = "us-central1-b"
+def test_connect_region_from_zone(gcloud_output, gcloud_config):
+    gcloud_config["dataproc/region"] = None
 
     runner.invoke(cli.app, ['connect', 'test-cluster', 'notebook', '--zone=us-east1-d'])
-
-    assert "--zone=us-east1-d" in gcloud_run.call_args[0][0]
-
-
-def test_connect_default_zone(gcloud_run, gcloud_config):
-    gcloud_config["compute/zone"] = "us-west1-a"
-
-    runner.invoke(cli.app, ['connect', 'test-cluster', 'notebook'])
-
-    assert "--zone=us-west1-a" in gcloud_run.call_args[0][0]
+    assert "--region=us-east1" in gcloud_output.call_args[0][0]
 
 
-def test_connect_zone_required(gcloud_run, gcloud_config):
+def test_connect_region_required(gcloud_output, gcloud_config):
+    gcloud_config["dataproc/region"] = None
     gcloud_config["compute/zone"] = None
 
     res = runner.invoke(cli.app, ['connect', 'test-cluster', 'notebook'])
     assert res.exit_code == 1
+    assert gcloud_output.call_count == 0
 
-    assert gcloud_run.call_count == 0
+
+def test_connect_gateway_not_enabled(gcloud_output, webbrowser):
+    gcloud_output.return_value = "{}"
+
+    res = runner.invoke(cli.app, ['connect', 'test-cluster', 'notebook'])
+    assert res.exit_code == 1
+    assert webbrowser.open.call_count == 0
 
 
-def test_connect_project(gcloud_run):
+def test_connect_project(gcloud_output):
     runner.invoke(cli.app, ['connect', 'test-cluster', 'notebook', '--project=test-project'])
-    assert "--project=test-project" in gcloud_run.call_args[0][0]
+    assert "--project=test-project" in gcloud_output.call_args[0][0]

--- a/hail/python/test/hailtop/hailctl/dataproc/test_modify.py
+++ b/hail/python/test/hailtop/hailctl/dataproc/test_modify.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 from typer.testing import CliRunner
 
@@ -95,15 +97,8 @@ def test_modify_wheel_remote_wheel(gcloud_run):
     assert gcloud_args[:3] == ["compute", "ssh", "test-cluster-m"]
 
     remote_command = gcloud_args[gcloud_args.index("--") + 1]
-    assert remote_command == (
-        "sudo gsutil cp gs://some-bucket/hail.whl /tmp/ && "
-        + "sudo /opt/conda/default/bin/pip uninstall -y hail && "
-        + "sudo /opt/conda/default/bin/pip install --no-dependencies /tmp/hail.whl && "
-        + "unzip /tmp/hail.whl && "
-        + "requirements_file=$(mktemp) && "
-        + "grep 'Requires-Dist: ' hail*dist-info/METADATA | sed 's/Requires-Dist: //' | sed 's/ (//' | sed 's/)//' | grep -v 'pyspark' >$requirements_file &&"
-        + "/opt/conda/default/bin/pip install -r $requirements_file"
-    )
+    assert remote_command.startswith("sudo gsutil cp gs://some-bucket/hail.whl /tmp/ && ")
+    assert "pip install --no-dependencies /tmp/hail.whl" in remote_command
 
 
 def test_modify_wheel_local_wheel(gcloud_run):
@@ -118,14 +113,7 @@ def test_modify_wheel_local_wheel(gcloud_run):
     assert install_gcloud_args[:3] == ["compute", "ssh", "test-cluster-m"]
 
     remote_command = install_gcloud_args[install_gcloud_args.index("--") + 1]
-    assert remote_command == (
-        "sudo /opt/conda/default/bin/pip uninstall -y hail && "
-        + "sudo /opt/conda/default/bin/pip install --no-dependencies /tmp/local-hail.whl && "
-        + "unzip /tmp/local-hail.whl && "
-        + "requirements_file=$(mktemp) && "
-        + "grep 'Requires-Dist: ' hail*dist-info/METADATA | sed 's/Requires-Dist: //' | sed 's/ (//' | sed 's/)//' | grep -v 'pyspark' >$requirements_file &&"
-        + "/opt/conda/default/bin/pip install -r $requirements_file"
-    )
+    assert "pip install --no-dependencies /tmp/local-hail.whl" in remote_command
 
 
 @pytest.mark.parametrize(
@@ -202,12 +190,27 @@ def test_update_hail_version(gcloud_run, monkeypatch, deploy_metadata):
     assert gcloud_args[:3] == ["compute", "ssh", "test-cluster-m"]
 
     remote_command = gcloud_args[gcloud_args.index("--") + 1]
-    assert remote_command == (
+    assert remote_command.startswith(
         "sudo gsutil cp gs://hail-common/hailctl/dataproc/test-version/hail-test-version-py3-none-any.whl /tmp/ && "
-        + "sudo /opt/conda/default/bin/pip uninstall -y hail && "
-        + "sudo /opt/conda/default/bin/pip install --no-dependencies /tmp/hail-test-version-py3-none-any.whl && "
-        + "unzip /tmp/hail-test-version-py3-none-any.whl && "
-        + "requirements_file=$(mktemp) && "
-        + "grep 'Requires-Dist: ' hail*dist-info/METADATA | sed 's/Requires-Dist: //' | sed 's/ (//' | sed 's/)//' | grep -v 'pyspark' >$requirements_file &&"
-        + "/opt/conda/default/bin/pip install -r $requirements_file"
     )
+
+    # assert the wheel is reinstalled and its requirements updated in the
+    # right order, regardless of which python environment the cluster uses
+    steps = [step.strip() for step in remote_command.split('&&')]
+
+    def step_matching(pattern):
+        matches = [i for i, step in enumerate(steps) if re.search(pattern, step)]
+        assert matches, f"no step matching {pattern!r} in {steps}"
+        return matches[0]
+
+    wheel = re.escape('/tmp/hail-test-version-py3-none-any.whl')
+    uninstall = step_matching(r"pip uninstall -y hail$")
+    install = step_matching(rf"pip install --no-dependencies {wheel}$")
+    unzip = step_matching(rf"^unzip {wheel}$")
+    requirements = step_matching(
+        r"grep 'Requires-Dist: ' hail\*dist-info/METADATA .* -v 'pyspark' >\$requirements_file$"
+    )
+    install_requirements = step_matching(r"pip install -r \$requirements_file$")
+
+    assert uninstall < install
+    assert unzip < requirements < install_requirements

--- a/hail/python/test/hailtop/hailctl/dataproc/test_start.py
+++ b/hail/python/test/hailtop/hailctl/dataproc/test_start.py
@@ -18,6 +18,16 @@ def test_dry_run(gcloud_run):
     assert gcloud_run.call_count == 0
 
 
+def test_jupyter_component_enabled(gcloud_run):
+    runner.invoke(cli.app, ['start', 'test-cluster'])
+    assert "--optional-components=JUPYTER" in gcloud_run.call_args[0][0]
+
+
+def test_component_gateway_enabled(gcloud_run):
+    runner.invoke(cli.app, ['start', 'test-cluster'])
+    assert "--enable-component-gateway" in gcloud_run.call_args[0][0]
+
+
 def test_cluster_project(gcloud_run):
     runner.invoke(cli.app, ['start', '--project', 'foo', 'test-cluster'])
     assert "--project=foo" in gcloud_run.call_args[0][0]
@@ -59,8 +69,8 @@ def test_secondary_workers_configuration(gcloud_run, workers_arg):
 @pytest.mark.parametrize(
     "machine_arg",
     [
-        "--master-machine-type=n1-highmem-16",
-        "--worker-machine-type=n1-standard-32",
+        "--master-machine-type=n4-highmem-16",
+        "--worker-machine-type=n4-standard-32",
     ],
 )
 def test_machine_type_configuration(gcloud_run, machine_arg):
@@ -79,7 +89,7 @@ def test_boot_disk_size_configuration(gcloud_run, machine_arg):
 
 def test_vep_defaults_to_highmem_master_machine(gcloud_run):
     runner.invoke(cli.app, ['start', 'test-cluster', '--vep=GRCh37'])
-    assert "--master-machine-type=n1-highmem-8" in gcloud_run.call_args[0][0]
+    assert "--master-machine-type=n2-highmem-8" in gcloud_run.call_args[0][0]
 
 
 def test_vep_defaults_to_larger_worker_boot_disk(gcloud_run):


### PR DESCRIPTION
Fixes #15658

Dataproc 3.0.x images ship Spark 4 and manage the default Python
environment with pixi rather than conda. Update `hailctl dataproc`
and its init action accordingly:

- Serve notebooks with the JUPYTER optional component and the
component gateway instead of hand-rolling a systemd unit for a
tokenless classic-notebook server on port 8123. Notebooks are now
JupyterLab, persisted in the cluster's staging bucket.
- `hailctl dataproc connect` now opens the requested service's
authenticated component gateway url (JupyterLab or the Spark
History Server) in the default browser. This replaces the ssh
socks tunnel and the hard-coded chrome invocation, and with them
the --port flag and the HAILCTL_CHROME environment variables; it
also means `connect` requires a gateway-enabled cluster.
- Replace hail's jgscm fork (a classic-notebook contents manager,
long unmaintained) with google's gcs-jupyter-plugin, which adds a
cloud storage browser to JupyterLab.
- Replace hail's patched sparkmonitor-0.0.12 wheel (fetched from
gs://hail-common) with upstream sparkmonitor 3.3.0, which supports
Spark 4 and JupyterLab. A sha-pinned patch fixes a race between
spark events and the frontend opening its comm channel; drop it
once https://github.com/swan-cern/sparkmonitor/pull/55 is released.
- Derive python paths from the interpreter running the init action
instead of hard-coding /opt/conda/default: neither the old conda
layout nor the new pixi layout is a documented interface.
`hailctl dataproc modify` likewise resolves python3 from PATH.
- Install libarpack2 on all nodes: Spark 4's dev.ludovic.netlib jni
shims bind the system blas, lapack and arpack, and the image ships
openblas but no arpack, without which jvm eigensolvers silently
fall back to pure-java implementations.
- Default machine types move from n1 to n2, and the hardcoded
machine-type memory table is replaced by a gcloud lookup, which
also handles custom machine types. Testing revealed n4 machines were
generally unavailable in us-central1.
- Re-enable the dataproc CI test steps.

Co-Authored-By: Claude Fable 5 [noreply@anthropic.com](mailto:noreply@anthropic.com)