### PR TITLE
[ci] add color to test logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ default:
 .PHONY: check-all
 check-all: check-hail check-services
 
+# Force color output from ruff even though CI captures stdout to a non-tty log,
+# so colored linter output renders correctly in the batch log viewer.
+check-hail-fast check-%-fast: export FORCE_COLOR := 1
+
 .PHONY: check-hail-fast
 check-hail-fast:
 	ruff check hail
@@ -54,7 +58,7 @@ check-hail-fast:
 .PHONY: pylint-hailtop
 pylint-hailtop:
 	# pylint on hail is still a work in progress
-	$(PYTHON) -m pylint --rcfile pylintrc hail/python/hailtop --score=n
+	$(PYTHON) -m pylint --rcfile pylintrc --output-format=colorized hail/python/hailtop --score=n
 
 .PHONY: check-hail
 check-hail: check-hail-fast pylint-hailtop
@@ -69,7 +73,7 @@ check-services: $(CHECK_SERVICES_MODULES)
 
 .PHONY: pylint-%
 pylint-%:
-	$(PYTHON) -m pylint --rcfile pylintrc --recursive=y $* --score=n
+	$(PYTHON) -m pylint --rcfile pylintrc --output-format=colorized --recursive=y $* --score=n
 
 .PHONY: check-%-fast
 check-%-fast:

--- a/build.yaml
+++ b/build.yaml
@@ -714,6 +714,7 @@ steps:
     script: |
       set -ex
       cd /io/repo/services/ui
+      export FORCE_COLOR=1
       npm ci
       npm test
       npm run check
@@ -1196,7 +1197,6 @@ steps:
       tar -C /io -xzf /io/mill-cache.tgz
 
       export HAIL_BUILD_MODE='CI'
-      export NO_COLOR=1
       export COURSIER_CACHE='/io/cache/coursier/v1'
       export COURSIER_ARCHIVE_CACHE='/io/cache/coursier/arc'
       export MILL_DOWNLOAD_PATH=/io/cache/mill
@@ -1258,6 +1258,7 @@ steps:
       export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
 
       python3 -m pytest \
+              --color=yes \
               -Werror:::hail -Werror::ResourceWarning \
               --log-cli-level=INFO \
               -s \
@@ -1314,6 +1315,7 @@ steps:
       export AWS_SHARED_CREDENTIALS_FILE=/test-aws-key/credentials
 
       python3 -m pytest \
+              --color=yes \
               -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
               --log-cli-level=INFO \
               -s \
@@ -1371,6 +1373,7 @@ steps:
       export HAIL_TEST_STORAGE_URI={{ global.test_storage_uri }}/{{ token }}
       export PYSPARK_SUBMIT_ARGS="--driver-memory 6g pyspark-shell"
       python3 -m pytest \
+              --color=yes \
               -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
               --log-cli-level=INFO \
               -s \
@@ -1443,6 +1446,7 @@ steps:
       hailctl config set query/backend local
 
       python3 -m pytest \
+              --color=yes \
               -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
               --log-cli-level=INFO \
               -s \
@@ -1502,6 +1506,7 @@ steps:
 
       # NB: do not use --timeout with doctest because there is no way to override it.
       python3 -m pytest \
+              --color=yes \
               -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
               --log-cli-level=INFO \
               -s \
@@ -2031,6 +2036,7 @@ steps:
       export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
 
       python3 -m pytest \
+              --color=yes \
               -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
               --log-cli-level=INFO \
               -s \
@@ -2736,6 +2742,7 @@ steps:
       export HAIL_BATCH_REMOTE_TMPDIR={{ global.test_storage_uri }}
 
       python3 -m pytest \
+              --color=yes \
               -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
               --log-cli-level=INFO \
               -s \
@@ -2809,6 +2816,7 @@ steps:
       export HAIL_BATCH_REMOTE_TMPDIR={{ global.test_storage_uri }}
 
       python3 -m pytest \
+              --color=yes \
               -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
               --log-cli-level=INFO \
               -s \
@@ -2863,6 +2871,7 @@ steps:
       export YOU_MAY_OVERWRITE_MY_SPARK_DEFAULTS_CONF_AND_HAILCTL_SETTINGS=1
 
       python3 -m pytest \
+              --color=yes \
               -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
               --log-cli-level=INFO \
               -s \
@@ -2963,6 +2972,7 @@ steps:
       hail-pip-install -r /io/dev-requirements.txt
 
       python3 -m pytest \
+              --color=yes \
               -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
               --log-cli-level=INFO \
               -s \
@@ -3042,6 +3052,7 @@ steps:
       hail-pip-install -r /io/dev-requirements.txt
 
       python3 -m pytest \
+              --color=yes \
               -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
               --log-cli-level=INFO \
               -s \
@@ -3109,6 +3120,7 @@ steps:
       hail-pip-install -r /io/dev-requirements.txt
 
       python3 -m pytest \
+              --color=yes \
               -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
               --log-cli-level=INFO \
               -s \
@@ -3157,6 +3169,7 @@ steps:
       hail-pip-install -r /io/dev-requirements.txt
 
       python3 -m pytest \
+              --color=yes \
               -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
               --log-cli-level=INFO \
               -s \
@@ -3367,6 +3380,7 @@ steps:
       hail-pip-install -r /io/dev-requirements.txt
 
       python3 -m pytest \
+              --color=yes \
               --log-cli-level=INFO -s -r A -vv --instafail \
               --durations=50 --timeout=600 \
               /io/test/test_system_permissions.py
@@ -3405,6 +3419,7 @@ steps:
       set -ex
       hail-pip-install -r /io/dev-requirements.txt
       python3 -m pytest \
+              --color=yes \
               -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
               --log-cli-level=INFO \
               -s \
@@ -3441,6 +3456,7 @@ steps:
       export NAMESPACE="{{ default_ns.name }}"
       pip install /io/ci
       python3 -m pytest \
+              --color=yes \
               -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
               --log-cli-level=INFO \
               -s \
@@ -3505,6 +3521,7 @@ steps:
       hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/test_hailtop_python/{{ token }}/
 
       python3 -m pytest \
+              --color=yes \
               -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
               --log-cli-level=INFO \
               -s \
@@ -3643,6 +3660,7 @@ steps:
       set -ex
       cd /io/repo
       python3 -m pytest \
+              --color=yes \
               -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
               --log-cli-level=INFO \
               -s \
@@ -3675,6 +3693,7 @@ steps:
       hailctl config set batch/billing_project test
       hailctl config set batch/remote_tmpdir {{ global.test_storage_uri }}/test_batch_docs/{{ token }}/
       python3 -m pytest \
+              --color=yes \
               -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
               --log-cli-level=INFO \
               -s \
@@ -3954,7 +3973,6 @@ steps:
       tar -C /io -xzf /io/mill-cache.tgz
 
       export HAIL_BUILD_MODE='CI'
-      export NO_COLOR=1
       export COURSIER_CACHE='/io/cache/coursier/v1'
       export COURSIER_ARCHIVE_CACHE='/io/cache/coursier/arc'
       export MILL_DOWNLOAD_PATH=/io/cache/mill
@@ -4016,7 +4034,6 @@ steps:
       tar -C /io -xzf /io/mill-cache.tgz
 
       export HAIL_BUILD_MODE='CI'
-      export NO_COLOR=1
       export COURSIER_CACHE='/io/cache/coursier/v1'
       export COURSIER_ARCHIVE_CACHE='/io/cache/coursier/arc'
       export MILL_DOWNLOAD_PATH=/io/cache/mill
@@ -4242,6 +4259,7 @@ steps:
       export DOCKER_PREFIX="{{ global.docker_prefix }}"
       export DOCKER_ROOT_IMAGE="{{ global.docker_root_image }}"
       python3 -m pytest \
+              --color=yes \
               -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
               --log-cli-level=INFO \
               -s \


### PR DESCRIPTION
## Change Description

Following #15738 we no longer need to suppress ansi color codes from test run outputs.

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Small tweaks to test jobs, which we already sandbox and assume could be arbitrary.

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
