### PR TITLE
[ci] isolate and add more time for timeout prone vep tests

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2787,9 +2787,82 @@ steps:
               --ignore=test/hailtop/ \
               --ignore=test/hail/matrixtable/test_file_formats.py \
               --ignore=test/hail/utils/test_hl_hadoop_and_hail_fs.py \
-              -m backend \
+              -m "backend and not vep" \
               --timeout=600 \
               test
+    timeout: 5400
+    inputs:
+      - from: /derived/release/hail/build/deploy/dist
+        to: /io/wheel
+      - from: /repo/hail/python/pytest.ini
+        to: /io/repo/hail/python/pytest.ini
+      - from: /repo/hail/python/test
+        to: /io/repo/hail/python/test
+    secrets:
+      - name: test-gsa-key
+        namespace:
+          valueFrom: default_ns.name
+        mountPath: /test-gsa-key
+    dependsOn:
+      - default_ns
+      - merge_code
+      - deploy_batch
+      - create_deploy_config
+      - create_accounts
+      - hail_run_image
+      - upload_query_jar
+      - upload_test_resources_to_blob_storage
+      - build_hail_jar_and_wheel
+      - hailgenetics_vep_grch37_85_image
+      - hailgenetics_vep_grch38_95_image
+    clouds:
+      - gcp
+  - kind: runImage
+    name: test_hail_python_service_backend_gcp_vep
+    scopes:
+      - test
+      - dev
+    image:
+      valueFrom: hail_run_image.image
+    resources:
+      cpu: '0.25'
+      preemptible: False
+    script: |
+      set -ex
+      python3 -m pip install --no-dependencies /io/wheel/hail-*-py3-none-any.whl
+
+      cd /io/repo/hail/python
+
+      export HAIL_CLOUD={{ global.cloud }}
+      export HAIL_DEFAULT_NAMESPACE={{ default_ns.name }}
+      export HAIL_TEST_STORAGE_URI={{ global.test_storage_uri }}/{{ token }}
+      export HAIL_TEST_RESOURCES_DIR="{{ global.test_storage_uri }}/{{ upload_test_resources_to_blob_storage.token }}/test/resources/"
+      export HAIL_DOCTEST_DATA_DIR="{{ global.test_storage_uri }}/{{ upload_test_resources_to_blob_storage.token }}/doctest/data/"
+      export HAIL_GENETICS_VEP_GRCH37_85_IMAGE={{ hailgenetics_vep_grch37_85_image.image }}
+      export HAIL_GENETICS_VEP_GRCH38_95_IMAGE={{ hailgenetics_vep_grch38_95_image.image }}
+      export GOOGLE_APPLICATION_CREDENTIALS=/test-gsa-key/key.json
+
+      export GCS_REQUESTER_PAYS_PROJECT=broad-ctsa
+
+      export HAIL_SHUFFLE_MAX_BRANCH=4
+      export HAIL_SHUFFLE_CUTOFF=1000000
+      export HAIL_QUERY_BACKEND=batch
+      export HAIL_BATCH_REGIONS={{ global.gcp_region }}
+      export HAIL_BATCH_BILLING_PROJECT=test
+      export HAIL_BATCH_REMOTE_TMPDIR={{ global.test_storage_uri }}
+
+      python3 -m pytest \
+              --color=yes \
+              -Werror:::hail -Werror:::hailtop -Werror::ResourceWarning \
+              --log-cli-level=INFO \
+              -s \
+              -r A \
+              -vv \
+              --instafail \
+              --durations=50 \
+              -m "backend and vep" \
+              --timeout=600 \
+              test/hail/methods/test_qc.py
     timeout: 5400
     inputs:
       - from: /derived/release/hail/build/deploy/dist
@@ -4192,6 +4265,7 @@ steps:
       - test_hailtop_python
       - test_hail_python_local_backend
       - test_hail_python_service_backend_gcp
+      - test_hail_python_service_backend_gcp_vep
       - test_hail_python_service_backend_gcp_fs
       - test_hail_scala_fs
       - test_hail_services_java
@@ -4286,6 +4360,7 @@ steps:
       - test_ci
       - test_hailtop_python
       - test_hail_python_service_backend_gcp
+      - test_hail_python_service_backend_gcp_vep
       - test_hail_python_service_backend_gcp_fs
       - test_hail_services_java
       - test_batch_docs
@@ -4379,6 +4454,7 @@ steps:
       - test_ci
       - test_hailtop_python
       - test_hail_python_service_backend_gcp
+      - test_hail_python_service_backend_gcp_vep
       - test_hail_python_service_backend_gcp_fs
   - kind: runImage
     name: setup_dev_namespace_autoscaledown

--- a/hail/python/pytest.ini
+++ b/hail/python/pytest.ini
@@ -11,6 +11,7 @@ markers =
     asyncio: test files that use asyncio
     backend: tests that relate only to one or more backend types
     cloud: tests that relate only to one or more clouds
+    vep: tests that run VEP annotation via a nested Batch execution
     uninitialized: tests that require the hail library to be uninitialized
     xtimeout: like timeout, only xfails instead of fails
 filterwarnings =

--- a/hail/python/test/hail/methods/test_qc.py
+++ b/hail/python/test/hail/methods/test_qc.py
@@ -333,7 +333,8 @@ class Tests(unittest.TestCase):
 
     @pytest.mark.backend('batch')
     @pytest.mark.cloud('gcp')
-    @test_timeout(batch=5 * 60)
+    @pytest.mark.vep
+    @test_timeout(batch=10 * 60)
     def test_vep_grch37_consequence_true(self):
         gnomad_vep_result = hl.import_vcf(
             resource('sample.gnomad.exomes.r2.1.1.sites.chr1.vcf.gz'), reference_genome='GRCh37', force=True
@@ -355,7 +356,8 @@ class Tests(unittest.TestCase):
 
     @pytest.mark.backend('batch')
     @pytest.mark.cloud('gcp')
-    @test_timeout(batch=5 * 60)
+    @pytest.mark.vep
+    @test_timeout(batch=10 * 60)
     def test_vep_grch38_consequence_true(self):
         gnomad_vep_result = hl.import_vcf(
             resource('sample.gnomad.genomes.r3.0.sites.chr1.vcf.gz'), reference_genome='GRCh38', force=True
@@ -379,7 +381,8 @@ class Tests(unittest.TestCase):
 
     @pytest.mark.backend('batch')
     @pytest.mark.cloud('gcp')
-    @test_timeout(batch=5 * 60)
+    @pytest.mark.vep
+    @test_timeout(batch=10 * 60)
     def test_vep_grch37_consequence_false(self):
         mt = hl.import_vcf(
             resource('sample.gnomad.exomes.r2.1.1.sites.chr1.vcf.gz'), reference_genome='GRCh37', force=True
@@ -392,7 +395,8 @@ class Tests(unittest.TestCase):
 
     @pytest.mark.backend('batch')
     @pytest.mark.cloud('gcp')
-    @test_timeout(batch=5 * 60)
+    @pytest.mark.vep
+    @test_timeout(batch=10 * 60)
     def test_vep_grch38_consequence_false(self):
         mt = hl.import_vcf(
             resource('sample.gnomad.genomes.r3.0.sites.chr1.vcf.gz'), reference_genome='GRCh38', force=True
@@ -405,7 +409,8 @@ class Tests(unittest.TestCase):
 
     @pytest.mark.backend('batch')
     @pytest.mark.cloud('gcp')
-    @test_timeout(batch=5 * 60)
+    @pytest.mark.vep
+    @test_timeout(batch=10 * 60)
     def test_vep_grch37_against_dataproc(self):
         mt = hl.import_vcf(resource('sample.vcf.gz'), reference_genome='GRCh37', force_bgz=True, n_partitions=4)
         mt = mt.head(20)
@@ -458,7 +463,8 @@ class Tests(unittest.TestCase):
 
     @pytest.mark.backend('batch')
     @pytest.mark.cloud('gcp')
-    @test_timeout(batch=5 * 60)
+    @pytest.mark.vep
+    @test_timeout(batch=10 * 60)
     def test_vep_grch38_against_dataproc(self):
         dataproc_result = hl.import_table(
             resource('dataproc_vep_grch38_annotations.tsv.gz'),
@@ -511,7 +517,8 @@ class Tests(unittest.TestCase):
 
     @pytest.mark.backend('batch')
     @pytest.mark.cloud('gcp')
-    @test_timeout(batch=5 * 60)
+    @pytest.mark.vep
+    @test_timeout(batch=10 * 60)
     def test_vep_grch38_with_large_positions(self):
         bad_variants = hl.import_table(
             resource('vep_grch38_input_req_indexed_cache.tsv'),


### PR DESCRIPTION
## Change Description

More flaky test work. These tests frequently run into timeouts so:

- Add more time to them in general
- Split them out into their own (unsharded) test suite so they won't compete with each other, at least

## Security Assessment

- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Test case reorganization. No prod facing outcome, no change in test coverage, just tweaking test locations and timeouts

### Appsec Review

- [ ] Required: The impact has been assessed and approved by appsec
