### PR TITLE
[ci] remove unnecessary `dependsOn`s in build.yaml that are now `after`s

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3262,7 +3262,6 @@ steps:
       - merge_code
       - batch_image
       - deploy_batch
-      - test_batch
     after:
       - test_batch
   - kind: runImage
@@ -3792,8 +3791,6 @@ steps:
       - default_ns
       - hail_ubuntu_image
       - create_ci_test_repo
-      - deploy_ci
-      - test_ci
     after:
       - deploy_ci
       - test_ci
@@ -4283,14 +4280,6 @@ steps:
       - default_ns
       - hailgenetics_hailtop_image
       - deploy_batch
-      - test_batch
-      - test_ci
-      - test_hailtop_python
-      - test_hail_python_service_backend_gcp
-      - test_hail_python_service_backend_gcp_fs
-      - test_hail_services_java
-      - test_batch_docs
-      - test_hailctl_batch
     after:
       - test_batch
       - test_batch_job_private_machines
@@ -4384,12 +4373,6 @@ steps:
       - default_ns
       - ci_utils_image
       - cancel_all_running_test_batches
-      - test_batch_invariants
-      - test_batch
-      - test_ci
-      - test_hailtop_python
-      - test_hail_python_service_backend_gcp
-      - test_hail_python_service_backend_gcp_fs
     after:
       - test_batch_invariants
       - test_batch


### PR DESCRIPTION
## Change Description

See #15691 for a reminder of the motivation. Following that PR merging and being deployed in prod, we can switch several of the build.yaml jobs fully over from "`after` AND `dependsOn`" to "only `after`". 

(We couldn't do this before because the previous CI deployed in prod had no idea what `after` meant, and so would not properly construct the dependency charts.)



## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Internal refactor of the CI test graph, already mostly validated in #15691

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
