### PR TITLE
[query] interrupt in-flight queries when python is interrupted

### DIFF
--- a/hail/hail/src/is/hail/backend/driver/Py4JQueryDriver.scala
+++ b/hail/hail/src/is/hail/backend/driver/Py4JQueryDriver.scala
@@ -28,6 +28,7 @@ import scala.annotation.nowarn
 import scala.collection.compat._
 import scala.collection.mutable
 import scala.jdk.CollectionConverters._
+import scala.util.control.NonFatal
 
 import java.io.Closeable
 import java.net.InetSocketAddress
@@ -58,26 +59,34 @@ final class Py4JQueryDriver(backend: Backend) extends Closeable with Logging {
     newFs(CloudStorageConfig.readEnv(None))
   )
 
+  // Driver state is owned by the executor's single thread: operations that
+  // touch it run there serially.
+  private[this] val executor =
+    new SerialExecutor("Py4J Driver Execution Thread")
+
+  def pyCancel(): Unit =
+    executor.cancel()
+
   def pyFs: FS =
-    synchronized(tmpFileManager.fs)
+    executor.run(tmpFileManager.fs)
 
   def pyGetFlag(name: String): String =
-    synchronized(flags.get(name))
+    executor.run(flags.get(name))
 
   def pySetFlag(name: String, value: String): Unit =
-    synchronized(flags.set(name, value))
+    executor.run(flags.set(name, value))
 
   def pyAvailableFlags: java.util.ArrayList[String] =
     flags.available
 
   def pySetRemoteTmp(tmp: String): Unit =
-    synchronized { tmpdir = tmp }
+    executor.run { tmpdir = tmp }
 
   def pyGetRemoteTmp: String =
-    synchronized(tmpdir)
+    executor.run(tmpdir)
 
   def pySetLocalTmp(tmp: String): Unit =
-    synchronized {
+    executor.run {
       localTmpdir = tmp
       backend match {
         case s: SparkBackend if tmp != "file://" + s.sc.getConf.get("spark.local.dir", "") =>
@@ -91,10 +100,10 @@ final class Py4JQueryDriver(backend: Backend) extends Closeable with Logging {
     }
 
   def pyGetLocalTmp: String =
-    synchronized(localTmpdir)
+    executor.run(localTmpdir)
 
   def pySetGcsRequesterPaysConfig(project: String, buckets: util.List[String]): Unit =
-    synchronized {
+    executor.run {
       tmpFileManager.close()
 
       val cloudfsConf = CloudStorageConfig.readEnv(None)
@@ -125,16 +134,16 @@ final class Py4JQueryDriver(backend: Backend) extends Closeable with Logging {
     }
 
   def pyRemoveJavaIR(id: Int): Unit =
-    synchronized(irCache -= id: Unit)
+    executor.run(irCache -= id: Unit)
 
   def pyAddSequence(name: String, fastaFile: String, indexFile: String): Unit =
-    synchronized {
+    executor.run {
       val seq = IndexedFastaSequenceFile(tmpFileManager.fs, fastaFile, indexFile)
       references(name).addSequence(seq)
     }
 
   def pyRemoveSequence(name: String): Unit =
-    synchronized(references(name).removeSequence())
+    executor.run(references(name).removeSequence())
 
   def pyExportBlockMatrix(
     pathIn: String,
@@ -260,13 +269,13 @@ final class Py4JQueryDriver(backend: Backend) extends Closeable with Logging {
     }
 
   def pyAddReference(jsonConfig: String): Unit =
-    synchronized(addReference(ReferenceGenome.fromJSON(jsonConfig)))
+    executor.run(addReference(ReferenceGenome.fromJSON(jsonConfig)))
 
   def pyRemoveReference(name: String): Unit =
-    synchronized(removeReference(name))
+    executor.run(removeReference(name))
 
   def pyAddLiftover(name: String, chainFile: String, destRGName: String): Unit =
-    synchronized {
+    executor.run {
       references(name).addLiftover(
         references(destRGName),
         LiftOver(tmpFileManager.fs, chainFile),
@@ -274,7 +283,7 @@ final class Py4JQueryDriver(backend: Backend) extends Closeable with Logging {
     }
 
   def pyRemoveLiftover(name: String, destRGName: String): Unit =
-    synchronized(references(name).removeLiftover(destRGName))
+    executor.run(references(name).removeLiftover(destRGName))
 
   def parse_blockmatrix_ir(s: String): BlockMatrixIR =
     withExecuteContext(selfContainedExecution = false) { ctx =>
@@ -286,7 +295,7 @@ final class Py4JQueryDriver(backend: Backend) extends Closeable with Logging {
     files: Seq[String],
     maxLines: Int,
   ): Map[String, Array[WithContext[String]]] =
-    synchronized {
+    executor.run {
       val regexp = regex.r
       backend.asSpark.sc
         .textFilesLines(tmpFileManager.fs.globAll(files).map(_.getPath))
@@ -312,15 +321,18 @@ final class Py4JQueryDriver(backend: Backend) extends Closeable with Logging {
   private[this] def addReference(rg: ReferenceGenome): Unit =
     ReferenceGenome.addFatalOnCollision(references, FastSeq(rg))
 
-  override def close(): Unit =
-    synchronized {
-      blockMatrixCache.clear()
-      compiledCodeCache.clear()
-      irCache.clear()
-      coercerCache.clear()
-      backend.close()
-      IRFunctionRegistry.clearUserFunctions()
+  override def close(): Unit = {
+    try executor.close()
+    catch {
+      case NonFatal(t) => logger.warn(t)
     }
+    blockMatrixCache.clear()
+    compiledCodeCache.clear()
+    irCache.clear()
+    coercerCache.clear()
+    backend.close()
+    IRFunctionRegistry.clearUserFunctions()
+  }
 
   private[this] def removeReference(name: String): Unit =
     references -= name
@@ -331,7 +343,7 @@ final class Py4JQueryDriver(backend: Backend) extends Closeable with Logging {
     f: ExecuteContext => T
   )(implicit E: Enclosing
   ): T =
-    synchronized {
+    executor.run {
       TimedBlock.enter {
         ExecuteContext.scoped(
           tmpdir = tmpdir,

--- a/hail/hail/test/src/is/hail/utils/SerialExecutorSuite.scala
+++ b/hail/hail/test/src/is/hail/utils/SerialExecutorSuite.scala
@@ -1,0 +1,78 @@
+package is.hail.utils
+
+import java.util.concurrent.CountDownLatch
+
+import org.junit.jupiter.api.Test
+import org.scalatest.matchers.should.Matchers._
+
+class SerialExecutorSuite {
+
+  private[this] def withExecutor[A](test: SerialExecutor => A): A = {
+    val executor = new SerialExecutor(getClass.getName)
+    try test(executor)
+    finally executor.close()
+  }
+
+  // run `op` on the executor from another thread, returning after `op` has
+  // started; join the result to observe what the submitter saw
+  private[this] def submitAndAwaitStart(executor: SerialExecutor)(op: => Unit): Thread = {
+    val started = new CountDownLatch(1)
+    val submitter = new Thread(() =>
+      try
+        executor.run {
+          started.countDown()
+          op
+        }
+      catch { case _: HailException => }
+    )
+    submitter.start()
+    started.await()
+    submitter
+  }
+
+  @Test def testRejectsConcurrentOperations(): Unit =
+    withExecutor { executor =>
+      val release = new CountDownLatch(1)
+      val busy = submitAndAwaitStart(executor)(release.await())
+      try
+        the[HailException] thrownBy executor.run(()) should have message
+          "another operation is in progress; wait for it to finish or cancel it"
+      finally {
+        release.countDown()
+        busy.join()
+      }
+    }
+
+  @Test def testCancelInterruptsTheRunningOperation(): Unit =
+    withExecutor { executor =>
+      @volatile var failure: Throwable = null
+      val started = new CountDownLatch(1)
+      val submitter = new Thread(() =>
+        try
+          executor.run {
+            started.countDown()
+            Thread.sleep(Long.MaxValue)
+          }
+        catch { case t: Throwable => failure = t }
+      )
+      submitter.start()
+      started.await()
+      executor.cancel()
+      submitter.join()
+      failure should have message "operation was cancelled"
+    }
+
+  @Test def testCancelIsANoOpWhenIdle(): Unit =
+    withExecutor { executor =>
+      executor.cancel()
+      executor.run(42) shouldBe 42
+    }
+
+  @Test def testAcceptsNewOperationsAfterCancellation(): Unit =
+    withExecutor { executor =>
+      val cancelled = submitAndAwaitStart(executor)(Thread.sleep(Long.MaxValue))
+      executor.cancel()
+      cancelled.join()
+      executor.run(42) shouldBe 42
+    }
+}

--- a/hail/hail/utils/src/is/hail/utils/SerialExecutor.scala
+++ b/hail/hail/utils/src/is/hail/utils/SerialExecutor.scala
@@ -1,0 +1,52 @@
+package is.hail.utils
+
+import java.io.Closeable
+import java.util.concurrent.{
+  CancellationException, ExecutionException, Executors, FutureTask, TimeUnit,
+}
+import java.util.concurrent.atomic.AtomicReference
+
+// Runs operations serially on one permanent daemon thread. At most one
+// operation is ever in flight: concurrent submissions are rejected rather
+// than queued behind it. The in-flight operation can be interrupted via
+// `cancel`.
+final class SerialExecutor(threadName: String) extends Closeable {
+
+  private[this] val inFlight =
+    new AtomicReference[FutureTask[_]]()
+
+  private[this] val executor =
+    Executors.newSingleThreadExecutor { r =>
+      val t = new Thread(r, threadName)
+      t.setDaemon(true)
+      t
+    }
+
+  def run[T](f: => T): T = {
+    val task = new FutureTask[T](() => f)
+    if (!inFlight.compareAndSet(null, task))
+      fatal("another operation is in progress; wait for it to finish or cancel it")
+    try {
+      executor.execute(task)
+      task.get()
+    } catch {
+      case e: ExecutionException => throw e.getCause
+      case _: CancellationException => fatal("operation was cancelled")
+    } finally inFlight.compareAndSet(task, null): Unit
+  }
+
+  def cancel(): Unit =
+    Option(inFlight.get()).foreach(_.cancel(true))
+
+  // await in-flight work so it unwinds before callers tear down the state it
+  // uses; termination also publishes the worker thread's writes to us
+  override def close(): Unit = {
+    cancel()
+    executor.shutdown()
+    if (!executor.awaitTermination(5, TimeUnit.SECONDS))
+      fatal(
+        "An operation is still running and did not respond to interrupt.\n" +
+          "You should restart the hail session."
+      )
+  }
+}

--- a/hail/python/hail/backend/local_backend.py
+++ b/hail/python/hail/backend/local_backend.py
@@ -6,7 +6,7 @@ from py4j.java_gateway import JavaGateway, JavaObject, Py4JJavaError
 from hail.backend.backend import fatal_error_from_java_error_triplet
 from hail.backend.py4j_backend import (
     Py4JBackend,
-    _log_suppress_shutdown_exceptions,
+    _log_suppress_exceptions,
     raise_when_mismatched_hail_versions,
     start_py4j_gateway,
 )
@@ -77,4 +77,4 @@ class LocalBackend(Py4JBackend):
         try:
             super().stop()
         finally:
-            _log_suppress_shutdown_exceptions(self._gateway.shutdown)
+            _log_suppress_exceptions(self._gateway.shutdown)

--- a/hail/python/hail/backend/py4j_backend.py
+++ b/hail/python/hail/backend/py4j_backend.py
@@ -32,7 +32,7 @@ from hailtop.aiocloud.aiogoogle import GCSRequesterPaysConfiguration
 from hailtop.aiotools.validators import validate_file
 from hailtop.fs.fs import FS
 from hailtop.fs.router_fs import RouterFS
-from hailtop.utils import async_to_blocking, find_spark_home, sync_retry_transient_errors
+from hailtop.utils import async_to_blocking, find_spark_home
 
 # This defaults to 65536 and fails if a header is longer than _MAXLINE
 # The timing json that we output can exceed 65536 bytes so we raise the limit
@@ -74,7 +74,7 @@ _make_interrupt_safe(GatewayConnection)
 _make_interrupt_safe(py4j.clientserver.ClientServerConnection)
 
 
-def _log_suppress_shutdown_exceptions(action: Callable[[], None]) -> None:
+def _log_suppress_exceptions(action: Callable[[], None]) -> None:
     # Failures while tearing down a dead or unreachable JVM must not prevent
     # the remaining shutdown steps from running, otherwise global state is
     # left pointing at the defunct JVM and re-initialization is impossible.
@@ -239,7 +239,7 @@ class Py4JBackend(Backend):
         install_exception_handler()
 
         self._initialize_flags(flags)
-        self._jhttp_server = self._new_jhttp_server()
+        self._jhttp_server = self._jbackend.pyHttpServer()
 
     def jvm(self) -> JVMView:
         return self._jvm
@@ -317,30 +317,20 @@ class Py4JBackend(Backend):
 
             raise err
 
-    def _new_jhttp_server(self) -> JavaObject:
-        server = self._jbackend.pyHttpServer()
-        if not isinstance(server, JavaObject):
-            raise FatalError(
-                'The Hail JVM is unreachable or its py4j connection is corrupted. '
-                'Call hl.stop() and hl.init() to recover.'
-            )
-        return server
-
     def _rpc(self, action, payload) -> bytes:
         data = orjson.dumps(payload)
         path = action_routes[action]
+        port = self._jhttp_server.port()
 
-        def go():
-            port = self._jhttp_server.port()
-            try:
-                # No read timeout: queries may legitimately run for a long time.
-                return requests.post(f'http://localhost:{port}{path}', data=data, timeout=(5, None))
-            except requests.exceptions.ConnectionError:
-                self._stop_jhttp_server()
-                self._jhttp_server = self._new_jhttp_server()
-                raise
-
-        resp = sync_retry_transient_errors(go)
+        try:
+            # No read timeout: queries may legitimately run for a long time.
+            resp = requests.post(f'http://localhost:{port}{path}', data=data, timeout=(5, None))
+        except BaseException:
+            # The post was interrupted (Ctrl-C, pytest timeout, ...) or the
+            # connection was severed; either way, stop the jvm running the
+            # abandoned operation to completion.
+            _log_suppress_exceptions(self._jbackend.pyCancel)
+            raise
 
         if resp.status_code >= 400:
             error_json = orjson.loads(resp.content)
@@ -409,11 +399,11 @@ class Py4JBackend(Backend):
         return self._parse_blockmatrix_ir(self._render_ir(ir))
 
     def _stop_jhttp_server(self):
-        _log_suppress_shutdown_exceptions(lambda: self._jhttp_server.close())
+        _log_suppress_exceptions(lambda: self._jhttp_server.close())
 
     def stop(self):
         super().stop()
         self._stop_jhttp_server()
-        _log_suppress_shutdown_exceptions(lambda: self._jbackend.close())
+        _log_suppress_exceptions(lambda: self._jbackend.close())
         uninstall_exception_handler()
         self.fs = None

--- a/hail/python/hail/backend/spark_backend.py
+++ b/hail/python/hail/backend/spark_backend.py
@@ -23,7 +23,7 @@ from hailtop.utils import async_to_blocking
 
 from ..fs.hadoop_fs import HadoopFS
 from .backend import local_jar_information
-from .py4j_backend import Py4JBackend, _log_suppress_shutdown_exceptions, raise_when_mismatched_hail_versions
+from .py4j_backend import Py4JBackend, _log_suppress_exceptions, raise_when_mismatched_hail_versions
 
 
 def _modify_spark_conf(conf: pyspark.SparkConf, key: str, update: Callable[[str | None], str]):
@@ -241,9 +241,9 @@ class SparkBackend(Py4JBackend):
     def stop(self):
         try:
             if self._hail_managed_spark:
-                _log_suppress_shutdown_exceptions(self._spark.stop)
+                _log_suppress_exceptions(self._spark.stop)
                 super().stop()
-                _log_suppress_shutdown_exceptions(lambda: SparkContext._gateway.shutdown())
+                _log_suppress_exceptions(lambda: SparkContext._gateway.shutdown())
 
                 # clean up pyspark's global state to support
                 # re-init with different spark conf; pyspark only does this

--- a/hail/python/test/hail/backend/test_py4j_backend.py
+++ b/hail/python/test/hail/backend/test_py4j_backend.py
@@ -1,8 +1,15 @@
+import types
+from typing import Callable
+
+import orjson
 import py4j.clientserver
 import pytest
+import requests
 from py4j.java_gateway import GatewayConnection
 
-from hail.backend.py4j_backend import _log_suppress_shutdown_exceptions, _make_interrupt_safe
+from hail.backend.backend import ActionTag
+from hail.backend.py4j_backend import Py4JBackend, _log_suppress_exceptions, _make_interrupt_safe
+from hail.utils.java import FatalError
 
 pytestmark = pytest.mark.uninitialized
 
@@ -13,8 +20,45 @@ class Interrupt(BaseException):
     pass
 
 
-def interrupt(*ignored):
-    raise Interrupt
+def raising(exception):
+    def raise_(*ignored, **also_ignored):
+        raise exception
+
+    return raise_
+
+
+interrupt = raising(Interrupt)
+
+
+class FakeJBackend:
+    def __init__(self, cancel: Callable[[], None] = lambda: None):
+        self._cancel = cancel
+
+    def pyCancel(self):
+        self._cancel()
+
+
+@pytest.fixture
+def rpc(monkeypatch):
+    def go(post, jbackend):
+        # `_rpc` only touches the http server's port and `pyCancel`, so a
+        # stand-in object suffices; no gateway or JVM is involved
+        backend = types.SimpleNamespace(
+            _jhttp_server=types.SimpleNamespace(port=lambda: 5555),
+            _jbackend=jbackend,
+        )
+        monkeypatch.setattr(requests, 'post', post)
+        return Py4JBackend._rpc(backend, ActionTag.EXECUTE, {})
+
+    return go
+
+
+def response(status_code, content):
+    return types.SimpleNamespace(status_code=status_code, content=content)
+
+
+def java_error(status_code=500):
+    return response(status_code, orjson.dumps({'short': 'short', 'expanded': 'expanded', 'error_id': -1}))
 
 
 def fake_connection(handler):
@@ -47,10 +91,7 @@ def test_interrupt_closes_the_connection():
 
 
 def test_exceptions_do_not_close_the_connection():
-    def raise_value_error(command):
-        raise ValueError(command)
-
-    connection = fake_connection(raise_value_error)
+    connection = fake_connection(raising(ValueError))
     with pytest.raises(ValueError):
         connection.send_command('command')
     assert connection.closed_with_reset is None
@@ -74,12 +115,40 @@ def test_py4j_connections_are_interrupt_safe(cls):
 
 
 def test_log_suppress_shutdown_exceptions_swallows_exceptions():
-    def raise_value_error():
-        raise ValueError
-
-    _log_suppress_shutdown_exceptions(raise_value_error)
+    _log_suppress_exceptions(raising(ValueError))
 
 
 def test_log_suppress_shutdown_exceptions_propagates_interrupts():
     with pytest.raises(Interrupt):
-        _log_suppress_shutdown_exceptions(interrupt)
+        _log_suppress_exceptions(interrupt)
+
+
+@pytest.mark.parametrize('failure', [Interrupt, requests.exceptions.ConnectionError])
+def test_rpc_failures_cancel_the_operation_and_propagate(rpc, failure):
+    cancelled = []
+    with pytest.raises(failure):
+        rpc(raising(failure), FakeJBackend(cancel=lambda: cancelled.append(True)))
+    assert cancelled
+
+
+def test_rpc_cancel_failures_do_not_mask_the_original_failure(rpc):
+    with pytest.raises(Interrupt):
+        rpc(interrupt, FakeJBackend(cancel=raising(ValueError)))
+
+
+def test_rpc_returns_successful_responses(rpc):
+    assert (
+        rpc(
+            lambda *a, **k: response(200, b'payload'),
+            FakeJBackend(cancel=lambda: pytest.fail("cancel should not have been called")),
+        )
+        == b'payload'
+    )
+
+
+def test_rpc_java_errors_raise_fatal_errors(rpc):
+    with pytest.raises(FatalError):
+        rpc(
+            lambda *a, **k: java_error(),
+            FakeJBackend(cancel=lambda: pytest.fail("cancel should not have been called")),
+        )


### PR DESCRIPTION
A python interrupt (Ctrl-C, pytest timeout) mid-query left the JVM running the
abandoned operation to completion. This effectively bricked every subsequent
thread that called into the driver code until the orphaned task completed. This
is because operations that read/write driver state are guarded behind
`synchronized` blocks. _rpc then treated the resulting connection errors as
transient, recreating the http server and retrying behind the still-running
operation.

The driver now serialises tasks through a new `SerialExecutor`. This
- executes tasks on a dedicated thread using a one-in-on-out policy.
- holds onto the in-flight task for cancellation, and 
- rejects concurrent submissions.
- It allows optimistic queuing of a new task if the current task has been
  cancelled, freeing us from implementing retry logic in python.

Given that python is effectively single-threaded, we don't expect to see task
rejections; in fact it can only arise when two queries or py4j requests are 
executed concurrently or interrupted and re-executed in short succession.

The driver exposes this as `pyCancel`. On interrupt or severed connection, `_rpc`
now makes a best-effort `pyCancel` call and re-raises instead of retrying.

This change does not affect the broad-managed batch service in gcp.