### PR TITLE
[ci] resolve flake risks in rare instances test

### DIFF
--- a/batch/test/test_batch_rare_instances.py
+++ b/batch/test/test_batch_rare_instances.py
@@ -13,7 +13,7 @@ from .utils import DOCKER_ROOT_IMAGE, create_batch
 
 
 def _run_on_rare_instance(
-    client: BatchClient, image: str, command, resources: dict, xfail_message: str, n_max_attempts: int = 4
+    client: BatchClient, image: str, command, resources: dict, xfail_message: str, n_max_attempts: int
 ) -> dict:
     b = create_batch(client)
     j = b.create_job(image, command, resources=resources, n_max_attempts=n_max_attempts)
@@ -29,7 +29,7 @@ def _run_on_rare_instance(
 
 
 @skip_in_azure
-@pytest.mark.timeout(10 * 60)
+@pytest.mark.timeout(20 * 60)
 def test_nvidia_driver_accesibility_usage(client: BatchClient):
     _run_on_rare_instance(
         client,
@@ -41,6 +41,7 @@ def test_nvidia_driver_accesibility_usage(client: BatchClient):
         ],
         {'machine_type': 'g2-standard-4', 'storage': '100Gi'},
         "G2 instances unavailable (ZONE_RESOURCE_POOL_EXHAUSTED)",
+        n_max_attempts=3,
     )
 
 
@@ -48,7 +49,6 @@ def test_nvidia_driver_accesibility_usage(client: BatchClient):
 @pytest.mark.timeout(20 * 60)
 def test_over_64_cpus(client: BatchClient):
     # The relevant part of this machine type ('highmem-96') is the CPU count, which is 96.
-    # Timeout is a 5 minute activation timeout per attempt plus a 5 minute buffer for scheduling, etc.
     status = _run_on_rare_instance(
         client,
         DOCKER_ROOT_IMAGE,

--- a/batch/test/test_batch_rare_instances.py
+++ b/batch/test/test_batch_rare_instances.py
@@ -12,9 +12,11 @@ from hailtop.test_utils import skip_in_azure
 from .utils import DOCKER_ROOT_IMAGE, create_batch
 
 
-def _run_on_rare_instance(client: BatchClient, image: str, command, resources: dict, xfail_message: str) -> dict:
+def _run_on_rare_instance(
+    client: BatchClient, image: str, command, resources: dict, xfail_message: str, n_max_attempts: int = 4
+) -> dict:
     b = create_batch(client)
-    j = b.create_job(image, command, resources=resources, n_max_attempts=4)
+    j = b.create_job(image, command, resources=resources, n_max_attempts=n_max_attempts)
     b.submit()
     status = j.wait()
     if status['state'] != 'Success':
@@ -43,14 +45,19 @@ def test_nvidia_driver_accesibility_usage(client: BatchClient):
 
 
 @skip_in_azure
-@pytest.mark.timeout(10 * 60)
+@pytest.mark.timeout(20 * 60)
 def test_over_64_cpus(client: BatchClient):
     # The relevant part of this machine type ('highmem-96') is the CPU count, which is 96.
+    # n1-highmem-96 instances can sit in GCE's PROVISIONING/STAGING state for the full
+    # 5-minute activation_timeout before Hail gives up on an attempt, rather than failing
+    # fast like a zone-exhaustion error, so give this test a larger timeout budget and
+    # fewer attempts than the default so it can't blow past it.
     status = _run_on_rare_instance(
         client,
         DOCKER_ROOT_IMAGE,
         ['true'],
         {'machine_type': 'n1-highmem-96', 'preemptible': False},
         "n1-highmem-96 instances unavailable",
+        n_max_attempts=3,
     )
     assert 'job-private' in status['status']['worker'], status

--- a/batch/test/test_batch_rare_instances.py
+++ b/batch/test/test_batch_rare_instances.py
@@ -48,10 +48,7 @@ def test_nvidia_driver_accesibility_usage(client: BatchClient):
 @pytest.mark.timeout(20 * 60)
 def test_over_64_cpus(client: BatchClient):
     # The relevant part of this machine type ('highmem-96') is the CPU count, which is 96.
-    # n1-highmem-96 instances can sit in GCE's PROVISIONING/STAGING state for the full
-    # 5-minute activation_timeout before Hail gives up on an attempt, rather than failing
-    # fast like a zone-exhaustion error, so give this test a larger timeout budget and
-    # fewer attempts than the default so it can't blow past it.
+    # Timeout is a 5 minute activation timeout per attempt plus a 5 minute buffer for scheduling, etc.
     status = _run_on_rare_instance(
         client,
         DOCKER_ROOT_IMAGE,

--- a/build.yaml
+++ b/build.yaml
@@ -4260,6 +4260,7 @@ steps:
       - hailgenetics_hailtop_image
       - deploy_batch
       - test_batch
+      - test_batch_job_private_machines
       - test_ci
       - test_hailtop_python
       - test_hail_python_service_backend_gcp


### PR DESCRIPTION
## Change Description

Two ways for `test_batch_job_private_machines` to flake out have been resolved:

1. When the 96 CPU VMs take a long time to provision (as opposed to being unavailable / not found immediately like we see with the GPUs that are just not available right now in the zone), the driver allows it up to 5 minutes in PROVISIONING before giving up. So our test XFAIL timeouts should be at least 5 minutes per attempt.
2. The `test_batch_job_private_machines` test was not listed as a precursor to the `cancel_all_running_test_batches` job. So if the timing worked out wrong, these tests could be abruptly cancelled by the batch cleanup jobs and the whole test run fails. Oops! 

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Test configuration change. Should be no impact in prod

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
