### PR TITLE
[compiler] invalidate `TailLoop` regions after every evaluation

### DIFF
--- a/hail/hail/src/is/hail/expr/ir/Emit.scala
+++ b/hail/hail/src/is/hail/expr/ir/Emit.scala
@@ -2782,11 +2782,13 @@ class Emit[C](val ctx: EmitContext, val cb: EmitClassBuilder[C]) {
         emitVoid(body, container = Some(newContainer))
         val codeRes = emitI(result, container = Some(newContainer))
 
-        codeRes.map(cb) { pc =>
-          val res = cb.memoizeField(pc, "agg_res")
-          newContainer.cleanup()
-          res
-        }
+        codeRes
+          .mapMissing(cb)(newContainer.cleanup())
+          .map(cb) { pc =>
+            val res = cb.memoizeField(pc, "agg_res")
+            newContainer.cleanup()
+            res
+          }
 
       case ResultOp(idx, sig) =>
         val AggContainer(_, sc, _) = container.get
@@ -3040,21 +3042,25 @@ class Emit[C](val ctx: EmitContext, val cb: EmitClassBuilder[C]) {
 
         cb.define(loopStartLabel)
 
-        val result = emitI(
-          body,
-          region = loopRef.r1,
-          env = argEnv,
-          loopEnv = Some(newLoopEnv.bind(name, loopRef)),
-        ).map(cb) { pc =>
-          val answerInRightRegion = pc.copyToRegion(cb, region, pc.st)
-          cb.append(loopRef.r1.clearRegion())
-          cb.append(loopRef.r2.clearRegion())
-          answerInRightRegion
+        def releaseLoopRegions() = {
+          cb += loopRef.r1.invalidate()
+          cb += loopRef.r2.invalidate()
         }
+
+        val result =
+          emitI(body, loopRef.r1, argEnv, loopEnv = Some(newLoopEnv.bind(name, loopRef)))
+            .mapMissing(cb)(releaseLoopRegions())
+            .map(cb) { pc =>
+              val answerInRightRegion = pc.copyToRegion(cb, region, pc.st)
+              releaseLoopRegions()
+              answerInRightRegion
+            }
+
         assert(
           result.emitType == resultEmitType,
           s"loop type mismatch: emitted=${result.emitType}, expected=$resultEmitType",
         )
+
         result
 
       case Recur(name, args, _) =>

--- a/hail/hail/src/is/hail/expr/ir/IR.scala
+++ b/hail/hail/src/is/hail/expr/ir/IR.scala
@@ -142,6 +142,9 @@ class IROps(val ir: IR) extends AnyVal {
   def enumerate(f: (Atom, Atom) => IR): IR =
     zip(iota(0, 1), ArrayZipBehavior.TakeMinLength)(f)
 
+  def streamFold(zero: IR)(f: (Atom, Atom) => IR): IR =
+    foldIR(ir, zero)(f)
+
   def streamFor(f: Atom => IR): IR =
     forIR(ir)(f)
 

--- a/hail/hail/src/is/hail/expr/ir/agg/NDArrayMultiplyAddAggregator.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/NDArrayMultiplyAddAggregator.scala
@@ -89,7 +89,7 @@ class NDArrayMultiplyAddAggregator(ndVTyp: VirtualTypeWithReq) extends StagedAgg
                     currentNDPValue.asNDArray,
                   ),
               )
-              cb += tempRegionForCreation.clearRegion()
+              cb += tempRegionForCreation.invalidate()
             },
           )
         },

--- a/hail/hail/src/is/hail/expr/ir/agg/NDArraySumAggregator.scala
+++ b/hail/hail/src/is/hail/expr/ir/agg/NDArraySumAggregator.scala
@@ -61,7 +61,7 @@ class NDArraySumAggregator(ndVTyp: VirtualTypeWithReq) extends StagedAggregator 
               val fullyCopiedNDArray =
                 ndTyp.constructByActuallyCopyingData(nextNDPV, cb, tempRegionForCreation)
               state.storeNonmissing(cb, fullyCopiedNDArray)
-              cb += tempRegionForCreation.clearRegion()
+              cb += tempRegionForCreation.invalidate()
             },
             currentND =>
               NDArraySumAggregator.addValues(cb, state.region, currentND.asNDArray, nextNDPV),

--- a/hail/hail/src/is/hail/expr/ir/lowering/LowerTableIR.scala
+++ b/hail/hail/src/is/hail/expr/ir/lowering/LowerTableIR.scala
@@ -1208,7 +1208,16 @@ object LowerTableIR extends Logging {
                     val (parts, rows) = nPartsAndRows(sizes, targetNumRows)((_, take) => take)
                     maketuple(parts, rows)
                   case None =>
-                    nPartsAndRows(loweredChild, contexts, nPartitions, targetNumRows)(minIR(_, _))
+                    // Each partition is read once, so rows past the target
+                    // cannot change the answer and need not be counted.
+                    def countUpToTarget(rows: Atom): IR =
+                      if (targetNumRows <= Int.MaxValue) rows.take(targetNumRows.toInt).len
+                      else rows.len
+
+                    nPartsAndRows(loweredChild, contexts, nPartitions, targetNumRows,
+                      countUpToTarget)(
+                      minIR(_, _)
+                    )
                 }
 
               nPartsToTake <- nPartsAndLastRowCount.get(0)
@@ -1252,7 +1261,7 @@ object LowerTableIR extends Logging {
                     maketuple(n, math.max(0, drop))
 
                   case None =>
-                    nPartsAndRows(loweredChild, reverse, nPartitions, targetNumRows) {
+                    nPartsAndRows(loweredChild, reverse, nPartitions, targetNumRows, _.len) {
                       (takeRight, remainder) => maxIR(0L, takeRight - remainder)
                     }
                 }
@@ -1931,6 +1940,7 @@ object LowerTableIR extends Logging {
     contexts: Atom,
     nPartitions: Atom,
     target: Long,
+    count: Atom => IR,
   )(
     f: (Atom, Atom) => IR
   ): IR = {
@@ -1948,7 +1958,7 @@ object LowerTableIR extends Logging {
                 .mapCollect(
                   "table_head_or_tail_recursive_count",
                   strConcat("iteration=", i, ",nParts=", n),
-                )(_.len)
+                )(count)
 
             n <- counts.len
             p <- m + n

--- a/hail/hail/test/src/is/hail/expr/ir/Aggregators2Suite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/Aggregators2Suite.scala
@@ -1,11 +1,12 @@
 package is.hail.expr.ir
 
-import is.hail.ExecStrategy
+import is.hail.{ExecStrategy, ParameterizedTest}
 import is.hail.TestUtils._
 import is.hail.annotations._
 import is.hail.asm4s._
 import is.hail.backend.ExecuteContext
 import is.hail.collection.FastSeq
+import is.hail.expr.Nat
 import is.hail.expr.ir.agg._
 import is.hail.expr.ir.defs._
 import is.hail.io.BufferSpec
@@ -1174,5 +1175,48 @@ class Aggregators2Suite {
     }
 
     assertEvalsTo(x, FastSeq(null, -1L, 2L, 3L, null, null, -1L, 2L, 0L))
+  }
+
+  def testAggregationReleasesScratchRegions(): ArraySeq[(String, IR)] = {
+    // The seqOp takes a scratch region for the first row (sum) or every row
+    // (multiply-add).
+    def ndAgg(op: AggOp, arity: Int): IR = {
+      val nd = Literal(
+        TNDArray(TFloat64, Nat(2)),
+        SafeNDArray(IndexedSeq(2L, 2L), IndexedSeq(1.0, 1.0, 1.0, 1.0)),
+      )
+      NDArrayRef(
+        rangeIR(2).streamMap(_ => nd).streamAgg(x => ApplyAggOp(op)(Seq.fill[IR](arity)(x): _*)),
+        FastSeq(I64(0), I64(0)),
+        -1,
+      )
+    }
+
+    // Min over no values is missing; the RunAgg container region must be
+    // released on that exit path too.
+    val sig = PhysicalAggSig(Min(), TypedStateSig(VirtualTypeWithReq(PFloat64(false))))
+    val missingMin =
+      RunAgg(InitOp(0, FastSeq(), sig), ResultOp(0, sig), FastSeq(sig.state)).orElse(F64(0.0))
+
+    ArraySeq(
+      ("RunAgg with missing result", missingMin),
+      ("NDArraySum", ndAgg(NDArraySum(), 1)),
+      ("NDArrayMultiplyAdd", ndAgg(NDArrayMultiplyAdd(), 2)),
+    )
+  }
+
+  @ParameterizedTest
+  def testAggregationReleasesScratchRegions(name: String, agg: IR)(implicit ctx: ExecuteContext)
+    : Unit = {
+    // Peak usage must not scale with the number of aggregations. The outer
+    // stream needs per-element regions so each result is freed in turn.
+    def sumOfAggs(n: Int): IR =
+      StreamRange(0, n, 1, true)
+        .streamMap(_ => agg)
+        .streamFold(F64(0.0))(_ + _)
+
+    val (_, memUsed) = measuringHighestTotalMemoryUsage(eval(sumOfAggs(10))(_))
+    val (_, memUsed2) = measuringHighestTotalMemoryUsage(eval(sumOfAggs(100))(_))
+    assert(memUsed == memUsed2, s"$name: peak usage grew from $memUsed to $memUsed2 bytes")
   }
 }

--- a/hail/hail/test/src/is/hail/expr/ir/IRSuite.scala
+++ b/hail/hail/test/src/is/hail/expr/ir/IRSuite.scala
@@ -4306,6 +4306,28 @@ class IRSuite {
     assert(memUsed == memUsed2)
   }
 
+  def testTailLoopReleasesRegionsPerEvaluation() = ArraySeq(false, true)
+
+  @ParameterizedTest
+  def testTailLoopReleasesRegionsPerEvaluation(missing: Boolean)(implicit ctx: ExecuteContext)
+    : Unit = {
+    // Each evaluation of a TailLoop takes two regions from the pool and must
+    // release them on both the present and the missing exit. Peak usage must
+    // not scale with how many times the loop is evaluated.
+    def sumOfTriangles(n: Int): IR =
+      rangeIR(n)
+        .streamMap { i =>
+          tailLoop(TInt32, i, I32(0)) { case (recur, Seq(x, acc)) =>
+            If(x <= 0, if (missing) NA(TInt32) else acc, recur(FastSeq(x - 1, acc + x)))
+          }.orElse(I32(0))
+        }
+        .sum
+
+    val (_, memUsed) = measuringHighestTotalMemoryUsage(eval(sumOfTriangles(10))(_))
+    val (_, memUsed2) = measuringHighestTotalMemoryUsage(eval(sumOfTriangles(100))(_))
+    assert(memUsed == memUsed2, s"peak usage grew from $memUsed to $memUsed2 bytes")
+  }
+
   @Test def freeVariables(implicit ctx: ExecuteContext): Unit = {
     val stream = rangeIR(5)
     val y = Ref(freshName(), TInt32)


### PR DESCRIPTION
Fixes a RegionPool leak reported against 0.2.139: `array_agg` over an entry array field with `LA.contains(ai)`, consumed in full, allocated ~64KB per entry and never freed. A 5000-row, 15-column query peaked at 16GB of off-heap memory in a single task.

`LoopRef` takes two regions from the pool each time control reaches a `TailLoop`. On exit the emitter only `clear()`ed them and dropped the references. `clear` resets contents but keeps the `RegionMemory` attached; only `invalidate` returns it to the pool. Inside per-element code (streams, `AggArrayPerElement`) that leaked two regions per evaluation until the task finished. Both regions are now invalidated on the present and missing exit paths.

Two changes exposed this. `ArrayFunctions.exists` (and so `contains`) became a `TailLoop` rather than a `StreamFold`, putting the node in the per-entry hot path. Then the `TableHead` lowering rewrite in #15525 counted each partition in full instead of reading up to `n` rows, so `head(1)` now evaluates the loop for every entry in the partition.

The `TableHead` count now stops at `targetNumRows` again. Partitions are read once, so rows past the target cannot change the answer. `TableTail` still needs the full length.

An audit of the other staged region sites found the same pattern in the
`NDArraySum` and `NDArrayMultiplyAdd` seqOps, which `clear`ed their
scratch region rather than invalidating it, and in `RunAgg`, which
released its aggregator region only when the result was present. All
three now invalidate on every exit.

This change does not affect the broad-managed batch service in gcp.