### PR TITLE
[batch] Fix issues with JVM Profiles UI (take 2)

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -2874,7 +2874,11 @@ async def ui_get_jvm_profile(request: web.Request, _, batch_id: int) -> web.Resp
     profile = await _get_jvm_profile(app, batch_id, job_id)
     if profile is None:
         raise web.HTTPNotFound()
-    return web.Response(text=profile, content_type='text/html')
+    return web.Response(
+        text=profile,
+        content_type='text/html',
+        headers={'Content-Disposition': 'attachment; filename="jvm_profile.html"'},
+    )
 
 
 @routes.get('/batches/{batch_id}/jobs/{job_id}')

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -2877,7 +2877,7 @@ async def ui_get_jvm_profile(request: web.Request, _, batch_id: int) -> web.Resp
     return web.Response(
         text=profile,
         content_type='text/html',
-        headers={'Content-Disposition': 'attachment; filename="jvm_profile.html"'},
+        headers={'Content-Disposition': f'attachment; filename="{batch_id}_{job_id}_jvm_profile.html"'},
     )
 
 

--- a/batch/batch/front_end/templates/job.html
+++ b/batch/batch/front_end/templates/job.html
@@ -134,9 +134,9 @@
   <div class='w-full lg:basis-2/3 overflow-auto'>
     <div>
       {% if has_jvm_profile %}
-      <a href="{{ base_path }}/batches/{{ batch_id }}/jobs/{{ job_id }}/jvm_profile" download="jvm_profile.html" class="text-sm text-sky-600 hover:underline flex items-center gap-1">
+      <a href="{{ base_path }}/batches/{{ batch_id }}/jobs/{{ job_id }}/jvm_profile" download="{{ batch_id }}_{{ job_id }}_jvm_profile.html" class="text-sm text-sky-600 hover:underline flex items-center gap-1">
         <span class="material-symbols-outlined text-base leading-none">download</span>
-        Download JVM Profile
+        JVM Profile
       </a>
       {% endif %}
 

--- a/batch/batch/front_end/templates/job.html
+++ b/batch/batch/front_end/templates/job.html
@@ -134,7 +134,10 @@
   <div class='w-full lg:basis-2/3 overflow-auto'>
     <div>
       {% if has_jvm_profile %}
-      <a href="{{ base_path }}/batches/{{ batch_id }}/jobs/{{ job_id }}/jvm_profile">JVM Profile</a>
+      <a href="{{ base_path }}/batches/{{ batch_id }}/jobs/{{ job_id }}/jvm_profile" download="jvm_profile.html" class="text-sm text-sky-600 hover:underline flex items-center gap-1">
+        <span class="material-symbols-outlined text-base leading-none">download</span>
+        Download JVM Profile
+      </a>
       {% endif %}
 
       {% if plot_job_durations is not none %}

--- a/devbin/dev_proxy.py
+++ b/devbin/dev_proxy.py
@@ -155,6 +155,27 @@ async def openapi_yaml_route(request: web.Request) -> web.Response:
     return web.Response(body=body, content_type='text/yaml')
 
 
+@routes.get('/{service:[^/]+}/batches/{batch_id}/jobs/{job_id}/jvm_profile')
+async def jvm_profile_passthrough(request: web.Request) -> web.Response:
+    service = request.match_info['service']
+    if service not in ALL_SERVICES:
+        raise web.HTTPNotFound()
+    backend_client = request.app[BC]
+    backend_route = _backend_url(service, request.raw_path)
+    headers = {}
+    if request.cookies:
+        headers['Cookie'] = '; '.join(f'{k}={v}' for k, v in request.cookies.items())
+    try:
+        async with await backend_client.request(request.method, backend_route, headers=headers) as resp:
+            body = await resp.read()
+            content_disposition = resp.headers.get('Content-Disposition', '')
+    except httpx.ClientResponseError as e:
+        if e.status == 404:
+            raise web.HTTPNotFound()
+        raise
+    return web.Response(body=body, content_type='text/html', headers={'Content-Disposition': content_disposition})
+
+
 @routes.view('/{route:.*}')
 @web_security_headers
 async def default_proxied_web_route(request: web.Request) -> web.Response:

--- a/devbin/dev_proxy.py
+++ b/devbin/dev_proxy.py
@@ -168,6 +168,8 @@ async def _proxy(request: web.Request, service: str) -> dict:
     backend_client = request.app[BC]
     backend_route = _backend_url(service, request.raw_path)
     headers = {'x-hail-return-jinja-context': '1'}
+    if request.cookies:
+        headers['Cookie'] = '; '.join(f'{k}={v}' for k, v in request.cookies.items())
     try:
         async with await backend_client.request(request.method, backend_route, headers=headers) as resp:
             return await resp.json()

--- a/services/ui/src/batch/components/JobPage.tsx
+++ b/services/ui/src/batch/components/JobPage.tsx
@@ -227,10 +227,12 @@ export function JobPage({ basePath, batchId, jobId }: Props): JSX.Element {
         <JobStatusPanel
           batchId={batchId}
           jobId={jobId}
+          basePath={basePath}
           job={job}
           latestAttempt={latestAttempt}
           autoRefresh={autoRefresh}
           isTerminal={isTerminal}
+          hasJvmProfile={job.spec?.process?.type === 'jvm' && job.spec.process.profile === true}
           onAutoRefreshToggle={handleAutoRefreshToggle}
           countdownKey={countdownKey}
           refreshIntervalMs={refreshIntervalMs}

--- a/services/ui/src/batch/components/JobStatusPanel.tsx
+++ b/services/ui/src/batch/components/JobStatusPanel.tsx
@@ -108,8 +108,9 @@ export function JobStatusPanel({ batchId, jobId, basePath, job, latestAttempt, a
         )}
         {hasJvmProfile && isTerminal && (
           <li className="p-4">
-            <a href={`${basePath}/batches/${batchId}/jobs/${jobId}/jvm_profile_wrapped`} className="text-sky-600 hover:underline text-sm">
-              View JVM profile
+            <a href={`${basePath}/batches/${batchId}/jobs/${jobId}/jvm_profile`} download="jvm_profile.html" className="text-sm text-sky-600 hover:underline flex items-center gap-1">
+              <span className="material-symbols-outlined text-base leading-none">download</span>
+              Download JVM profile
             </a>
           </li>
         )}

--- a/services/ui/src/batch/components/JobStatusPanel.tsx
+++ b/services/ui/src/batch/components/JobStatusPanel.tsx
@@ -108,9 +108,9 @@ export function JobStatusPanel({ batchId, jobId, basePath, job, latestAttempt, a
         )}
         {hasJvmProfile && isTerminal && (
           <li className="p-4">
-            <a href={`${basePath}/batches/${batchId}/jobs/${jobId}/jvm_profile`} download="jvm_profile.html" className="text-sm text-sky-600 hover:underline flex items-center gap-1">
+            <a href={`${basePath}/batches/${batchId}/jobs/${jobId}/jvm_profile`} download={`${batchId}_${jobId}_jvm_profile.html`} className="text-sm text-sky-600 hover:underline flex items-center gap-1">
               <span className="material-symbols-outlined text-base leading-none">download</span>
-              Download JVM profile
+              JVM profile
             </a>
           </li>
         )}

--- a/services/ui/src/batch/components/JobStatusPanel.tsx
+++ b/services/ui/src/batch/components/JobStatusPanel.tsx
@@ -19,17 +19,19 @@ function CostDisplay({ cost }: { cost: number }): JSX.Element {
 interface Props {
   batchId: string;
   jobId: string;
+  basePath: string;
   job: Job;
   latestAttempt: Attempt | null;
   autoRefresh: boolean;
   isTerminal: boolean;
+  hasJvmProfile: boolean;
   onAutoRefreshToggle: (_checked: boolean) => void;
   countdownKey: number;
   refreshIntervalMs: number;
   jobRefreshing: boolean;
 }
 
-export function JobStatusPanel({ batchId, jobId, job, latestAttempt, autoRefresh, isTerminal, onAutoRefreshToggle, countdownKey, refreshIntervalMs, jobRefreshing }: Props): JSX.Element {
+export function JobStatusPanel({ batchId, jobId, basePath, job, latestAttempt, autoRefresh, isTerminal, hasJvmProfile, onAutoRefreshToggle, countdownKey, refreshIntervalMs, jobRefreshing }: Props): JSX.Element {
   return (
     <div className="w-full lg:basis-1/4 drop-shadow-sm shrink-0">
       <ul className="border border-collapse divide-y bg-slate-50 rounded">
@@ -103,6 +105,13 @@ export function JobStatusPanel({ batchId, jobId, job, latestAttempt, autoRefresh
               </table>
             )}
           </CollapsibleItem>
+        )}
+        {hasJvmProfile && isTerminal && (
+          <li className="p-4">
+            <a href={`${basePath}/batches/${batchId}/jobs/${jobId}/jvm_profile_wrapped`} className="text-sky-600 hover:underline text-sm">
+              View JVM profile
+            </a>
+          </li>
         )}
       </ul>
     </div>


### PR DESCRIPTION
## Change Description

Two fixes:

- Add a JVM profile link to the new react UI job details page
- Change the profile access link to download rather than page load. 

Example in the UI:

<img width="452" height="296" alt="image" src="https://github.com/user-attachments/assets/9c4687a8-8071-4bd0-a305-74ceb7cf1ef3" />


Note: In comparison to #15712, this sidesteps the CSP issues, the iframe/sandbox juggling and feels closer to the original profiler intent of "generate a standalone HTML file". 

I still think the better long term solution will be to host the data over an API and a viewer component embedded in the UI, but this is a lot simpler for now.

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

- Adds a link in the new react ui in analogy to the old html page.
- Changes the link from page-load to download.
- And **Note**: Changes in the local devserver have no impact in prod

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
