### PR TITLE
[batch-driver] fix a handful of small uncaught exceptions

### DIFF
--- a/batch/batch/driver/instance_collection/base.py
+++ b/batch/batch/driver/instance_collection/base.py
@@ -10,12 +10,13 @@ import sortedcontainers
 from gear import Database
 from gear.time_limited_max_size_cache import TimeLimitedMaxSizeCache
 from hailtop import aiotools
-from hailtop.utils import periodically_call, secret_alnum_string, time_msecs
+from hailtop.utils import periodically_call, time_msecs
 
 from ...globals import INSTANCE_VERSION, live_instance_states
 from ...instance_config import QuantifiedResource
 from ..instance import Instance
 from ..location import CloudLocationMonitor
+from ..naming import build_inst_coll_regex, make_machine_name
 from ..resource_manager import (
     CloudResourceManager,
     UnknownVMState,
@@ -48,7 +49,7 @@ class InstanceCollectionManager:
         self._default_region = default_region
         self.regions = regions
 
-        self.inst_coll_regex = re.compile(f'{self.machine_name_prefix}(?P<inst_coll>.*)-.*')
+        self.inst_coll_regex = build_inst_coll_regex(self.machine_name_prefix)
         self.name_inst_coll: Dict[str, InstanceCollection] = {}
         self.name_token_cache: TimeLimitedMaxSizeCache[str, str] = TimeLimitedMaxSizeCache(
             self.get_token_from_instance_name,
@@ -299,12 +300,9 @@ class InstanceCollection:
 
     def generate_machine_name(self) -> str:
         while True:
-            # 36 ** 12 = ~4.7e18
-            suffix = f'{secret_alnum_string(6, case="lower")}-{secret_alnum_string(6, case="lower")}'
-            machine_name = f'{self.machine_name_prefix}{suffix}'[:63]
-            if machine_name not in self.name_instance:
-                break
-        return machine_name
+            name = make_machine_name(self.machine_name_prefix)
+            if name not in self.name_instance:
+                return name
 
     def adjust_for_remove_instance(self, instance: Instance):
         assert instance in self.instances_by_last_updated

--- a/batch/batch/driver/instance_collection/base.py
+++ b/batch/batch/driver/instance_collection/base.py
@@ -413,7 +413,7 @@ class InstanceCollection:
         active_and_healthy = await instance.check_is_active_and_healthy()
 
         if instance.state == 'active' and instance.failed_request_count > 5:
-            log.exception(
+            log.warning(
                 f'deleting {instance} with {instance.failed_request_count} failed request counts after more than 5 minutes'
             )
             await self.call_delete_instance(instance, 'not_responding')
@@ -431,7 +431,7 @@ class InstanceCollection:
         # Cases are mutually exclusive and therefore order-independent
         if instance.state == 'pending' and isinstance(vm_state, (VMStateCreating, VMStateRunning)):
             if vm_state.time_since_last_state_change() > 5 * 60 * 1000:
-                log.exception(f'{instance} (state: {vm_state}) has made no progress in last 5m, deleting')
+                log.warning(f'{instance} (vm_state: {vm_state.state}) has made no progress in last 5m, deleting')
                 await self.call_delete_instance(instance, 'activation_timeout')
         elif instance.state in ('pending', 'active') and isinstance(vm_state, VMStateTerminated):
             log.info(f'{instance} live but stopping or terminated, deactivating')

--- a/batch/batch/driver/instance_collection/base.py
+++ b/batch/batch/driver/instance_collection/base.py
@@ -299,9 +299,9 @@ class InstanceCollection:
 
     def generate_machine_name(self) -> str:
         while True:
-            # 36 ** 5 = ~60M
-            suffix = secret_alnum_string(5, case='lower')
-            machine_name = f'{self.machine_name_prefix}{suffix}'
+            # 36 ** 12 = ~4.7e18
+            suffix = f'{secret_alnum_string(6, case="lower")}-{secret_alnum_string(6, case="lower")}'
+            machine_name = f'{self.machine_name_prefix}{suffix}'[:63]
             if machine_name not in self.name_instance:
                 break
         return machine_name
@@ -317,6 +317,12 @@ class InstanceCollection:
 
         await self.db.just_execute('UPDATE instances SET removed = 1 WHERE name = %s;', (instance.name,))
 
+        # A concurrent path (e.g. activity log event) may have already removed this instance while
+        # we were suspended at one of the awaits above.  Guard with a synchronous check so we don't
+        # double-remove; no yield points follow so this is race-free within asyncio.
+        if instance.name not in self.name_instance:
+            log.info(f'{instance} already removed by concurrent path, skipping cleanup')
+            return
         self.adjust_for_remove_instance(instance)
         del self.name_instance[instance.name]
 

--- a/batch/batch/driver/main.py
+++ b/batch/batch/driver/main.py
@@ -107,7 +107,7 @@ auth = get_authenticator()
 
 warnings.filterwarnings(
     'ignore',
-    ".*Warning: Field or reference 'batch.billing_projects.name' of SELECT #. was resolved in SELECT #.",
+    ".*Warning: Field or reference 'batch\\..*' of SELECT #. was resolved in SELECT #.",
     module='aiomysql.*',
 )
 

--- a/batch/batch/driver/naming.py
+++ b/batch/batch/driver/naming.py
@@ -1,0 +1,16 @@
+import re
+
+from hailtop.utils import secret_alnum_string
+
+
+def make_machine_name(prefix: str) -> str:
+    # 36 ** 12 = ~4.7e18 unique suffixes
+    suffix = f'{secret_alnum_string(6, case="lower")}-{secret_alnum_string(6, case="lower")}'
+    return f'{prefix}{suffix}'
+
+
+def build_inst_coll_regex(machine_name_prefix: str) -> re.Pattern:
+    # The suffix must be length-specific so the greedy .* doesn't consume hyphenated
+    # inst_coll names (e.g. 'standard-np') into the inst_coll group.
+    # Old suffix: 5 alphanum chars. New suffix: two 6-char alphanum groups separated by a hyphen.
+    return re.compile(f'{machine_name_prefix}(?P<inst_coll>.*)-(?:[a-z0-9]{{5}}|[a-z0-9]{{6}}-[a-z0-9]{{6}})$')

--- a/batch/batch/driver/naming.py
+++ b/batch/batch/driver/naming.py
@@ -2,15 +2,19 @@ import re
 
 from hailtop.utils import secret_alnum_string
 
+_GCE_MAX_VM_NAME_LEN = 63
+
 
 def make_machine_name(prefix: str) -> str:
-    # 36 ** 12 = ~4.7e18 unique suffixes
-    suffix = f'{secret_alnum_string(6, case="lower")}-{secret_alnum_string(6, case="lower")}'
-    return f'{prefix}{suffix}'
+    # Suffix has no hyphens so the last '-' in the full name is always the inst_coll separator.
+    # Fill remaining space up to 12 chars (36^12 ≈ 4.7e18 unique values at full length).
+    available = _GCE_MAX_VM_NAME_LEN - len(prefix)
+    assert available > 0, f'machine name prefix is too long for GCE: {prefix!r}'
+    suffix_len = min(12, available)
+    return f'{prefix}{secret_alnum_string(suffix_len, case="lower")}'
 
 
 def build_inst_coll_regex(machine_name_prefix: str) -> re.Pattern:
-    # The suffix must be length-specific so the greedy .* doesn't consume hyphenated
-    # inst_coll names (e.g. 'standard-np') into the inst_coll group.
-    # Old suffix: 5 alphanum chars. New suffix: two 6-char alphanum groups separated by a hyphen.
-    return re.compile(f'{machine_name_prefix}(?P<inst_coll>.*)-(?:[a-z0-9]{{5}}|[a-z0-9]{{6}}-[a-z0-9]{{6}})$')
+    # The suffix contains no hyphens, so greedy .* naturally stops at the last '-'.
+    # This correctly handles hyphenated inst_coll names (e.g. 'standard-np').
+    return re.compile(f'{machine_name_prefix}(?P<inst_coll>.*)-[a-z0-9]+$')

--- a/batch/test/test_utils.py
+++ b/batch/test/test_utils.py
@@ -13,6 +13,7 @@ from batch.cloud.gcp.resource_utils import (
 )
 from batch.cloud.gcp.resources import GCPAcceleratorResource, gcp_resource_from_dict
 from batch.cloud.resource_utils import adjust_cores_for_packability
+from batch.driver.naming import build_inst_coll_regex, make_machine_name
 from batch.utils import rewrite_dockerhub_image
 from hailtop.batch_client.parse import parse_memory_in_bytes
 
@@ -236,3 +237,34 @@ def test_gcp_accelerator_to_from_dict():
 def test_rewrite_dockerhub_image(image, expected):
     dockerhub_prefix = "us-central1-docker.pkg.dev/my-project/dockerhubproxy"
     assert rewrite_dockerhub_image(image, dockerhub_prefix) == expected
+
+
+_INST_COLL_NAMES = [
+    'standard',
+    'highmem',
+    'lowmem',
+    'standard-np',  # hyphenated
+    'pool-abcde',  # 5-char last segment (old suffix length)
+    'pool-abcdef',  # 6-char last segment (half of new suffix)
+    'pool-abcdef-ghijkl',  # 6-6 last two segments (looks like new suffix)
+    'pool-abcde-fghij',  # two 5-char segments
+]
+
+
+@pytest.mark.parametrize('inst_coll_name', _INST_COLL_NAMES)
+def test_machine_name_inst_coll_roundtrip(inst_coll_name):
+    manager_prefix = 'batch-worker-default-'
+    child_prefix = f'{manager_prefix}{inst_coll_name}-'
+    machine_name = make_machine_name(child_prefix)
+    match = build_inst_coll_regex(manager_prefix).search(machine_name)
+    assert match is not None, f'regex did not match {machine_name!r}'
+    assert match.group('inst_coll') == inst_coll_name
+
+
+@pytest.mark.parametrize('inst_coll_name', _INST_COLL_NAMES)
+def test_old_style_machine_name_inst_coll_roundtrip(inst_coll_name):
+    manager_prefix = 'batch-worker-default-'
+    machine_name = f'{manager_prefix}{inst_coll_name}-ab1cd'  # fixed 5-char alphanumeric suffix
+    match = build_inst_coll_regex(manager_prefix).search(machine_name)
+    assert match is not None, f'regex did not match {machine_name!r}'
+    assert match.group('inst_coll') == inst_coll_name

--- a/batch/test/test_utils.py
+++ b/batch/test/test_utils.py
@@ -16,6 +16,7 @@ from batch.cloud.resource_utils import adjust_cores_for_packability
 from batch.driver.naming import build_inst_coll_regex, make_machine_name
 from batch.utils import rewrite_dockerhub_image
 from hailtop.batch_client.parse import parse_memory_in_bytes
+from hailtop.utils import secret_alnum_string
 
 
 def test_packability():
@@ -244,9 +245,9 @@ _INST_COLL_NAMES = [
     'highmem',
     'lowmem',
     'standard-np',  # hyphenated
-    'pool-abcde',  # 5-char last segment (old suffix length)
-    'pool-abcdef',  # 6-char last segment (half of new suffix)
-    'pool-abcdef-ghijkl',  # 6-6 last two segments (looks like new suffix)
+    'pool-abcde',  # last segment looks like an old 5-char suffix
+    'pool-abcdef',  # last segment looks like half the old 6-6 suffix
+    'pool-abcdef-ghijkl',  # last two segments look like the old 6-6 suffix
     'pool-abcde-fghij',  # two 5-char segments
 ]
 
@@ -256,6 +257,20 @@ def test_machine_name_inst_coll_roundtrip(inst_coll_name):
     manager_prefix = 'batch-worker-default-'
     child_prefix = f'{manager_prefix}{inst_coll_name}-'
     machine_name = make_machine_name(child_prefix)
+    assert len(machine_name) <= 63, f'machine name exceeds GCE limit: {machine_name!r}'
+    match = build_inst_coll_regex(manager_prefix).search(machine_name)
+    assert match is not None, f'regex did not match {machine_name!r}'
+    assert match.group('inst_coll') == inst_coll_name
+
+
+@pytest.mark.parametrize('inst_coll_name', _INST_COLL_NAMES)
+def test_machine_name_inst_coll_roundtrip_long_namespace(inst_coll_name):
+    # Verify names stay within GCE's 63-char limit even with long namespaces (e.g. CI test namespaces).
+    ns = secret_alnum_string(20, case='lower')
+    manager_prefix = f'batch-worker-{ns}-'
+    child_prefix = f'{manager_prefix}{inst_coll_name}-'
+    machine_name = make_machine_name(child_prefix)
+    assert len(machine_name) <= 63, f'machine name exceeds GCE limit: {machine_name!r}'
     match = build_inst_coll_regex(manager_prefix).search(machine_name)
     assert match is not None, f'regex did not match {machine_name!r}'
     assert match.group('inst_coll') == inst_coll_name


### PR DESCRIPTION
## Change Description

Fixes a couple of issues in the batch-driver causing restarts and noisy error logs:

- Race condition deleting instances - `monitor_instances` can try to delete an instance already handled by the activity log handler. If so, we hit an `assert` error and the driver crashes and restarts. 
- Instance name collisions - we never delete any instance details from the database, so any re-generation of any previously used (random) ID is an error. Causes: noisy logs, wasted database round trips.
- MySQL lateral join warnings - we already filtered some of these out, but some got through. Luckily the SQL completed and this is just a log. Causes: Noisy logs
- Instance inactivity logs at error level - causes: unnecessary noise trying to debug real problems
- 

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Better resilience to an observable race condition. Also noisy error log reduction to make tracking system status easier.

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
