### PR TITLE
[github] apply dataproc label to pip bump PRs

### DIFF
--- a/.github/workflows/pip-npm-bump.yml
+++ b/.github/workflows/pip-npm-bump.yml
@@ -2,7 +2,7 @@ name: Weekly pip/npm bump
 
 on:
   schedule:
-    - cron: '0 9 * * 5'  # Friday 9am UTC
+    - cron: '0 4 * * 5'  # Friday 4am UTC
   workflow_dispatch:
 
 permissions:
@@ -84,4 +84,5 @@ jobs:
           gh pr create \
             --title "[services] pip npm bump ${{ steps.date.outputs.value }}" \
             --body "$PR_BODY" \
-            --base main
+            --base main \
+            --label run-dataproc-tests


### PR DESCRIPTION
## Change Description

Run dataproc tests when updating pip dependencies.

Also move the trigger earlier in the day to hopefully avoid Us and European busy times (today's actions didn't automatically trigger, presumably because of action overload)


## Security Assessment

- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP