### PR TITLE
[ci] fix ci auto-success if test batch submission fails

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -236,7 +236,7 @@ class Step(abc.ABC):
         return config
 
     def deps_parents(self):
-        parents = flatten([d.wrapped_job() for d in self.deps + self.after_steps])
+        parents = list(dict.fromkeys(flatten([d.wrapped_job() for d in self.deps + self.after_steps])))
         return parents or None
 
     def all_deps(self):

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -531,6 +531,7 @@ class PR(Code):
         self.set_build_state(None)
 
         batch = None
+        submitted = False
         try:
             log.info(f'merging for {self.number}')
             repo_dir = self.repo_dir()
@@ -654,6 +655,7 @@ mkdir -p {shq(repo_dir)}
                 )
             config.build(batch, self, scope='test')
             await batch.submit()
+            submitted = True
             self.tactical = False
             self.batch = batch
         except concurrent.futures.CancelledError:
@@ -675,9 +677,12 @@ mkdir -p {shq(repo_dir)}
             self.source_sha_failed = True
             self.target_branch.state_changed = True
         finally:
-            if batch and not self.batch:
-                log.info(f'cancelling partial test batch {batch.id}')
-                await batch.cancel()
+            if batch is not None and not submitted:
+                if batch.is_created:
+                    log.info(f'cancelling partial test batch {batch.id} for PR #{self.number}: build failed')
+                    await batch.cancel()
+                else:
+                    log.info(f'test batch for PR #{self.number} was never created because build failed')
 
     @staticmethod
     async def is_invalidated_batch(batch, db: Database):


### PR DESCRIPTION
## Change Description

Fixes a bug that allows test batches to auto-succeed (with 0 jobs) if the job creation part of the CI batch submit process fails (because a batch with 0 added jobs is a success from the batch service's point of view).

Also guards against errors in batch construction logic (for example triggered by #15691 and cleaned up by its follow up #15749)

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Fixes a test correctness issue after flakiness in infrastructure.

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
