### PR TITLE
[batch] surface region details for job attempts in the UI

### DIFF
--- a/batch/batch/front_end/front_end.py
+++ b/batch/batch/front_end/front_end.py
@@ -2542,10 +2542,11 @@ async def _get_attempts(app, batch_id, job_id):
 
     attempts = db.select_and_fetchall(
         """
-SELECT attempts.*
+SELECT attempts.*, instances.location
 FROM jobs
 INNER JOIN batches ON jobs.batch_id = batches.id
 LEFT JOIN attempts ON jobs.batch_id = attempts.batch_id and jobs.job_id = attempts.job_id
+LEFT JOIN instances ON attempts.instance_name = instances.name
 WHERE jobs.batch_id = %s AND NOT deleted AND jobs.job_id = %s;
 """,
         (batch_id, job_id),
@@ -2976,6 +2977,16 @@ async def ui_get_job(request, userdata, batch_id):
             non_io_storage_limit_bytes = int(non_io_storage_limit_gb * 1024**3 + 1)
             resources['actual_cpu'] = cores
             del resources['cores_mcpu']
+
+        spec_regions = job['spec'].get('regions') if job.get('spec') else None
+        if spec_regions:
+            resources['req_regions'] = ', '.join(spec_regions)
+
+        original_status = job.get('status')
+        if original_status:
+            actual_region = original_status.get('region')
+            if actual_region:
+                resources['actual_region'] = actual_region
 
     # Not all logs will be proper utf-8 but we attempt to show them as
     # str or else Jinja will present them surrounded by b''

--- a/batch/batch/front_end/templates/openapi.yaml
+++ b/batch/batch/front_end/templates/openapi.yaml
@@ -2134,6 +2134,10 @@ components:
         instance_name:
           type: string
           description: "Name of the instance that ran the attempt"
+        location:
+          type: string
+          description: "Zone or region where the attempt ran (e.g. 'us-central1-a')"
+          nullable: true
         start_time:
           type: string
           format: date-time

--- a/services/ui/src/batch/components/AttemptPanel.tsx
+++ b/services/ui/src/batch/components/AttemptPanel.tsx
@@ -91,6 +91,12 @@ export function AttemptPanel({
                 <td className="py-2 font-mono">{attempt.instance_name}</td>
               </tr>
             )}
+            {attempt.location && (
+              <tr className="border-t">
+                <td className="py-2 pr-4 text-zinc-500">Location</td>
+                <td className="py-2">{attempt.location}</td>
+              </tr>
+            )}
             {attempt.start_time_ms != null && (
               <tr className="border-t">
                 <td className="py-2 pr-4 text-zinc-500">Started</td>

--- a/services/ui/src/batch/components/JobPage.tsx
+++ b/services/ui/src/batch/components/JobPage.tsx
@@ -130,10 +130,10 @@ export function JobPage({ basePath, batchId, jobId }: Props): JSX.Element {
 
   const [topTab, setTopTabState] = useState<TopTab>(getInitialTab);
 
-  const [specSubTab, setSpecSubTab] = useState<'input' | 'main' | 'output'>(() => {
+  const [specSubTab, setSpecSubTab] = useState<'details' | 'input' | 'main' | 'output'>(() => {
     const params = new URLSearchParams(window.location.search);
     const sub = params.get('subtab');
-    return sub === 'input' || sub === 'output' ? sub : 'main';
+    return sub === 'input' || sub === 'main' || sub === 'output' ? sub : 'details';
   });
 
   const [attemptSubTabs, setAttemptSubTabs] = useState<Record<string, 'details' | 'charts' | 'input' | 'main' | 'output'>>(() => {
@@ -158,7 +158,7 @@ export function JobPage({ basePath, batchId, jobId }: Props): JSX.Element {
     window.history.replaceState(null, '', `?${params.toString()}`);
   }, []);
 
-  const updateSpecSubTab = useCallback((sub: 'input' | 'main' | 'output') => {
+  const updateSpecSubTab = useCallback((sub: 'details' | 'input' | 'main' | 'output') => {
     setSpecSubTab(sub);
     const params = new URLSearchParams(window.location.search);
     params.set('subtab', sub);

--- a/services/ui/src/batch/components/JobSpecPanel.tsx
+++ b/services/ui/src/batch/components/JobSpecPanel.tsx
@@ -37,9 +37,10 @@ interface Props {
   instColl?: string;
 }
 
-type SubTab = 'input' | 'main' | 'output';
+type SubTab = 'details' | 'input' | 'main' | 'output';
 
 const SUB_TABS: { id: SubTab; label: string }[] = [
+  { id: 'details', label: 'Details' },
   { id: 'input', label: 'Input' },
   { id: 'main', label: 'Main' },
   { id: 'output', label: 'Output' },
@@ -134,30 +135,10 @@ export function JobSpecPanel({
         </div>
       )}
 
-      {activeSubTab === 'main' && (
+      {activeSubTab === 'details' && (
         <div className="space-y-4 py-2">
           {spec?.process ? (
             <>
-              {spec.process.type === 'docker' && spec.process.image && (
-                <CollapsibleSection title="Image" defaultOpen>
-                  <div className="font-mono text-sm break-all">{spec.process.image}</div>
-                </CollapsibleSection>
-              )}
-              {spec.user_code && (
-                <CollapsibleSection title="User Code" defaultOpen>
-                  <CodeBlock code={spec.user_code} />
-                </CollapsibleSection>
-              )}
-              {spec.process.command && (
-                <CollapsibleSection title="Command" defaultOpen>
-                  <CodeBlock code={spec.process.command.join("' '")} />
-                </CollapsibleSection>
-              )}
-              {spec.process.type === 'jvm' && spec.process.jar_spec && (
-                <CollapsibleSection title="JAR" defaultOpen>
-                  <div className="font-mono text-sm">{spec.process.jar_spec.type}: {spec.process.jar_spec.value}</div>
-                </CollapsibleSection>
-              )}
               {(reqCpu != null || reqMemory != null || reqStorage != null || requestedMachineType != null) && (
                 <CollapsibleSection title="Resources" defaultOpen>
                   <table className="text-sm border-collapse w-full max-w-sm">
@@ -323,6 +304,37 @@ export function JobSpecPanel({
                   )}
                 </div>
               </CollapsibleSection>
+            </>
+          ) : (
+            <div className="text-zinc-400 text-sm">No spec available.</div>
+          )}
+        </div>
+      )}
+
+      {activeSubTab === 'main' && (
+        <div className="space-y-4 py-2">
+          {spec?.process ? (
+            <>
+              {spec.process.type === 'docker' && spec.process.image && (
+                <CollapsibleSection title="Image" defaultOpen>
+                  <div className="font-mono text-sm break-all">{spec.process.image}</div>
+                </CollapsibleSection>
+              )}
+              {spec.user_code && (
+                <CollapsibleSection title="User Code" defaultOpen>
+                  <CodeBlock code={spec.user_code} />
+                </CollapsibleSection>
+              )}
+              {spec.process.command && (
+                <CollapsibleSection title="Command" defaultOpen>
+                  <CodeBlock code={spec.process.command.join("' '")} />
+                </CollapsibleSection>
+              )}
+              {spec.process.type === 'jvm' && spec.process.jar_spec && (
+                <CollapsibleSection title="JAR" defaultOpen>
+                  <div className="font-mono text-sm">{spec.process.jar_spec.type}: {spec.process.jar_spec.value}</div>
+                </CollapsibleSection>
+              )}
             </>
           ) : (
             <div className="text-zinc-400 text-sm">No spec available.</div>

--- a/services/ui/src/batch/components/jobModels.ts
+++ b/services/ui/src/batch/components/jobModels.ts
@@ -76,6 +76,7 @@ export type Job = {
 export type Attempt = {
   attempt_id: string;
   instance_name?: string;
+  location?: string;
   start_time?: string;
   start_time_ms?: number;
   end_time?: string;


### PR DESCRIPTION
## Change Description

In the jinja2 templated UI: 
- adds requested and actual region info to the resources panel.

In the new react (attempt-by-attempt) UI: 
- add actual location to attempt details 
- Move the container-agnostic job spec details to their own tab (requested region is already in the job spec)

### Screenshots

#### Jinja2 templated UI:

<img width="457" height="448" alt="image" src="https://github.com/user-attachments/assets/c771df35-fcc4-44f6-b246-291e6cfaf736" />

#### New layout, react UI:

##### Actual per-attempt location:

<img width="597" height="502" alt="image" src="https://github.com/user-attachments/assets/3f0e6a54-7a58-416a-86a9-53ab30456eb1" />

##### Requested region(s) in the job spec:

<img width="437" height="527" alt="image" src="https://github.com/user-attachments/assets/ae58c639-b667-49f2-ae10-a40872ff7775" />


## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Provides an easy way to view data which is already findable (under Raw Details) in a more user friendly way

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
