### PR TITLE
[terraform] remove unused gcr-push user

### DIFF
--- a/infra/gcp-broad/main.tf
+++ b/infra/gcp-broad/main.tf
@@ -593,11 +593,6 @@ resource "google_artifact_registry_repository" "dockerhub_remote" {
   }
 }
 
-resource "google_service_account" "gcr_push" {
-  account_id = "gcr-push"
-  display_name = "push to gcr.io"
-}
-
 resource "google_artifact_registry_repository_iam_member" "artifact_registry_batch_agent_viewer" {
   provider = google-beta
   project = var.gcp_project
@@ -625,15 +620,6 @@ resource "google_artifact_registry_repository_iam_member" "artifact_registry_ci_
   location = var.artifact_registry_location
   role = "roles/artifactregistry.admin"
   member = "serviceAccount:${module.ci_gsa_secret.email}"
-}
-
-resource "google_artifact_registry_repository_iam_member" "artifact_registry_push_admin" {
-  provider = google-beta
-  project = var.gcp_project
-  repository = google_artifact_registry_repository.repository.name
-  location = var.artifact_registry_location
-  role = "roles/artifactregistry.repoAdmin"
-  member = "serviceAccount:${google_service_account.gcr_push.email}"
 }
 
 

--- a/infra/gcp/main.tf
+++ b/infra/gcp/main.tf
@@ -552,15 +552,6 @@ resource "google_artifact_registry_repository" "dockerhub_remote" {
   }
 }
 
-resource "google_service_account" "gcr_push" {
-  account_id = "gcr-push"
-  display_name = "push to gcr.io"
-}
-
-resource "google_service_account_key" "gcr_push_key" {
-  service_account_id = google_service_account.gcr_push.name
-}
-
 resource "google_artifact_registry_repository_iam_member" "artifact_registry_batch_agent_viewer" {
   provider = google-beta
   project = var.gcp_project
@@ -588,22 +579,6 @@ resource "google_artifact_registry_repository_iam_member" "artifact_registry_ci_
   location = var.gcp_location
   role = "roles/artifactregistry.admin"
   member = "serviceAccount:${module.ci_gsa_secret.email}"
-}
-
-resource "google_storage_bucket_iam_member" "gcr_push_admin" {
-  count = var.use_artifact_registry ? 0 : 1
-  bucket = google_container_registry.registry[0].id
-  role = "roles/storage.admin"
-  member = "serviceAccount:${google_service_account.gcr_push.email}"
-}
-
-resource "google_artifact_registry_repository_iam_member" "artifact_registry_push_admin" {
-  provider = google-beta
-  project = var.gcp_project
-  repository = google_artifact_registry_repository.repository.name
-  location = var.gcp_location
-  role = "roles/artifactregistry.admin"
-  member = "serviceAccount:${google_service_account.gcr_push.email}"
 }
 
 resource "google_project_iam_custom_role" "auth_service_account_manager" {


### PR DESCRIPTION
## Change Description

Fixes #14620 

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Removing unused SA

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
