### PR TITLE
[query] dont forever retry errors that no longer exist

### DIFF
--- a/hail/hail/src/is/hail/services/BatchClient.scala
+++ b/hail/hail/src/is/hail/services/BatchClient.scala
@@ -7,7 +7,7 @@ import is.hail.services.BatchClient.{
 }
 import is.hail.services.JobGroupStates.Running
 import is.hail.services.oauth2.CloudCredentials
-import is.hail.services.requests.{ClientResponseException, Requester}
+import is.hail.services.requests.Requester
 import is.hail.utils._
 
 import scala.collection.compat.immutable.LazyList
@@ -268,40 +268,23 @@ case class BatchClient private (req: Requester) extends Logging with AutoCloseab
     batchId
   }
 
-  def newJobGroup(req: JobGroupRequest): (Int, Int) =
-    retryable { attempts =>
-      try {
-        val batchId = req.batch_id
-        val nJobs = req.jobs.length
-        val (updateId, startJobGroupId, startJobId) = beginUpdate(batchId, req.token, nJobs)
-        logger.info(s"Began update $updateId of batch $batchId.")
+  def newJobGroup(req: JobGroupRequest): (Int, Int) = {
+    val batchId = req.batch_id
+    val nJobs = req.jobs.length
+    val (updateId, startJobGroupId, startJobId) = beginUpdate(batchId, req.token, nJobs)
+    logger.info(s"Began update $updateId of batch $batchId.")
 
-        createJobGroup(updateId, req)
-        logger.info(s"Created job group $startJobGroupId in batch $batchId.")
+    createJobGroup(updateId, req)
+    logger.info(s"Created job group $startJobGroupId in batch $batchId.")
 
-        createJobs(batchId, updateId, req.jobs)
-        logger.info(s"Created $nJobs jobs in job group $startJobGroupId in batch $batchId.")
+    createJobs(batchId, updateId, req.jobs)
+    logger.info(s"Created $nJobs jobs in job group $startJobGroupId in batch $batchId.")
 
-        commitUpdate(batchId, updateId)
-        logger.info(s"Committed update $updateId of batch $batchId.")
+    commitUpdate(batchId, updateId)
+    logger.info(s"Committed update $updateId of batch $batchId.")
 
-        (startJobGroupId, startJobId)
-      } catch {
-        case e: ClientResponseException
-            if e.status == 400
-              && e.getMessage.contains("job group specs were not submitted in order") =>
-          val delay = delayMsForTry(attempts + 1)
-          logger.warn(
-            f"Tried to update batch '${req.batch_id}' before another process could commit " +
-              "an earlier update. This is most likely caused by running parallel query pipelines " +
-              "in the same batch. Batch does not yet support out-of-order updates. Sleeping for " +
-              f"'$delay' ms to allow the other update complete.",
-            e,
-          )
-          Thread.sleep(delay)
-          retry
-      }
-    }
+    (startJobGroupId, startJobId)
+  }
 
   def getJobGroup(batchId: Int, jobGroupId: Int): JobGroupResponse =
     req

--- a/hail/python/test/hailtop/batch/test_batch_service_backend.py
+++ b/hail/python/test/hailtop/batch/test_batch_service_backend.py
@@ -867,7 +867,6 @@ def test_submit_sequential_qob_pipelines(request, service_backend: ServiceBacken
     assert status['state'] == 'success', str((status, r.debug_info()))
 
 
-@pytest.mark.xfail(reason='Concurrent QoB pipelines are not supported', strict=False)
 def test_race_qob_pipelines(request, service_backend: ServiceBackend):
     b = Batch(request.node.nodeid, service_backend, default_image=HAIL_GENETICS_HAIL_IMAGE)
 


### PR DESCRIPTION
#15690 added support for out-of-order job-group creation and so this
failure mode exists no longer.

This change does not affect the broad-managed batch service in gcp.