### PR TITLE
[batch] quick ansi color parser for logs

### DIFF
--- a/services/ui/package-lock.json
+++ b/services/ui/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@observablehq/plot": "^0.6.16",
+        "anser": "^2.3.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "recharts": "^3.8.0",
@@ -2178,6 +2179,12 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/anser": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/anser/-/anser-2.3.5.tgz",
+      "integrity": "sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==",
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",

--- a/services/ui/package.json
+++ b/services/ui/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@observablehq/plot": "^0.6.16",
+    "anser": "^2.3.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "recharts": "^3.8.0",

--- a/services/ui/src/batch/components/LogViewer.tsx
+++ b/services/ui/src/batch/components/LogViewer.tsx
@@ -1,4 +1,5 @@
-import { useState, useMemo, useEffect, useRef } from 'react';
+import { useState, useMemo, useEffect, useRef, Fragment } from 'react';
+import { ansiLineToNodes, type AnsiState } from '../../shared/ansi';
 
 type Props = {
   text: string;
@@ -26,6 +27,15 @@ export function LogViewer({ text, downloadUrl, downloadName, hasPendingUpdate, o
     () => (query.trim() ? lines.filter((l) => l.includes(query)) : lines),
     [lines, query]
   );
+
+  const renderedLines = useMemo(() => {
+    let state: AnsiState = {};
+    return filteredLines.map((line, i) => {
+      const { nodes, outgoingState } = ansiLineToNodes(line, state);
+      state = outgoingState;
+      return <Fragment key={i}>{nodes}{i < filteredLines.length - 1 ? '\n' : ''}</Fragment>;
+    });
+  }, [filteredLines]);
 
   return (
     <div className="flex flex-col gap-2">
@@ -69,7 +79,7 @@ export function LogViewer({ text, downloadUrl, downloadName, hasPendingUpdate, o
       </div>
       <div ref={scrollRef} className="bg-slate-50 border rounded overflow-auto" style={{ maxHeight: expanded ? '64rem' : '32rem' }}>
         <pre className="text-sm p-2 whitespace-pre-wrap break-all">
-          {filteredLines.join('\n')}
+          {renderedLines}
         </pre>
       </div>
       {query && (

--- a/services/ui/src/batch/components/LogViewer.tsx
+++ b/services/ui/src/batch/components/LogViewer.tsx
@@ -1,5 +1,5 @@
-import { useState, useMemo, useEffect, useRef, Fragment } from 'react';
-import { ansiLineToNodes, type AnsiState } from '../../shared/ansi';
+import { useState, useMemo, useEffect, useRef } from 'react';
+import { ansiTextToNodes } from '../../shared/ansi';
 
 type Props = {
   text: string;
@@ -28,14 +28,7 @@ export function LogViewer({ text, downloadUrl, downloadName, hasPendingUpdate, o
     [lines, query]
   );
 
-  const renderedLines = useMemo(() => {
-    let state: AnsiState = {};
-    return filteredLines.map((line, i) => {
-      const { nodes, outgoingState } = ansiLineToNodes(line, state);
-      state = outgoingState;
-      return <Fragment key={i}>{nodes}{i < filteredLines.length - 1 ? '\n' : ''}</Fragment>;
-    });
-  }, [filteredLines]);
+  const renderedLines = useMemo(() => ansiTextToNodes(filteredLines.join('\n')), [filteredLines]);
 
   return (
     <div className="flex flex-col gap-2">

--- a/services/ui/src/shared/ansi.test.tsx
+++ b/services/ui/src/shared/ansi.test.tsx
@@ -26,4 +26,11 @@ describe('ansiTextToNodes', () => {
     const container = renderText('\x1b[1mbold\x1b[0m');
     expect(container.querySelector('span')?.style.fontWeight).toBe('bold');
   });
+
+  it('combines underline and strikethrough when both apply to the same span', () => {
+    const container = renderText('\x1b[4;9mboth\x1b[0m');
+    const textDecoration = container.querySelector('span')?.style.textDecoration;
+    expect(textDecoration).toContain('underline');
+    expect(textDecoration).toContain('line-through');
+  });
 });

--- a/services/ui/src/shared/ansi.test.tsx
+++ b/services/ui/src/shared/ansi.test.tsx
@@ -1,0 +1,38 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ansiLineToNodes } from './ansi';
+
+function renderLine(line: string) {
+  const { nodes } = ansiLineToNodes(line, {});
+  const { container } = render(<>{nodes}</>);
+  return container;
+}
+
+describe('ansiLineToNodes', () => {
+  it('returns plain text unchanged when there are no escape codes', () => {
+    const container = renderLine('hello world');
+    expect(container.textContent).toBe('hello world');
+    expect(container.querySelector('span')).toBeNull();
+  });
+
+  it('colors text wrapped in an SGR color code', () => {
+    const container = renderLine('\x1b[31merror\x1b[0m ok');
+    expect(container.textContent).toBe('error ok');
+    const span = container.querySelector('span');
+    expect(span?.textContent).toBe('error');
+    expect(span?.style.color).toBe('rgb(220, 38, 38)');
+  });
+
+  it('carries state across lines until reset', () => {
+    const first = ansiLineToNodes('\x1b[32mstarted', {});
+    expect(first.outgoingState.fg).toBe('#16a34a');
+    const second = ansiLineToNodes('still green', first.outgoingState);
+    const { container } = render(<>{second.nodes}</>);
+    expect(container.querySelector('span')?.style.color).toBe('rgb(22, 163, 74)');
+  });
+
+  it('supports 256-color and truecolor SGR sequences', () => {
+    const truecolor = renderLine('\x1b[38;2;10;20;30mrgb\x1b[0m');
+    expect(truecolor.querySelector('span')?.style.color).toBe('rgb(10, 20, 30)');
+  });
+});

--- a/services/ui/src/shared/ansi.test.tsx
+++ b/services/ui/src/shared/ansi.test.tsx
@@ -14,7 +14,7 @@ describe('ansiTextToNodes', () => {
     expect(container.querySelector('span')).toBeNull();
   });
 
-  it('colors text wrapped in an SGR color code', () => {
+  it('maps an SGR color code to a CSS color style', () => {
     const container = renderText('\x1b[31merror\x1b[0m ok');
     expect(container.textContent).toBe('error ok');
     const span = container.querySelector('span');
@@ -22,19 +22,8 @@ describe('ansiTextToNodes', () => {
     expect(span?.style.color).toBe('rgb(187, 0, 0)');
   });
 
-  it('carries state across lines until reset', () => {
-    const container = renderText('\x1b[32mstarted\nstill green\x1b[0m\nplain');
-    const span = container.querySelector('span');
-    expect(span?.textContent).toBe('started\nstill green');
-    expect(span?.style.color).toBe('rgb(0, 187, 0)');
-    expect(container.textContent).toBe('started\nstill green\nplain');
-  });
-
-  it('supports 256-color and truecolor SGR sequences', () => {
-    const truecolor = renderText('\x1b[38;2;10;20;30mrgb\x1b[0m');
-    expect(truecolor.querySelector('span')?.style.color).toBe('rgb(10, 20, 30)');
-
-    const palette = renderText('\x1b[38;5;208morange\x1b[0m');
-    expect(palette.querySelector('span')?.style.color).toBe('rgb(255, 135, 0)');
+  it('maps SGR decorations to CSS styles', () => {
+    const container = renderText('\x1b[1mbold\x1b[0m');
+    expect(container.querySelector('span')?.style.fontWeight).toBe('bold');
   });
 });

--- a/services/ui/src/shared/ansi.test.tsx
+++ b/services/ui/src/shared/ansi.test.tsx
@@ -1,38 +1,40 @@
 import { render } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { ansiLineToNodes } from './ansi';
+import { ansiTextToNodes } from './ansi';
 
-function renderLine(line: string) {
-  const { nodes } = ansiLineToNodes(line, {});
-  const { container } = render(<>{nodes}</>);
+function renderText(text: string) {
+  const { container } = render(<>{ansiTextToNodes(text)}</>);
   return container;
 }
 
-describe('ansiLineToNodes', () => {
+describe('ansiTextToNodes', () => {
   it('returns plain text unchanged when there are no escape codes', () => {
-    const container = renderLine('hello world');
+    const container = renderText('hello world');
     expect(container.textContent).toBe('hello world');
     expect(container.querySelector('span')).toBeNull();
   });
 
   it('colors text wrapped in an SGR color code', () => {
-    const container = renderLine('\x1b[31merror\x1b[0m ok');
+    const container = renderText('\x1b[31merror\x1b[0m ok');
     expect(container.textContent).toBe('error ok');
     const span = container.querySelector('span');
     expect(span?.textContent).toBe('error');
-    expect(span?.style.color).toBe('rgb(220, 38, 38)');
+    expect(span?.style.color).toBe('rgb(187, 0, 0)');
   });
 
   it('carries state across lines until reset', () => {
-    const first = ansiLineToNodes('\x1b[32mstarted', {});
-    expect(first.outgoingState.fg).toBe('#16a34a');
-    const second = ansiLineToNodes('still green', first.outgoingState);
-    const { container } = render(<>{second.nodes}</>);
-    expect(container.querySelector('span')?.style.color).toBe('rgb(22, 163, 74)');
+    const container = renderText('\x1b[32mstarted\nstill green\x1b[0m\nplain');
+    const span = container.querySelector('span');
+    expect(span?.textContent).toBe('started\nstill green');
+    expect(span?.style.color).toBe('rgb(0, 187, 0)');
+    expect(container.textContent).toBe('started\nstill green\nplain');
   });
 
   it('supports 256-color and truecolor SGR sequences', () => {
-    const truecolor = renderLine('\x1b[38;2;10;20;30mrgb\x1b[0m');
+    const truecolor = renderText('\x1b[38;2;10;20;30mrgb\x1b[0m');
     expect(truecolor.querySelector('span')?.style.color).toBe('rgb(10, 20, 30)');
+
+    const palette = renderText('\x1b[38;5;208morange\x1b[0m');
+    expect(palette.querySelector('span')?.style.color).toBe('rgb(255, 135, 0)');
   });
 });

--- a/services/ui/src/shared/ansi.tsx
+++ b/services/ui/src/shared/ansi.tsx
@@ -9,8 +9,8 @@ function styleFromEntry(entry: AnserJsonEntry): React.CSSProperties {
     if (decoration === 'bold') style.fontWeight = 'bold';
     else if (decoration === 'dim') style.opacity = 0.65;
     else if (decoration === 'italic') style.fontStyle = 'italic';
-    else if (decoration === 'underline') style.textDecoration = 'underline';
-    else if (decoration === 'strikethrough') style.textDecoration = 'line-through';
+    else if (decoration === 'underline') style.textDecoration = (style.textDecoration ? style.textDecoration + ' ' : '') + 'underline';
+    else if (decoration === 'strikethrough') style.textDecoration = (style.textDecoration ? style.textDecoration + ' ' : '') + 'line-through';
   }
   return style;
 }

--- a/services/ui/src/shared/ansi.tsx
+++ b/services/ui/src/shared/ansi.tsx
@@ -1,0 +1,149 @@
+import { Fragment, type ReactNode } from 'react';
+
+// Standard 16-color ANSI palette, tuned for readability on a light background
+// (the log viewer renders on bg-slate-50), so pure white/yellow are avoided.
+const ANSI_COLORS: Record<number, string> = {
+  0: '#3f3f46', // black -> zinc-700 (pure black is too harsh on slate-50)
+  1: '#dc2626', // red
+  2: '#16a34a', // green
+  3: '#a16207', // yellow -> amber-700 (legible on light bg)
+  4: '#2563eb', // blue
+  5: '#c026d3', // magenta
+  6: '#0891b2', // cyan
+  7: '#71717a', // white -> zinc-500
+  8: '#a1a1aa', // bright black (gray)
+  9: '#ef4444', // bright red
+  10: '#22c55e', // bright green
+  11: '#ca8a04', // bright yellow
+  12: '#3b82f6', // bright blue
+  13: '#d946ef', // bright magenta
+  14: '#06b6d4', // bright cyan
+  15: '#27272a', // bright white -> near-black for contrast
+};
+
+// xterm 256-color palette: 16 standard + 6x6x6 color cube + 24 grayscale ramp.
+function ansi256ToHex(n: number): string {
+  if (n < 16) return ANSI_COLORS[n];
+  if (n < 232) {
+    const i = n - 16;
+    const levels = [0, 95, 135, 175, 215, 255];
+    const r = levels[Math.floor(i / 36) % 6];
+    const g = levels[Math.floor(i / 6) % 6];
+    const b = levels[i % 6];
+    return `rgb(${r}, ${g}, ${b})`;
+  }
+  const gray = 8 + (n - 232) * 10;
+  return `rgb(${gray}, ${gray}, ${gray})`;
+}
+
+export type AnsiState = {
+  fg?: string;
+  bg?: string;
+  bold?: boolean;
+  dim?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+};
+
+function styleFromState(state: AnsiState): React.CSSProperties {
+  const style: React.CSSProperties = {};
+  if (state.fg) style.color = state.fg;
+  if (state.bg) style.backgroundColor = state.bg;
+  if (state.bold) style.fontWeight = 'bold';
+  if (state.dim) style.opacity = 0.65;
+  if (state.italic) style.fontStyle = 'italic';
+  if (state.underline) style.textDecoration = 'underline';
+  return style;
+}
+
+function applyParams(state: AnsiState, params: number[]): AnsiState {
+  const next = { ...state };
+  for (let i = 0; i < params.length; i++) {
+    const p = params[i];
+    if (p === 0) {
+      return {};
+    } else if (p === 1) {
+      next.bold = true;
+    } else if (p === 2) {
+      next.dim = true;
+    } else if (p === 3) {
+      next.italic = true;
+    } else if (p === 4) {
+      next.underline = true;
+    } else if (p === 22) {
+      next.bold = false;
+      next.dim = false;
+    } else if (p === 23) {
+      next.italic = false;
+    } else if (p === 24) {
+      next.underline = false;
+    } else if (p >= 30 && p <= 37) {
+      next.fg = ANSI_COLORS[p - 30];
+    } else if (p === 38) {
+      if (params[i + 1] === 5 && params[i + 2] !== undefined) {
+        next.fg = ansi256ToHex(params[i + 2]);
+        i += 2;
+      } else if (params[i + 1] === 2 && params[i + 4] !== undefined) {
+        next.fg = `rgb(${params[i + 2]}, ${params[i + 3]}, ${params[i + 4]})`;
+        i += 4;
+      }
+    } else if (p === 39) {
+      next.fg = undefined;
+    } else if (p >= 40 && p <= 47) {
+      next.bg = ANSI_COLORS[p - 40];
+    } else if (p === 48) {
+      if (params[i + 1] === 5 && params[i + 2] !== undefined) {
+        next.bg = ansi256ToHex(params[i + 2]);
+        i += 2;
+      } else if (params[i + 1] === 2 && params[i + 4] !== undefined) {
+        next.bg = `rgb(${params[i + 2]}, ${params[i + 3]}, ${params[i + 4]})`;
+        i += 4;
+      }
+    } else if (p === 49) {
+      next.bg = undefined;
+    } else if (p >= 90 && p <= 97) {
+      next.fg = ANSI_COLORS[8 + (p - 90)];
+    } else if (p >= 100 && p <= 107) {
+      next.bg = ANSI_COLORS[8 + (p - 100)];
+    }
+  }
+  return next;
+}
+
+// eslint-disable-next-line no-control-regex
+const SGR_RE = /\x1b\[([0-9;]*)m/g;
+
+// Parses one line of text containing ANSI SGR color/style escape codes into React nodes,
+// carrying style state in from the previous line and returning the state to carry into the next.
+export function ansiLineToNodes(line: string, incomingState: AnsiState): { nodes: ReactNode[]; outgoingState: AnsiState } {
+  if (!line.includes('\x1b[')) {
+    const style = styleFromState(incomingState);
+    const nodes = Object.keys(style).length ? [<span style={style} key="0">{line}</span>] : [line];
+    return { nodes, outgoingState: incomingState };
+  }
+
+  const nodes: ReactNode[] = [];
+  let state = incomingState;
+  let lastIndex = 0;
+  let key = 0;
+  SGR_RE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = SGR_RE.exec(line)) !== null) {
+    const chunk = line.slice(lastIndex, match.index);
+    if (chunk) {
+      const style = styleFromState(state);
+      nodes.push(
+        Object.keys(style).length ? <span style={style} key={key++}>{chunk}</span> : <Fragment key={key++}>{chunk}</Fragment>
+      );
+    }
+    const params = match[1].length ? match[1].split(';').map((s) => (s === '' ? 0 : parseInt(s, 10))) : [0];
+    state = applyParams(state, params);
+    lastIndex = SGR_RE.lastIndex;
+  }
+  const rest = line.slice(lastIndex);
+  if (rest) {
+    const style = styleFromState(state);
+    nodes.push(Object.keys(style).length ? <span style={style} key={key++}>{rest}</span> : <Fragment key={key++}>{rest}</Fragment>);
+  }
+  return { nodes, outgoingState: state };
+}

--- a/services/ui/src/shared/ansi.tsx
+++ b/services/ui/src/shared/ansi.tsx
@@ -1,149 +1,34 @@
+import Anser, { type AnserJsonEntry } from 'anser';
 import { Fragment, type ReactNode } from 'react';
 
-// Standard 16-color ANSI palette, tuned for readability on a light background
-// (the log viewer renders on bg-slate-50), so pure white/yellow are avoided.
-const ANSI_COLORS: Record<number, string> = {
-  0: '#3f3f46', // black -> zinc-700 (pure black is too harsh on slate-50)
-  1: '#dc2626', // red
-  2: '#16a34a', // green
-  3: '#a16207', // yellow -> amber-700 (legible on light bg)
-  4: '#2563eb', // blue
-  5: '#c026d3', // magenta
-  6: '#0891b2', // cyan
-  7: '#71717a', // white -> zinc-500
-  8: '#a1a1aa', // bright black (gray)
-  9: '#ef4444', // bright red
-  10: '#22c55e', // bright green
-  11: '#ca8a04', // bright yellow
-  12: '#3b82f6', // bright blue
-  13: '#d946ef', // bright magenta
-  14: '#06b6d4', // bright cyan
-  15: '#27272a', // bright white -> near-black for contrast
-};
-
-// xterm 256-color palette: 16 standard + 6x6x6 color cube + 24 grayscale ramp.
-function ansi256ToHex(n: number): string {
-  if (n < 16) return ANSI_COLORS[n];
-  if (n < 232) {
-    const i = n - 16;
-    const levels = [0, 95, 135, 175, 215, 255];
-    const r = levels[Math.floor(i / 36) % 6];
-    const g = levels[Math.floor(i / 6) % 6];
-    const b = levels[i % 6];
-    return `rgb(${r}, ${g}, ${b})`;
-  }
-  const gray = 8 + (n - 232) * 10;
-  return `rgb(${gray}, ${gray}, ${gray})`;
-}
-
-export type AnsiState = {
-  fg?: string;
-  bg?: string;
-  bold?: boolean;
-  dim?: boolean;
-  italic?: boolean;
-  underline?: boolean;
-};
-
-function styleFromState(state: AnsiState): React.CSSProperties {
+function styleFromEntry(entry: AnserJsonEntry): React.CSSProperties {
   const style: React.CSSProperties = {};
-  if (state.fg) style.color = state.fg;
-  if (state.bg) style.backgroundColor = state.bg;
-  if (state.bold) style.fontWeight = 'bold';
-  if (state.dim) style.opacity = 0.65;
-  if (state.italic) style.fontStyle = 'italic';
-  if (state.underline) style.textDecoration = 'underline';
+  if (entry.fg) style.color = `rgb(${entry.fg})`;
+  if (entry.bg) style.backgroundColor = `rgb(${entry.bg})`;
+  for (const decoration of entry.decorations) {
+    if (decoration === 'bold') style.fontWeight = 'bold';
+    else if (decoration === 'dim') style.opacity = 0.65;
+    else if (decoration === 'italic') style.fontStyle = 'italic';
+    else if (decoration === 'underline') style.textDecoration = 'underline';
+    else if (decoration === 'strikethrough') style.textDecoration = 'line-through';
+  }
   return style;
 }
 
-function applyParams(state: AnsiState, params: number[]): AnsiState {
-  const next = { ...state };
-  for (let i = 0; i < params.length; i++) {
-    const p = params[i];
-    if (p === 0) {
-      return {};
-    } else if (p === 1) {
-      next.bold = true;
-    } else if (p === 2) {
-      next.dim = true;
-    } else if (p === 3) {
-      next.italic = true;
-    } else if (p === 4) {
-      next.underline = true;
-    } else if (p === 22) {
-      next.bold = false;
-      next.dim = false;
-    } else if (p === 23) {
-      next.italic = false;
-    } else if (p === 24) {
-      next.underline = false;
-    } else if (p >= 30 && p <= 37) {
-      next.fg = ANSI_COLORS[p - 30];
-    } else if (p === 38) {
-      if (params[i + 1] === 5 && params[i + 2] !== undefined) {
-        next.fg = ansi256ToHex(params[i + 2]);
-        i += 2;
-      } else if (params[i + 1] === 2 && params[i + 4] !== undefined) {
-        next.fg = `rgb(${params[i + 2]}, ${params[i + 3]}, ${params[i + 4]})`;
-        i += 4;
-      }
-    } else if (p === 39) {
-      next.fg = undefined;
-    } else if (p >= 40 && p <= 47) {
-      next.bg = ANSI_COLORS[p - 40];
-    } else if (p === 48) {
-      if (params[i + 1] === 5 && params[i + 2] !== undefined) {
-        next.bg = ansi256ToHex(params[i + 2]);
-        i += 2;
-      } else if (params[i + 1] === 2 && params[i + 4] !== undefined) {
-        next.bg = `rgb(${params[i + 2]}, ${params[i + 3]}, ${params[i + 4]})`;
-        i += 4;
-      }
-    } else if (p === 49) {
-      next.bg = undefined;
-    } else if (p >= 90 && p <= 97) {
-      next.fg = ANSI_COLORS[8 + (p - 90)];
-    } else if (p >= 100 && p <= 107) {
-      next.bg = ANSI_COLORS[8 + (p - 100)];
-    }
-  }
-  return next;
-}
+// Renders text containing ANSI SGR color/style escape codes into React nodes.
+// Colors and styles carry across lines within `text` (e.g. a color set on one line
+// and reset on a later one), matching normal terminal behavior.
+export function ansiTextToNodes(text: string): ReactNode[] {
+  if (!text.includes('\x1b[')) return [text];
 
-// eslint-disable-next-line no-control-regex
-const SGR_RE = /\x1b\[([0-9;]*)m/g;
-
-// Parses one line of text containing ANSI SGR color/style escape codes into React nodes,
-// carrying style state in from the previous line and returning the state to carry into the next.
-export function ansiLineToNodes(line: string, incomingState: AnsiState): { nodes: ReactNode[]; outgoingState: AnsiState } {
-  if (!line.includes('\x1b[')) {
-    const style = styleFromState(incomingState);
-    const nodes = Object.keys(style).length ? [<span style={style} key="0">{line}</span>] : [line];
-    return { nodes, outgoingState: incomingState };
-  }
-
-  const nodes: ReactNode[] = [];
-  let state = incomingState;
-  let lastIndex = 0;
-  let key = 0;
-  SGR_RE.lastIndex = 0;
-  let match: RegExpExecArray | null;
-  while ((match = SGR_RE.exec(line)) !== null) {
-    const chunk = line.slice(lastIndex, match.index);
-    if (chunk) {
-      const style = styleFromState(state);
-      nodes.push(
-        Object.keys(style).length ? <span style={style} key={key++}>{chunk}</span> : <Fragment key={key++}>{chunk}</Fragment>
-      );
-    }
-    const params = match[1].length ? match[1].split(';').map((s) => (s === '' ? 0 : parseInt(s, 10))) : [0];
-    state = applyParams(state, params);
-    lastIndex = SGR_RE.lastIndex;
-  }
-  const rest = line.slice(lastIndex);
-  if (rest) {
-    const style = styleFromState(state);
-    nodes.push(Object.keys(style).length ? <span style={style} key={key++}>{rest}</span> : <Fragment key={key++}>{rest}</Fragment>);
-  }
-  return { nodes, outgoingState: state };
+  return Anser.ansiToJson(text, { use_classes: false, remove_empty: true }).map((entry, i) => {
+    const style = styleFromEntry(entry);
+    return Object.keys(style).length ? (
+      <span style={style} key={i}>
+        {entry.content}
+      </span>
+    ) : (
+      <Fragment key={i}>{entry.content}</Fragment>
+    );
+  });
 }


### PR DESCRIPTION
## Change Description

Longer term we probably want the LazyLog viewer from melloware: https://github.com/melloware/react-logviewer

In the meantime (ie - before we switch to signed URLs), we can use the much smaller `anser` to color code the log output according to ansi color codes.

### Screenshots

#### New UI:

<img width="645" height="388" alt="image" src="https://github.com/user-attachments/assets/6f2e8ca2-e9dc-4bfc-bbff-f78216b69d0c" />

#### Unparsed view:

<img width="781" height="176" alt="image" src="https://github.com/user-attachments/assets/c0a247c5-6c11-4b91-8dad-72a18816a431" />

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Standard ANSI parsing logic, but over user-controlled data so we should be at least a little careful.

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
