### PR TITLE
[query] Avoid closure-captured $outer in Spark task partitions

### DIFF
--- a/hail/hail/src/is/hail/backend/spark/SparkBackend.scala
+++ b/hail/hail/src/is/hail/backend/spark/SparkBackend.scala
@@ -203,6 +203,13 @@ class AnonymousDependency[T](val _rdd: RDD[T]) extends NarrowDependency[T](_rdd)
   override def getParents(partitionId: Int): Seq[Int] = Seq.empty
 }
 
+// Top-level (not a member of the anonymous RDD in mapCollectPartitions) so it carries
+// no implicit $outer pointer back to the enclosing RDD instance -- otherwise every task's
+// serialized Partition drags the whole RDD (and its full `contexts` array, `f`, etc.)
+// along with it, not just this partition's own `data`.
+private[spark] case class RDDPartition(data: Array[Byte], override val index: Int)
+    extends Partition
+
 class SparkBackend(val spark: SparkSession) extends Backend with Logging {
 
   // cached for convenience
@@ -238,8 +245,6 @@ class SparkBackend(val spark: SparkSession) extends Backend with Logging {
 
         val rdd: RDD[Array[Byte]] =
           new RDD[Array[Byte]](sc, sparkDeps) {
-
-            case class RDDPartition(data: Array[Byte], override val index: Int) extends Partition
 
             override protected val getPartitions: Array[Partition] =
               Array.tabulate(contexts.length)(index => RDDPartition(contexts(index), index))


### PR DESCRIPTION
## Change Description

RDDPartition was defined as a case class nested inside the anonymous RDD in mapCollectPartitions, so it carried an implicit $outer field pointing back to the enclosing RDD instance. Every task's serialized Partition therefore dragged along the whole RDD's captured state (the full contexts array, compiled PartitionFn, reference genomes, etc.), not just its own data slice -- size scaling with partition count and triggering Spark's "task of very large size" warnings.

Moving RDDPartition to a top-level, package-private case class (same shape already used by TableStageToRDDPartition in RVDToTableStage.scala) removes the $outer capture; compute() already accesses f/fsBc/globalsBc directly as RDD instance state, so no functional change.

## Security Assessment
- This change cannot impact the Hail Batch instance as deployed by Broad Institute in GCP