### PR TITLE
[aws] Add script to create AWS worker image

### DIFF
--- a/batch/aws-create-worker-image.sh
+++ b/batch/aws-create-worker-image.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "$0")"
+source ../devbin/functions.sh
+
+if [ -z "${NAMESPACE}" ]; then
+    echo "Must specify a NAMESPACE environment variable"
+    exit 1;
+fi
+
+REGION=us-east-1  #$(get_global_config_field aws_region $NAMESPACE)
+DOCKER_ROOT_IMAGE=$(get_global_config_field docker_root_image $NAMESPACE)
+
+# When you bump the WORKER_IMAGE_VERSION, you should also update:
+# - the INSTANCE_VERSION in globals.py (add one to the current value)
+# - the image name in batch/batch/cloud/gcp/driver/create_instance.py (should match this value)
+WORKER_IMAGE_VERSION=33
+
+if [ "$NAMESPACE" == "default" ]; then
+    WORKER_IMAGE=batch-worker-${WORKER_IMAGE_VERSION}
+    BUILDER=build-batch-worker-image
+else
+    WORKER_IMAGE=batch-worker-$NAMESPACE-${WORKER_IMAGE_VERSION}
+    BUILDER=build-batch-worker-$NAMESPACE-image
+fi
+
+UBUNTU_IMAGE=/aws/service/canonical/ubuntu/server-minimal/24.04/stable/current/amd64/hvm/ebs-gp3/ami-id
+
+WORKER_IMAGE_EXISTS=false
+if [[ "$(aws ec2 describe-images --filter="Name=tag:Name,Values=${WORKER_IMAGE}" --query="Reservations[*].Instances[*].[InstanceId]" --region "${REGION}")" -ne "null" ]]; then
+    WORKER_IMAGE_EXISTS=true
+    if [ "$NAMESPACE" == "default" ]; then
+        echo "ERROR: Image $WORKER_IMAGE already exists in region $REGION. Delete it first or bump WORKER_IMAGE_VERSION."
+        exit 1
+    else
+        echo "WARNING: Image $WORKER_IMAGE already exists in region $REGION and will be overwritten."
+    fi
+fi
+
+LEFTOVER_BUILDERS="$(aws ec2 describe-instances --region $REGION --filter="Name=tag:Name,Values=${BUILDER}" --query="Reservations[*].Instances[*].[InstanceId]" --output text | tr '\n' ' ')"
+if [[ -n "$LEFTOVER_BUILDERS" ]]; then
+    echo "WARNING: Found leftover builder VM(s) in region $REGION:"
+    echo "$LEFTOVER_BUILDERS"
+fi
+
+create_build_image_instance() {
+    if [[ -n "$LEFTOVER_BUILDERS" ]]; then
+        aws ec2 terminate-instances --region $REGION --instance-ids ${LEFTOVER_BUILDERS}
+    fi
+
+    python3 ../ci/jinja2_render.py '{"global":{"docker_root_image":"'${DOCKER_ROOT_IMAGE}'"}}' \
+        build-batch-worker-image-startup-aws.sh build-batch-worker-image-startup-aws.sh.out
+
+    UBUNTU_AMI_ID=$(aws ssm get-parameter --name "$UBUNTU_IMAGE" --query="Parameter.Value" --output text)
+
+    BUILDER_ID=$(aws ec2 run-instances \
+        --image-id ${UBUNTU_AMI_ID} \
+        --count 1 \
+        --instance-type t2.large \
+        --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value='${BUILDER}'}]" \
+        --user-data file://build-batch-worker-image-startup-aws.sh.out \
+	--region ${REGION} \
+        --query "Instances[*].[InstanceId]" \
+	--output text
+    )
+}
+
+create_worker_image() {
+    if [ "$WORKER_IMAGE_EXISTS" == "true" ]; then
+        aws ec2 deregister-image --image-id $WORKER_IMAGE --region $REGION
+    fi
+
+    aws ec2 create-image \
+        --instance-id ${BUILDER_ID} \
+        --name ${WORKER_IMAGE} \
+        --region ${REGION}
+
+    aws ec2 terminate-instances \
+        --instance-ids ${BUILDER_ID} \
+        --region ${REGION}
+}
+
+main() {
+    set -x
+    create_build_image_instance
+    while [ "$(aws ec2 describe-instance-status --instance-ids ${BUILDER_ID} --include-all-instances --query='InstanceStatuses[0].InstanceState.Name' --output text)" != "stopped" ];
+    do
+        sleep 5
+    done
+    create_worker_image
+}
+
+confirm "Building image $WORKER_IMAGE with properties:\n Version: ${WORKER_IMAGE_VERSION}\n Region: ${REGION}" && main

--- a/batch/aws-create-worker-image.sh
+++ b/batch/aws-create-worker-image.sh
@@ -10,7 +10,7 @@ if [ -z "${NAMESPACE}" ]; then
     exit 1;
 fi
 
-REGION=us-east-1  #$(get_global_config_field aws_region $NAMESPACE)
+REGION=$(get_global_config_field aws_region $NAMESPACE)
 DOCKER_ROOT_IMAGE=$(get_global_config_field docker_root_image $NAMESPACE)
 
 # When you bump the WORKER_IMAGE_VERSION, you should also update:
@@ -53,7 +53,7 @@ create_build_image_instance() {
     python3 ../ci/jinja2_render.py '{"global":{"docker_root_image":"'${DOCKER_ROOT_IMAGE}'"}}' \
         build-batch-worker-image-startup-aws.sh build-batch-worker-image-startup-aws.sh.out
 
-    UBUNTU_AMI_ID=$(aws ssm get-parameter --name "$UBUNTU_IMAGE" --query="Parameter.Value" --output text)
+    UBUNTU_AMI_ID=$(aws ssm get-parameter --region ${REGION} --name ${UBUNTU_IMAGE} --query="Parameter.Value" --output text)
 
     BUILDER_ID=$(aws ec2 run-instances \
         --image-id ${UBUNTU_AMI_ID} \
@@ -85,7 +85,7 @@ create_worker_image() {
 main() {
     set -x
     create_build_image_instance
-    while [ "$(aws ec2 describe-instance-status --instance-ids ${BUILDER_ID} --include-all-instances --query='InstanceStatuses[0].InstanceState.Name' --output text)" != "stopped" ];
+    while [ "$(aws ec2 describe-instance-status --region ${REGION} --instance-ids ${BUILDER_ID} --include-all-instances --query='InstanceStatuses[0].InstanceState.Name' --output text)" != "stopped" ];
     do
         sleep 5
     done

--- a/batch/build-batch-worker-image-startup-aws.sh
+++ b/batch/build-batch-worker-image-startup-aws.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+set -exo pipefail
+
+# The nvidia toolkit must be installed in this startup script to be able to configure docker with the command nvidia-ctk runtime configure --runtime=docker. This command cannot be run from Dockerfile.worker
+# The toolkit also has to be installed in Dockerfile.worker since to execute the nvidia hook, the toolkit needs to be installed in the container from which crun is invoked.
+
+echo "=== Installing base packages ==="
+apt-get update
+
+apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    jq \
+    software-properties-common \
+    xfsprogs \
+    mdadm
+
+echo "=== Adding Docker apt repo ==="
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+
+add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+
+echo "=== Installing Docker ==="
+apt-get install -y docker-ce
+
+rm -rf /var/lib/apt/lists/*
+
+[ -f /etc/docker/daemon.json ] || echo "{}" > /etc/docker/daemon.json
+
+echo "=== Installing docker-credential-gcr ==="
+VERSION=2.0.4
+OS=linux
+ARCH=amd64
+
+curl -fsSL "https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v${VERSION}/docker-credential-gcr_${OS}_${ARCH}-${VERSION}.tar.gz" \
+  | tar xz --to-stdout ./docker-credential-gcr \
+	> /usr/bin/docker-credential-gcr && chmod +x /usr/bin/docker-credential-gcr
+
+echo "=== Adding NVIDIA container toolkit apt repo ==="
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \
+     | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+curl -fsSL https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
+    sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+    tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+
+echo "=== Installing build tools and kernel headers ==="
+apt-get update
+apt-get install -y build-essential linux-headers-$(uname -r)
+
+echo "=== Downloading NVIDIA driver ==="
+wget --no-verbose https://us.download.nvidia.com/XFree86/Linux-x86_64/595.58.03/NVIDIA-Linux-x86_64-595.58.03.run
+echo "8c0d4f967b7932c4ab5714272aee8103392b0a702c92afa555176d36205829f9  NVIDIA-Linux-x86_64-595.58.03.run" | sha256sum -c
+chmod +x NVIDIA-Linux-x86_64-595.58.03.run
+
+echo "=== Running NVIDIA driver installer ==="
+touch /var/log/nvidia-installer.log
+tail -f /var/log/nvidia-installer.log &
+NVIDIA_LOG_PID=$!
+./NVIDIA-Linux-x86_64-595.58.03.run --silent
+kill $NVIDIA_LOG_PID
+
+echo "=== Installing NVIDIA container toolkit ==="
+apt-get --yes install nvidia-container-toolkit
+nvidia-ctk runtime configure --runtime=docker
+
+echo "=== Installing Google Cloud Ops Agent ==="
+curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
+bash add-google-cloud-ops-agent-repo.sh --also-install --version=2.*.*
+
+echo "=== Configuring Docker with GCR credentials and pulling root image ==="
+# avoid "unable to get current user home directory: os/user lookup failed"
+export HOME=/root
+
+docker-credential-gcr configure-docker --include-artifact-registry
+docker pull {{ global.docker_root_image }}
+
+echo "=== Disabling algif_aead kernel module (copy.fail / CVE-2026-31431) ==="
+echo "install algif_aead /bin/false" > /etc/modprobe.d/disable-algif.conf
+rmmod algif_aead 2>/dev/null || true
+
+echo "=== Blacklisting ESP modules (copy.fail2) ==="
+cat > /etc/modprobe.d/blocklist-esp.conf << 'EOF'
+blacklist esp4
+blacklist esp6
+EOF
+
+echo "=== Enabling Docker debug logging ==="
+jq '.debug = true' /etc/docker/daemon.json > daemon.json.tmp
+mv daemon.json.tmp /etc/docker/daemon.json
+
+systemctl restart docker
+
+echo "=== Startup complete, shutting down ==="
+shutdown -h now


### PR DESCRIPTION
## Change Description

Partial implementation of #15511. Rewrites the GCP worker creation script to create a VM in AWS with the worker startup script, take a snapshot of it, and register it as a batch worker image. For now, the worker script is a direct copy of the GCP script and is just a placeholder.

## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has no security impact

### Impact Description

This change cannot affect the GCP instance. It registers a worker image in AWS which will remain unused until the AWS batch driver is ready to schedule jobs.

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>