### PR TITLE
[ci] restore prompt ssl shutdown timing out after aiohttp update

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2814,7 +2814,7 @@ steps:
               -m backend \
               --timeout=600 \
               test/hail/utils/test_hl_hadoop_and_hail_fs.py
-    timeout: 600
+    timeout: 900
     inputs:
       - from: /derived/release/hail/build/deploy/dist
         to: /io/wheel

--- a/build.yaml
+++ b/build.yaml
@@ -2700,7 +2700,7 @@ steps:
     scopes:
       - test
       - dev
-    numSplits: 16
+    numSplits: 15
     image:
       valueFrom: hail_run_image.image
     resources:
@@ -2740,10 +2740,81 @@ steps:
               --durations=50 \
               --ignore=test/hailtop/ \
               --ignore=test/hail/matrixtable/test_file_formats.py \
+              --ignore=test/hail/utils/test_hl_hadoop_and_hail_fs.py \
               -m backend \
               --timeout=600 \
               test
     timeout: 5400
+    inputs:
+      - from: /derived/release/hail/build/deploy/dist
+        to: /io/wheel
+      - from: /repo/hail/python/pytest.ini
+        to: /io/repo/hail/python/pytest.ini
+      - from: /repo/hail/python/test
+        to: /io/repo/hail/python/test
+    secrets:
+      - name: test-gsa-key
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /test-gsa-key
+    dependsOn:
+      - default_ns
+      - merge_code
+      - deploy_batch
+      - create_deploy_config
+      - create_accounts
+      - hail_run_image
+      - upload_query_jar
+      - upload_test_resources_to_blob_storage
+      - build_hail_jar_and_wheel
+      - hailgenetics_vep_grch37_85_image
+      - hailgenetics_vep_grch38_95_image
+    clouds:
+      - gcp
+  - kind: runImage
+    name: test_hail_python_service_backend_gcp_fs
+    scopes:
+      - test
+      - dev
+    image:
+      valueFrom: hail_run_image.image
+    resources:
+      cpu: '0.25'
+      preemptible: False
+    script: |
+      set -ex
+      python3 -m pip install --no-dependencies /io/wheel/hail-*-py3-none-any.whl
+
+      cd /io/repo/hail/python
+
+      export HAIL_CLOUD={{ global.cloud }}
+      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
+      export HAIL_TEST_STORAGE_URI={{ global.test_storage_uri }}/{{ token }}
+      export HAIL_TEST_RESOURCES_DIR="{{ global.test_storage_uri }}/{{ upload_test_resources_to_blob_storage.token }}/test/resources/"
+      export HAIL_DOCTEST_DATA_DIR="{{ global.test_storage_uri }}/{{ upload_test_resources_to_blob_storage.token }}/doctest/data/"
+      export HAIL_GENETICS_VEP_GRCH37_85_IMAGE={{ hailgenetics_vep_grch37_85_image.image }}
+      export HAIL_GENETICS_VEP_GRCH38_95_IMAGE={{ hailgenetics_vep_grch38_95_image.image }}
+      export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
+
+      export GCS_REQUESTER_PAYS_PROJECT=broad-ctsa
+
+      export HAIL_QUERY_BACKEND=batch
+      export HAIL_BATCH_REGIONS={{ global.gcp_region }}
+      export HAIL_BATCH_BILLING_PROJECT=test
+      export HAIL_BATCH_REMOTE_TMPDIR={{ global.test_storage_uri }}
+
+      python3 -m pytest \
+              -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
+              --log-cli-level=INFO \
+              -s \
+              -r A \
+              -vv \
+              --instafail \
+              --durations=50 \
+              -m backend \
+              --timeout=600 \
+              test/hail/utils/test_hl_hadoop_and_hail_fs.py
+    timeout: 600
     inputs:
       - from: /derived/release/hail/build/deploy/dist
         to: /io/wheel
@@ -4081,6 +4152,7 @@ steps:
       - test_hailtop_python
       - test_hail_python_local_backend
       - test_hail_python_service_backend_gcp
+      - test_hail_python_service_backend_gcp_fs
       - test_hail_scala_fs
       - test_hail_services_java
       - test_hail_spark_conf_requester_pays_parsing
@@ -4180,6 +4252,7 @@ steps:
       - test_ci
       - test_hailtop_python
       - test_hail_python_service_backend_gcp
+      - test_hail_python_service_backend_gcp_fs
       - test_hail_services_java
       - test_batch_docs
       - test_hailctl_batch
@@ -4227,6 +4300,7 @@ steps:
       - test_ci
       - test_hailtop_python
       - test_hail_python_service_backend_gcp
+      - test_hail_python_service_backend_gcp_fs
       - cancel_all_running_test_batches
   - kind: runImage
     name: delete_gcp_batch_instances
@@ -4273,6 +4347,7 @@ steps:
       - test_ci
       - test_hailtop_python
       - test_hail_python_service_backend_gcp
+      - test_hail_python_service_backend_gcp_fs
       - cancel_all_running_test_batches
   - kind: runImage
     name: setup_dev_namespace_autoscaledown

--- a/hail/python/hail/utils/hadoop_utils.py
+++ b/hail/python/hail/utils/hadoop_utils.py
@@ -117,7 +117,11 @@ def hadoop_open(path: str, mode: str = 'r', buffer_size: int = 8192):
     if ext in ('.gz', '.bgz'):
         binary_mode = mode[0] + 'b'
         underlying = fs.open(path, binary_mode, buffer_size)
-        file = gzip.GzipFile(fileobj=underlying, mode=mode)
+        try:
+            file = gzip.GzipFile(fileobj=underlying, mode=mode)
+        except:
+            underlying.close()
+            raise
         # GzipFile.close() only closes myfileobj, not fileobj; set it so the
         # underlying stream is closed explicitly rather than lazily via __del__.
         file.myfileobj = underlying

--- a/hail/python/hail/utils/hadoop_utils.py
+++ b/hail/python/hail/utils/hadoop_utils.py
@@ -116,8 +116,11 @@ def hadoop_open(path: str, mode: str = 'r', buffer_size: int = 8192):
     _, ext = os.path.splitext(path)
     if ext in ('.gz', '.bgz'):
         binary_mode = mode[0] + 'b'
-        file = fs.open(path, binary_mode, buffer_size)
-        file = gzip.GzipFile(fileobj=file, mode=mode)
+        underlying = fs.open(path, binary_mode, buffer_size)
+        file = gzip.GzipFile(fileobj=underlying, mode=mode)
+        # GzipFile.close() only closes myfileobj, not fileobj; set it so the
+        # underlying stream is closed explicitly rather than lazily via __del__.
+        file.myfileobj = underlying
         if 'b' not in mode:
             file = io.TextIOWrapper(file, encoding='utf-8')
     else:

--- a/hail/python/hailtop/aiocloud/aiogoogle/credentials.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/credentials.py
@@ -9,6 +9,7 @@ from urllib.parse import urlencode
 import jwt
 
 from hailtop import httpx
+from hailtop.tls import internal_client_ssl_context
 from hailtop.utils import first_extant_file, retry_transient_errors
 
 from ..common.credentials import AnonymousCloudCredentials, CloudCredentials
@@ -129,8 +130,6 @@ class GoogleCredentials(CloudCredentials):
 
     async def access_token_with_expiration(self) -> Tuple[str, Optional[float]]:
         if self._access_token is None or self._access_token.expired():
-            from hailtop.tls import internal_client_ssl_context
-
             log.info('ssl session stats before token fetch: %s', internal_client_ssl_context().session_stats())
             self._access_token = await self._get_access_token()
         return self._access_token.token, self._access_token._expiry_time

--- a/hail/python/hailtop/aiocloud/aiogoogle/credentials.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/credentials.py
@@ -9,7 +9,6 @@ from urllib.parse import urlencode
 import jwt
 
 from hailtop import httpx
-from hailtop.tls import internal_client_ssl_context
 from hailtop.utils import first_extant_file, retry_transient_errors
 
 from ..common.credentials import AnonymousCloudCredentials, CloudCredentials
@@ -130,7 +129,12 @@ class GoogleCredentials(CloudCredentials):
 
     async def access_token_with_expiration(self) -> Tuple[str, Optional[float]]:
         if self._access_token is None or self._access_token.expired():
-            log.info('ssl session stats before token fetch: %s', internal_client_ssl_context().session_stats())
+            try:
+                from hailtop.tls import internal_client_ssl_context  # pylint: disable=import-outside-toplevel
+
+                log.info('ssl session stats before token fetch: %s', internal_client_ssl_context().session_stats())
+            except Exception as e:
+                log.info('ssl session stats unavailable: %s', e)
             self._access_token = await self._get_access_token()
         return self._access_token.token, self._access_token._expiry_time
 

--- a/hail/python/hailtop/aiocloud/aiogoogle/credentials.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/credentials.py
@@ -129,6 +129,9 @@ class GoogleCredentials(CloudCredentials):
 
     async def access_token_with_expiration(self) -> Tuple[str, Optional[float]]:
         if self._access_token is None or self._access_token.expired():
+            from hailtop.tls import internal_client_ssl_context
+
+            log.info('ssl session stats before token fetch: %s', internal_client_ssl_context().session_stats())
             self._access_token = await self._get_access_token()
         return self._access_token.token, self._access_token._expiry_time
 

--- a/hail/python/hailtop/aiocloud/aiogoogle/credentials.py
+++ b/hail/python/hailtop/aiocloud/aiogoogle/credentials.py
@@ -129,12 +129,6 @@ class GoogleCredentials(CloudCredentials):
 
     async def access_token_with_expiration(self) -> Tuple[str, Optional[float]]:
         if self._access_token is None or self._access_token.expired():
-            try:
-                from hailtop.tls import internal_client_ssl_context  # pylint: disable=import-outside-toplevel
-
-                log.info('ssl session stats before token fetch: %s', internal_client_ssl_context().session_stats())
-            except Exception as e:
-                log.info('ssl session stats unavailable: %s', e)
             self._access_token = await self._get_access_token()
         return self._access_token.token, self._access_token._expiry_time
 

--- a/hail/python/hailtop/httpx.py
+++ b/hail/python/hailtop/httpx.py
@@ -108,7 +108,7 @@ class ClientSession:
             *args,
             timeout=configuration_of_timeout,
             raise_for_status=False,
-            connector=aiohttp.TCPConnector(ssl=tls),
+            connector=aiohttp.TCPConnector(ssl=tls, ssl_shutdown_timeout=5),
             **kwargs,
         )
 

--- a/hail/python/hailtop/requirements.txt
+++ b/hail/python/hailtop/requirements.txt
@@ -1,4 +1,6 @@
 aiodns>=2.0.0,<3
+# <4: ssl_shutdown_timeout is deprecated in aiohttp 4.0 and will need a replacement
+# for bounding SSL shutdown time; see https://github.com/hail-is/hail/pull/15694
 aiohttp>=3.11.16,<4
 azure-identity>=1.23.0,<2
 azure-mgmt-storage==20.1.0


### PR DESCRIPTION
## Change Description

A few changes to help ease the python_service_backend_gcp_15 flakiness rate.

- Added (back) a `ssl_shutdown_timeout` to our `aiohttp.TCPConnector`.
  - What is it: if we're trying to shut down an ssl connection but the close is never ack'd, how long to wait before giving up and closing the connection anyway.
  - This was changed in June 2025 (nb 2025 not 2026) in version `3.12.11`: `"Changed the default ssl_shutdown_timeout from 0.1 to 0 seconds. SSL connections now use Python's default graceful shutdown during normal operation but are aborted immediately when the connector is closed."`
  - We didn't start seeing flakiness until June **2026** and upgrading `aiohttp` from `3.13.5` to `v3.14.1` 
  - (I checked pinning the version back to `3.13.5`, and that did indeed resolve the issue, but pinning to an old version isn't a good long term fix). 
  - It's not clear what changed to make this an issue now, but there is one changelog entry that is similar enough to be suspicious: `"Fixed CancelledError not closing a connection"`
  - One other thing to note: the `ssl_shutdown_timeout` might be going away in aiohttp 4, so we would need to find another way to guarantee not hanging when shutdowns aren't ack'd properly
- Extract the FS tests into their own separate test step (and drop the shards of `python_service_backend_gcp` down by 1, to compensate)
  - Side effect: found that hadoop connections weren't self closing properly, leading to file not found errors in the later test steps in the job. Example: https://batch.hail.is/batches/8444583/jobs/144).
  - This ended up not doing anything for the flakiness, but I'm inclined to keep it because it highlights the bug fix and there's no good reason to intermingle this test file with the other files run by the `python_service_backend_gcp` step.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has low security impact

### Impact Description

Updates SSL connections, but only by closing them more rapidly rather than leaving "closing" connections open for a long time

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
