### PR TITLE
[batch] Resolve `_create_job_groups` vs `cancel_job_group_in_db` deadlock (try 2)

### DIFF
--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -168,14 +168,11 @@ def job_record_to_dict(record: Dict[str, Any], name: Optional[str]) -> JobListEn
 async def cancel_job_group_in_db(db, batch_id, job_group_id):
     @transaction(db)
     async def cancel(tx):
-        # Plain MVCC read — no locks needed. Locks were previously acquired here (SELECT ... FOR UPDATE)
-        # but they would be released by START TRANSACTION in the cancel_job_group stored procedure
-        # before it does any real work, so they were never protecting anything.
+        # Quick sanity check for a nicer error message before calling the cancel_job_group stored procedure.
         #
-        # In the case that it does somehow happen that a batch is lost or (soft) deleted
-        # between this check and the cancel_job_group stored procedure, the stored procedure
-        # proceeds, but maybe a soft-deleted database record gets its state updated
-        # to cancelled... pretty harmless.
+        # No SELECT ... FOR UPDATE lock here: the stored procedure has its own checks and any lock would be
+        # released by the START TRANSACTION in the stored procedure anyway. The "worst case" of calling
+        # cancel on a deleted batch due to a race condition is harmless in practice.
         record = await tx.execute_and_fetchone(
             """
 SELECT 1

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -168,28 +168,22 @@ def job_record_to_dict(record: Dict[str, Any], name: Optional[str]) -> JobListEn
 async def cancel_job_group_in_db(db, batch_id, job_group_id):
     @transaction(db)
     async def cancel(tx):
-        # Check batch exists and is not deleted via MVCC (no lock on batches).
-        # Joining batches with FOR UPDATE previously caused a deadlock: cancel acquired
-        # X on job_groups then waited for X on batches, while _create_job_groups held
-        # S on batches and waited on cancel's gap lock in job_groups.
-        # A cascade-delete of the batch will remove job_groups rows, so if the batch
-        # is deleted between this check and the FOR UPDATE below, we get no rows and
-        # raise NonExistentJobGroupError — which is correct.
-        batch = await tx.execute_and_fetchone(
-            'SELECT 1 FROM batches WHERE id = %s AND NOT deleted;',
-            (batch_id,),
-        )
-        if not batch:
-            raise NonExistentJobGroupError(batch_id, job_group_id)
-
+        # Plain MVCC read — no locks needed. Locks were previously acquired here (SELECT ... FOR UPDATE)
+        # but they would be released by START TRANSACTION in the cancel_job_group stored procedure
+        # before it does any real work, so they were never protecting anything.
+        #
+        # In the case that it does somehow happen that a batch is lost or (soft) deleted
+        # between this check and the cancel_job_group stored procedure, the stored procedure
+        # proceeds, but maybe a soft-deleted database record gets its state updated
+        # to cancelled... pretty harmless.
         record = await tx.execute_and_fetchone(
             """
 SELECT 1
 FROM job_groups
+LEFT JOIN batches ON batches.id = job_groups.batch_id
 LEFT JOIN batch_updates ON job_groups.batch_id = batch_updates.batch_id AND
   job_groups.update_id = batch_updates.update_id
-WHERE job_groups.batch_id = %s AND job_groups.job_group_id = %s AND (batch_updates.committed OR job_groups.job_group_id = %s)
-FOR UPDATE;
+WHERE job_groups.batch_id = %s AND job_groups.job_group_id = %s AND NOT deleted AND (batch_updates.committed OR job_groups.job_group_id = %s);
 """,
             (batch_id, job_group_id, ROOT_JOB_GROUP_ID),
         )

--- a/batch/batch/batch.py
+++ b/batch/batch/batch.py
@@ -168,14 +168,27 @@ def job_record_to_dict(record: Dict[str, Any], name: Optional[str]) -> JobListEn
 async def cancel_job_group_in_db(db, batch_id, job_group_id):
     @transaction(db)
     async def cancel(tx):
+        # Check batch exists and is not deleted via MVCC (no lock on batches).
+        # Joining batches with FOR UPDATE previously caused a deadlock: cancel acquired
+        # X on job_groups then waited for X on batches, while _create_job_groups held
+        # S on batches and waited on cancel's gap lock in job_groups.
+        # A cascade-delete of the batch will remove job_groups rows, so if the batch
+        # is deleted between this check and the FOR UPDATE below, we get no rows and
+        # raise NonExistentJobGroupError — which is correct.
+        batch = await tx.execute_and_fetchone(
+            'SELECT 1 FROM batches WHERE id = %s AND NOT deleted;',
+            (batch_id,),
+        )
+        if not batch:
+            raise NonExistentJobGroupError(batch_id, job_group_id)
+
         record = await tx.execute_and_fetchone(
             """
 SELECT 1
 FROM job_groups
-LEFT JOIN batches ON batches.id = job_groups.batch_id
 LEFT JOIN batch_updates ON job_groups.batch_id = batch_updates.batch_id AND
   job_groups.update_id = batch_updates.update_id
-WHERE job_groups.batch_id = %s AND job_groups.job_group_id = %s AND NOT deleted AND (batch_updates.committed OR job_groups.job_group_id = %s)
+WHERE job_groups.batch_id = %s AND job_groups.job_group_id = %s AND (batch_updates.committed OR job_groups.job_group_id = %s)
 FOR UPDATE;
 """,
             (batch_id, job_group_id, ROOT_JOB_GROUP_ID),

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1149,9 +1149,7 @@ WHERE batch_id = %s AND update_id = %s AND job_group_id BETWEEN %s AND %s;
                 )
             except asyncio.CancelledError:
                 raise
-            except pymysql.err.IntegrityError:
-                raise
-            except (pymysql.err.OperationalError, pymysql.err.InternalError):
+            except (pymysql.err.IntegrityError, pymysql.err.OperationalError, pymysql.err.InternalError):
                 raise
             except Exception as e:
                 raise web.HTTPBadRequest(

--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -1151,6 +1151,8 @@ WHERE batch_id = %s AND update_id = %s AND job_group_id BETWEEN %s AND %s;
                 raise
             except pymysql.err.IntegrityError:
                 raise
+            except (pymysql.err.OperationalError, pymysql.err.InternalError):
+                raise
             except Exception as e:
                 raise web.HTTPBadRequest(
                     reason=f'error while inserting job group {spec["job_group_id"]} into batch {batch_id}: {e}'


### PR DESCRIPTION
## Change Description

Fixes #14413 
Resurrects and continues work from #14993 and #15722

Fixes a deadlock between two job group functions (create and delete). In the original code:

- `cancel_job_group_in_db` grabs a lock on `job_groups` then tries to get a lock on `batches`
- `_create_job_groups` grabs a lock on `batches` then tries to get a lock on `job_groups`
- One wins and is allowed to continue, the other fails and gets an error back from mysql.

Now:
- Thanks to copilot in #15722 (commit 1): allow deadlock errors to be retried, not returned to the client as a 400.
- We don't bother locking on the cancel path. The locks taken out in python were lost when the stored procedure runs `START_TRANSACTION` anyway, so it was a false security anyway.
  - Note that if the batch does get lost or soft deleted between the initial check and the transaction in the stored procedure, we might try to cancel an already-deleted batch. Two mitigations: (1) it's already deleted, so running cancel on it is unlikely to have any serious impact. Perhaps the final state of the already-deleted batch changes from failed to canceled 🤷‍♂️. The stored procedure has some sanity checking of its own, in-procedure, which is the right place for it (and for any more we might want to append) and (2) deleting is a very rare, manually triggered action, on batches which are already marked as complete. So very unlikely to happen concurrently, and definitely not at a scale that would cause a problem.
  - And note: This is not a regression, this is already the status quo because the START TRANSACTION is already dropping the locks from python. 

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Improve resilience by removing a deadlock risk

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
