### PR TITLE
[compiler] deepCopy does not return this.type

### DIFF
--- a/hail/hail/src/is/hail/expr/ir/BaseIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/BaseIR.scala
@@ -21,8 +21,8 @@ abstract class BaseIR {
 
   protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): BaseIR
 
-  def deepCopy: this.type =
-    copyWithNewChildren(newChildren = childrenSeq.map(_.deepCopy)).asInstanceOf[this.type]
+  def deepCopy: BaseIR =
+    copyWithNewChildren(newChildren = childrenSeq.map(_.deepCopy))
 
   // For use as a boolean flag by IR passes. Each pass uses a different sentinel value to encode
   // "true" (and anything else is false). As long as we maintain the global invariant that no

--- a/hail/hail/src/is/hail/expr/ir/BlockMatrixIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/BlockMatrixIR.scala
@@ -47,6 +47,7 @@ object BlockMatrixIR {
 
 sealed abstract class BlockMatrixIR extends BaseIR {
   override def typ: BlockMatrixType
+  override def deepCopy: BlockMatrixIR = super.deepCopy.asInstanceOf[BlockMatrixIR]
 
   protected[ir] def execute(ctx: ExecuteContext): BlockMatrix =
     fatal("tried to execute unexecutable IR:\n" + Pretty(ctx, this))

--- a/hail/hail/src/is/hail/expr/ir/IR.scala
+++ b/hail/hail/src/is/hail/expr/ir/IR.scala
@@ -45,10 +45,9 @@ abstract class IR extends BaseIR {
   override def mapChildrenWithIndex(f: (BaseIR, Int) => BaseIR): IR =
     super.mapChildrenWithIndex(f).asInstanceOf[IR]
 
-  override def deepCopy: this.type = {
-    val cp = super.deepCopy
-    if (_typ != null)
-      cp._typ = _typ
+  override def deepCopy: IR = {
+    val cp = super.deepCopy.asInstanceOf[IR]
+    if (_typ != null) cp._typ = _typ
     cp
   }
 
@@ -205,7 +204,7 @@ package defs {
 
   // Refs and Constants as IRs that are safe to duplicate
   trait Atom { this: IR =>
-    def ir: IR with Atom = deepCopy
+    def ir: IR with Atom = deepCopy.asInstanceOf[IR with Atom]
   }
 
   object Atom {

--- a/hail/hail/src/is/hail/expr/ir/MatrixIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/MatrixIR.scala
@@ -56,7 +56,7 @@ object MatrixIR {
 
 sealed abstract class MatrixIR extends BaseIR {
   override def typ: MatrixType
-
+  override def deepCopy: MatrixIR = super.deepCopy.asInstanceOf[MatrixIR]
   override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): MatrixIR
 }
 

--- a/hail/hail/src/is/hail/expr/ir/TableIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/TableIR.scala
@@ -59,7 +59,7 @@ object TableIR {
 
 sealed abstract class TableIR extends BaseIR {
   override def typ: TableType
-
+  override def deepCopy: TableIR = super.deepCopy.asInstanceOf[TableIR]
   override protected def copyWithNewChildren(newChildren: IndexedSeq[BaseIR]): TableIR
 }
 


### PR DESCRIPTION
This change does not affect the broad-managed batch service in gcp.