### PR TITLE
[monitoring] add tailwind style compilation in monitoring

### DIFF
--- a/monitoring/Dockerfile
+++ b/monitoring/Dockerfile
@@ -1,6 +1,11 @@
 ARG BASE_IMAGE={{ hail_ubuntu_image.image }}
 FROM $BASE_IMAGE
 
+RUN curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/download/v3.4.3/tailwindcss-linux-x64 && \
+    echo "3cea66f5fd87986538701a551c7342c29a0ae3e3139eed57c5bd9151f66dab96  tailwindcss-linux-x64" | sha256sum --status -c && \
+    chmod +x tailwindcss-linux-x64 && \
+    mv tailwindcss-linux-x64 /usr/bin/tailwindcss
+
 COPY hail/python/hailtop/pinned-requirements.txt hailtop-requirements.txt
 COPY gear/pinned-requirements.txt gear-requirements.txt
 COPY web_common/pinned-requirements.txt web_common-requirements.txt
@@ -16,11 +21,15 @@ COPY hail/python/hailtop /hailtop/hailtop/
 COPY gear/pyproject.toml /gear/pyproject.toml
 COPY gear/gear /gear/gear/
 
-COPY web_common/pyproject.toml web_common/MANIFEST.in /web_common/
+COPY web_common/pyproject.toml web_common/MANIFEST.in web_common/input.css web_common/tailwind.config.js /web_common/
 COPY web_common/web_common /web_common/web_common/
 
 COPY monitoring/pyproject.toml /monitoring/
 COPY monitoring/monitoring /monitoring/monitoring/
+
+RUN cd web_common && \
+    mkdir web_common/static/css && \
+    tailwindcss -i input.css -o web_common/static/css/output.css
 
 RUN hail-pip-install /hailtop /gear /web_common /monitoring
 


### PR DESCRIPTION
## Change Description

Fixes the billing comparison dashboard in monitoring by compiling the styles which it relies on.

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP
### Impact Rating

- This change has a low security impact

### Impact Description

Compiles a tailwind css into the monitoring image. Analogous to batch, ci and auth which all already do this.

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
