### PR TITLE
[ci] fix bugs in test/dev batch graph construction

### DIFF
--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -138,8 +138,6 @@ class BuildConfiguration:
                 for s in config['steps']
                 if s.get('name') in name_step and name_step[s['name']].can_run_in_scope(scope)
             ]
-            # See select_steps' docstring for why tactically_succeeded_always_run_steps
-            # must be excluded here rather than left to select_steps.
             always_run_steps = set(config.get('alwaysRunSteps', [])) - tactically_succeeded_always_run_steps
             # follow_forward=False for dev/deploy: see select_steps' docstring.
             selected_names = select_steps(seeds, valid_raw_steps, always_run_steps, follow_forward=scope == 'test')

--- a/ci/ci/build.py
+++ b/ci/ci/build.py
@@ -108,6 +108,7 @@ class BuildConfiguration:
         excluded_step_names: Sequence[str] = (),
         pr_labels: FrozenSet[str] = frozenset(),
         is_release: bool = False,
+        tactically_succeeded_always_run_steps: FrozenSet[str] = frozenset(),
     ):
         if len(excluded_step_names) > 0 and scope != 'dev':
             raise BuildConfigurationError('Excluding build steps is only permitted in a dev scope')
@@ -132,8 +133,16 @@ class BuildConfiguration:
                 step.name for step in runnable_steps if step.is_forced_by_labels(pr_labels)
             }
             # Use raw step configs so the selection logic stays pure and testable.
-            valid_raw_steps = [s for s in config['steps'] if s.get('name') in name_step]
-            selected_names = select_steps(seeds, valid_raw_steps)
+            valid_raw_steps = [
+                s
+                for s in config['steps']
+                if s.get('name') in name_step and name_step[s['name']].can_run_in_scope(scope)
+            ]
+            # See select_steps' docstring for why tactically_succeeded_always_run_steps
+            # must be excluded here rather than left to select_steps.
+            always_run_steps = set(config.get('alwaysRunSteps', [])) - tactically_succeeded_always_run_steps
+            # follow_forward=False for dev/deploy: see select_steps' docstring.
+            selected_names = select_steps(seeds, valid_raw_steps, always_run_steps, follow_forward=scope == 'test')
             self.steps = [
                 step
                 for step in runnable_steps

--- a/ci/ci/build_selection.py
+++ b/ci/ci/build_selection.py
@@ -106,37 +106,22 @@ def select_steps(
     always_run_steps: AbstractSet[str] = frozenset(),
     follow_forward: bool = True,
 ) -> Set[str]:
-    """Return the full set of step names that should run given a seed set.
+    """Return the full set of step names that should run, given a seed set.
 
     Algorithm:
       1. Forward pass (only if follow_forward) — expand seeds to include steps
          whose ordering predecessors (`dependsOn` *or* `after`) are selected.
-         This is appropriate when seeds come from what actually changed (a PR
-         diff, or a tactical retry within that same build) -- steps downstream
-         of a real change should re-run. It is NOT appropriate when seeds are an
-         explicit, hand-picked list (a dev deploy's `-s ...`, or a deploy's
-         DEPLOY_STEPS) -- there, the caller asked for exactly those steps, not
-         everything that happens to depend on them.
-      2. Backward pass — for every selected step (including always_run_steps,
-         mixed in after the forward pass), pull in hard dependsOn ancestors.
-         after edges are NOT followed here, so a cleanup step never forces its
-         ordering predecessors to re-run.
-
-    `always_run_steps` are force-included unconditionally by this function, so a
-    caller that already knows one of them succeeded (e.g. a tactical retry that
-    scanned prior batches) must exclude it beforehand -- otherwise a fully-succeeded
-    retry can never be a true no-op.
+         Appropriate when we want "X and everything that might be affected by
+         X".
+      2. Backward pass — for every selected step, pull in the `dependsOn`
+         dependencies. This makes sure we include everything necessary to run
+         the steps we want to run.
     """
     run_if_requested = {s['name'] for s in ordered_steps if s.get('runIfRequested')}
     eligible = [s for s in ordered_steps if not s.get('runIfRequested')]
     node_names = {s['name'] for s in ordered_steps}
 
-    # Hard-dep map over ALL steps (including runIfRequested ones), so that an
-    # explicitly-requested runIfRequested step still has its own dependsOn edges
-    # available for the backward pass below. Edges TO a runIfRequested step, or to
-    # a step that isn't in ordered_steps at all (e.g. filtered out by the caller for
-    # scope/cloud), are dropped, so a step never transitively drags in a step that
-    # can't actually run here.
+    # build the map of dependencies which are eligible to be included in the backward pass
     deps_map: Dict[str, List[str]] = {
         s['name']: [d for d in s.get('dependsOn', []) if d not in run_if_requested and d in node_names]
         for s in ordered_steps
@@ -159,14 +144,9 @@ def compute_requested_steps(
     scope: str,
     cloud: Optional[str] = None,
 ) -> Set[str]:
-    """Select which build steps are genuinely affected by the changed files in a PR.
+    """Select which build steps are potentially affected by files changed in a PR.
 
-    set(directly affected steps + their descendants)
-
-    Deliberately does NOT include alwaysRunSteps -- those carry no file-driven
-    signal of their own and must not be treated as seeds by select_steps's forward
-    pass (see select_steps' docstring). Callers that need them unconditionally
-    present should pass alwaysRunSteps to select_steps separately.
+    Includes directly affected steps AND their descendants, but NOT always-run steps.
     """
     config = yaml.safe_load(config_str)
     repo_prefix: str = config.get('repoPrefix', '/repo')

--- a/ci/ci/build_selection.py
+++ b/ci/ci/build_selection.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Sequence, Set
+from typing import AbstractSet, Dict, List, Optional, Sequence, Set
 
 import yaml
 
@@ -100,32 +100,57 @@ def _descendants_closure(seeds: Set[str], ordered_steps: Sequence[Dict]) -> Set[
     return selected
 
 
-def select_steps(seeds: Set[str], ordered_steps: Sequence[Dict]) -> Set[str]:
+def select_steps(
+    seeds: Set[str],
+    ordered_steps: Sequence[Dict],
+    always_run_steps: AbstractSet[str] = frozenset(),
+    follow_forward: bool = True,
+) -> Set[str]:
     """Return the full set of step names that should run given a seed set.
 
     Algorithm:
-      1. Forward pass  — expand seeds to include steps whose ordering predecessors
-         (dependsOn *or* after) are selected.  after edges are used here
-         so that cleanup steps follow the steps they clean up.
-      2. Backward pass — for every selected step, pull in hard dependsOn ancestors.
+      1. Forward pass (only if follow_forward) — expand seeds to include steps
+         whose ordering predecessors (`dependsOn` *or* `after`) are selected.
+         This is appropriate when seeds come from what actually changed (a PR
+         diff, or a tactical retry within that same build) -- steps downstream
+         of a real change should re-run. It is NOT appropriate when seeds are an
+         explicit, hand-picked list (a dev deploy's `-s ...`, or a deploy's
+         DEPLOY_STEPS) -- there, the caller asked for exactly those steps, not
+         everything that happens to depend on them.
+      2. Backward pass — for every selected step (including always_run_steps,
+         mixed in after the forward pass), pull in hard dependsOn ancestors.
          after edges are NOT followed here, so a cleanup step never forces its
-         ordering predecessors to re-run (important for tactical retries).
+         ordering predecessors to re-run.
+
+    `always_run_steps` are force-included unconditionally by this function, so a
+    caller that already knows one of them succeeded (e.g. a tactical retry that
+    scanned prior batches) must exclude it beforehand -- otherwise a fully-succeeded
+    retry can never be a true no-op.
     """
     run_if_requested = {s['name'] for s in ordered_steps if s.get('runIfRequested')}
     eligible = [s for s in ordered_steps if not s.get('runIfRequested')]
+    node_names = {s['name'] for s in ordered_steps}
 
-    # Hard-dep map: dependsOn only, excluding runIfRequested steps.
+    # Hard-dep map over ALL steps (including runIfRequested ones), so that an
+    # explicitly-requested runIfRequested step still has its own dependsOn edges
+    # available for the backward pass below. Edges TO a runIfRequested step, or to
+    # a step that isn't in ordered_steps at all (e.g. filtered out by the caller for
+    # scope/cloud), are dropped, so a step never transitively drags in a step that
+    # can't actually run here.
     deps_map: Dict[str, List[str]] = {
-        s['name']: [d for d in s.get('dependsOn', []) if d not in run_if_requested] for s in eligible
+        s['name']: [d for d in s.get('dependsOn', []) if d not in run_if_requested and d in node_names]
+        for s in ordered_steps
     }
 
-    # runIfRequested steps may appear as explicit seeds but are never pulled in
-    # transitively, so handle them separately.
     seeded_run_if_requested = seeds & run_if_requested
-    eligible_seeds = seeds - run_if_requested
+    forward_seeds = seeds - run_if_requested
 
-    with_descendants = _descendants_closure(eligible_seeds, eligible)
-    return _ancestors_closure(with_descendants, deps_map) | seeded_run_if_requested
+    if follow_forward:
+        with_descendants = _descendants_closure(forward_seeds, eligible)
+    else:
+        with_descendants = set(forward_seeds)
+    with_descendants |= always_run_steps - run_if_requested
+    return _ancestors_closure(with_descendants | seeded_run_if_requested, deps_map)
 
 
 def compute_requested_steps(
@@ -134,16 +159,20 @@ def compute_requested_steps(
     scope: str,
     cloud: Optional[str] = None,
 ) -> Set[str]:
-    """Select which build steps should be requested, given the changed files in a PR.
+    """Select which build steps are genuinely affected by the changed files in a PR.
 
-    set((directly affected steps + their descendants) + alwaysRunSteps)
+    set(directly affected steps + their descendants)
+
+    Deliberately does NOT include alwaysRunSteps -- those carry no file-driven
+    signal of their own and must not be treated as seeds by select_steps's forward
+    pass (see select_steps' docstring). Callers that need them unconditionally
+    present should pass alwaysRunSteps to select_steps separately.
     """
     config = yaml.safe_load(config_str)
     repo_prefix: str = config.get('repoPrefix', '/repo')
-    always_run_steps: Set[str] = set(config.get('alwaysRunSteps', []))
 
     if not changed_files:
-        return always_run_steps
+        return set()
 
     steps = [s for s in config.get('steps', []) if _valid_step(s, scope, cloud)]
 
@@ -153,7 +182,4 @@ def compute_requested_steps(
             descendants_map.setdefault(dep, []).append(step['name'])
 
     affected_steps = _find_affected_steps(steps, changed_files, repo_prefix)
-    affected_and_descendants = _expand_to_descendants(affected_steps, descendants_map)
-    requested_steps = affected_and_descendants | always_run_steps
-
-    return requested_steps
+    return _expand_to_descendants(affected_steps, descendants_map)

--- a/ci/ci/github.py
+++ b/ci/ci/github.py
@@ -9,12 +9,13 @@ import re
 import secrets
 import time
 from shlex import quote as shq
-from typing import Any, Dict, Iterable, List, Optional, Protocol, Sequence, Set, Union
+from typing import Any, Dict, FrozenSet, Iterable, List, Optional, Protocol, Sequence, Set, Union
 
 import aiohttp
 import aiohttp.client_exceptions
 import gidgethub
 import prometheus_client as pc  # type: ignore
+import yaml
 import zulip
 from gidgethub import aiohttp as gh_aiohttp
 
@@ -554,6 +555,7 @@ mkdir -p {shq(repo_dir)}
 
             with open(f'{repo_dir}/build.yaml', 'r', encoding='utf-8') as f:
                 build_yaml = f.read()
+            always_run_steps = set(yaml.safe_load(build_yaml).get('alwaysRunSteps', []))
             # None means run everything; a list (possibly empty) means run only those steps + label-forced.
             if RERUN_ALL_TESTS in self.labels or 'build.yaml' in changed_files:
                 log.info(f'PR #{self.number} running full test suite (rerun all tests label or build.yaml changed)')
@@ -565,9 +567,11 @@ mkdir -p {shq(repo_dir)}
 
             tactical = self.tactical
             tactical_skipped: Dict[str, int] = {}
+            tactically_succeeded_always_run_steps: FrozenSet[str] = frozenset()
             if tactical and requested_step_names is not None:
                 succeeded_steps: Dict[str, int] = {}
-                requested_steps_set = set(requested_step_names)
+                # See select_steps' docstring for why alwaysRunSteps need to be in this scan too.
+                requested_steps_set = set(requested_step_names) | always_run_steps
                 async for b in batch_client.list_batches(
                     f'test=1 pr={self.number} source_sha={self.source_sha} target_sha={self.target_branch.sha} user:ci',
                     limit=50,
@@ -593,6 +597,7 @@ mkdir -p {shq(repo_dir)}
                         break
                 tactical_skipped = {s: succeeded_steps[s] for s in requested_step_names if s in succeeded_steps}
                 requested_step_names = [s for s in requested_step_names if s not in succeeded_steps]
+                tactically_succeeded_always_run_steps = frozenset(always_run_steps & succeeded_steps.keys())
                 log.info(
                     f'PR #{self.number} tactical retry: skipping {len(tactical_skipped)} already-succeeded steps: {list(tactical_skipped)}'
                 )
@@ -602,6 +607,7 @@ mkdir -p {shq(repo_dir)}
                 build_yaml,
                 scope='test',
                 requested_step_names=requested_step_names,
+                tactically_succeeded_always_run_steps=tactically_succeeded_always_run_steps,
                 pr_labels=frozenset(self.labels),
             )
             namespace: Optional[str] = config.namespace()

--- a/ci/unit-test/test_build_selection.py
+++ b/ci/unit-test/test_build_selection.py
@@ -1,4 +1,5 @@
 import pathlib
+from typing import AbstractSet, Set
 
 import pytest
 import yaml
@@ -262,28 +263,29 @@ steps:
 @pytest.mark.parametrize(
     'config_str, changed_files, scope, cloud, expected_steps',
     [
-        # empty changed_files -> nothing runs except alwaysRunSteps (ie merge_code)
-        (_SIMPLE_CONFIG, [], 'test', None, {'merge_code'}),
-        # ci change affects check_ci; merge_code always included
-        (_SIMPLE_CONFIG, ['ci/foo.py'], 'test', None, ['check_ci', 'merge_code']),
-        # hail change affects check_hail; merge_code always included
-        (_SIMPLE_CONFIG, ['hail/foo.py'], 'test', None, ['check_hail', 'merge_code']),
+        # empty changed_files -> nothing genuinely affected (alwaysRunSteps are not this
+        # function's concern; select_steps adds them separately)
+        (_SIMPLE_CONFIG, [], 'test', None, set()),
+        # ci change affects check_ci
+        (_SIMPLE_CONFIG, ['ci/foo.py'], 'test', None, ['check_ci']),
+        # hail change affects check_hail
+        (_SIMPLE_CONFIG, ['hail/foo.py'], 'test', None, ['check_hail']),
         # README.md under ci/ affects check_ci just like any other file there
-        (_SIMPLE_CONFIG, ['ci/README.md'], 'test', None, ['check_ci', 'merge_code']),
+        (_SIMPLE_CONFIG, ['ci/README.md'], 'test', None, ['check_ci']),
         # multiple ci/ files both affect check_ci
-        (_SIMPLE_CONFIG, ['ci/README.md', 'ci/foo.py'], 'test', None, ['check_ci', 'merge_code']),
-        # deploy scope: check_ci scoped to [test,dev] is not affected; merge_code always included
-        (_SIMPLE_CONFIG, ['ci/foo.py'], 'deploy', None, ['merge_code']),
-        # gcp cloud filter — test_gcp + merge_code
-        (_CLOUD_CONFIG, ['ci/foo.py'], 'test', 'gcp', ['merge_code', 'test_gcp']),
+        (_SIMPLE_CONFIG, ['ci/README.md', 'ci/foo.py'], 'test', None, ['check_ci']),
+        # deploy scope: check_ci scoped to [test,dev] is not affected
+        (_SIMPLE_CONFIG, ['ci/foo.py'], 'deploy', None, []),
+        # gcp cloud filter — test_gcp only
+        (_CLOUD_CONFIG, ['ci/foo.py'], 'test', 'gcp', ['test_gcp']),
         # azure cloud filter
-        (_CLOUD_CONFIG, ['ci/foo.py'], 'test', 'azure', ['merge_code', 'test_azure']),
-        # no cloud filter -> both cloud-specific steps + merge_code
-        (_CLOUD_CONFIG, ['ci/foo.py'], 'test', None, ['merge_code', 'test_azure', 'test_gcp']),
+        (_CLOUD_CONFIG, ['ci/foo.py'], 'test', 'azure', ['test_azure']),
+        # no cloud filter -> both cloud-specific steps
+        (_CLOUD_CONFIG, ['ci/foo.py'], 'test', None, ['test_azure', 'test_gcp']),
         # runIfRequested step is never auto-selected as a descendant
-        (_RUN_IF_REQUESTED_CONFIG, ['ci/foo.py'], 'test', None, ['check_ci', 'merge_code']),
+        (_RUN_IF_REQUESTED_CONFIG, ['ci/foo.py'], 'test', None, ['check_ci']),
         # custom repoPrefix in config: ci change affects check_ci
-        (_CUSTOM_PREFIX_CONFIG, ['ci/foo.py'], 'test', None, ['check_ci', 'merge_code']),
+        (_CUSTOM_PREFIX_CONFIG, ['ci/foo.py'], 'test', None, ['check_ci']),
     ],
 )
 def test_compute_requested_steps(config_str, changed_files, scope, cloud, expected_steps):
@@ -367,12 +369,72 @@ def test_select_steps_forwards_not_backwards():
     }
 
 
+def test_select_steps_always_run_steps_do_not_seed_forward_pass():
+    steps = [
+        {'name': 'root_image'},
+        {'name': 'merge_code', 'dependsOn': ['root_image']},
+        {'name': 'unrelated_build', 'dependsOn': ['merge_code']},
+    ]
+    result = select_steps(set(), steps, always_run_steps={'merge_code'})
+
+    assert result == {'merge_code', 'root_image'}
+    assert 'unrelated_build' not in result
+
+
+def test_select_steps_empty_seeds_and_always_run_steps_is_a_true_no_op():
+    # See select_steps' docstring re always_run_steps and tactical retries.
+    steps = [
+        {'name': 'root_image'},
+        {'name': 'merge_code', 'dependsOn': ['root_image']},
+    ]
+    assert select_steps(set(), steps, always_run_steps=set()) == set()
+
+
+def test_select_steps_genuinely_selected_always_run_step_still_forward_propagates():
+    steps = [
+        {'name': 'root_image'},
+        {'name': 'merge_code', 'dependsOn': ['root_image']},
+        {'name': 'downstream_of_merge_code', 'dependsOn': ['merge_code']},
+    ]
+    result = select_steps({'merge_code'}, steps, always_run_steps={'merge_code'})
+
+    assert result == {'merge_code', 'root_image', 'downstream_of_merge_code'}
+
+
+def test_select_steps_requested_run_if_requested_step_pulls_in_its_ancestors():
+    steps = [
+        {'name': 'A'},
+        {'name': 'B', 'dependsOn': ['A']},
+        {'name': 'C', 'runIfRequested': True, 'dependsOn': ['B']},
+    ]
+    assert select_steps({'C'}, steps) == {'A', 'B', 'C'}
+
+
+def test_select_steps_unrequested_run_if_requested_step_not_pulled_in_forward_via_after():
+    steps = [
+        {'name': 'X'},
+        {'name': 'Y', 'runIfRequested': True, 'after': ['X']},
+    ]
+    assert select_steps({'X'}, steps) == {'X'}
+
+
 # ---------------------------------------------------------------------------
 # Unit tests against the real build.yaml
 # ---------------------------------------------------------------------------
 
 _BUILD_YAML = (pathlib.Path(__file__).parents[2] / 'build.yaml').read_text()
-_BUILD_STEPS = [s for s in yaml.safe_load(_BUILD_YAML)['steps'] if _valid_step(s, 'test', 'gcp')]
+_ALL_RAW_STEPS = yaml.safe_load(_BUILD_YAML)['steps']
+_BUILD_STEPS = [s for s in _ALL_RAW_STEPS if _valid_step(s, 'test', 'gcp')]
+
+
+def _steps_for_scope(scope, cloud='gcp'):
+    # Mirrors build.py's valid_raw_steps construction: filtered by scope and cloud,
+    # but runIfRequested steps are kept (select_steps needs them for the backward pass).
+    return [
+        s
+        for s in _ALL_RAW_STEPS
+        if (s.get('clouds') is None or cloud in s['clouds']) and (s.get('scopes') is None or scope in s['scopes'])
+    ]
 
 
 def test_batch_file_change_selects_batch_steps():
@@ -382,6 +444,121 @@ def test_batch_file_change_selects_batch_steps():
     result = compute_requested_steps(_BUILD_YAML, ['batch/batch/driver/main.py'], scope='test', cloud='gcp')
     assert 'test_batch' in result
     assert 'cancel_all_running_test_batches' in result
+
+
+_ALWAYS_RUN_STEPS = set(yaml.safe_load(_BUILD_YAML).get('alwaysRunSteps', []))
+
+
+def _assert_selection(scope: str, seed: Set[str], must_include: Set[str], must_exclude: AbstractSet[str] = frozenset()):
+    ordered_steps = _steps_for_scope(scope)
+    incompatible_with_scope = {s['name'] for s in _ALL_RAW_STEPS if s.get('scopes') and scope not in s['scopes']}
+
+    # Mirrors build.py: only a test-scope build's seeds come from what actually
+    # changed, so only test-scope forward-propagates to downstream steps.
+    result = select_steps(seed, ordered_steps, _ALWAYS_RUN_STEPS, follow_forward=scope == 'test')
+
+    assert _ALWAYS_RUN_STEPS <= result
+    assert must_include <= result
+    assert (must_exclude | incompatible_with_scope).isdisjoint(result)
+
+
+@pytest.mark.parametrize(
+    'changed_files, must_include, must_exclude',
+    [
+        (['monitoring/Dockerfile'], {'monitoring_image', 'deploy_monitoring', 'test_monitoring'}, {'test_batch'}),
+        (['docker/hail-ubuntu/Dockerfile'], {'hail_ubuntu_image'}, set()),
+        # A file with no matching `inputs` anywhere still triggers the whole-repo
+        # lint checks (their `inputs` is literally `/repo`), but nothing else.
+        (
+            ['dev-docs/pip-dependencies.md'],
+            {'check_pip_requirements', 'check_services'},
+            {'test_batch', 'test_auth', 'test_ci', 'monitoring_image', 'auth_image', 'batch_image', 'deploy_batch'},
+        ),
+        # hailtop is a shared input of every service image -- one change should
+        # fan out to every consumer, not just one.
+        (
+            ['hail/python/hailtop/utils/__init__.py'],
+            {
+                'batch_image',
+                'auth_image',
+                'ci_image',
+                'monitoring_image',
+                'deploy_batch',
+                'deploy_auth',
+                'deploy_ci',
+                'deploy_monitoring',
+                'test_batch',
+                'test_auth',
+                'test_ci',
+                'test_monitoring',
+            },
+            set(),
+        ),
+    ],
+    ids=[
+        'monitoring Dockerfile changed',
+        'hail-ubuntu Dockerfile changed',
+        'unrelated doc changed',
+        'shared hailtop dependency changed',
+    ],
+)
+def test_select_steps_pr_test_build(changed_files, must_include, must_exclude):
+    seed = compute_requested_steps(_BUILD_YAML, changed_files, scope='test', cloud='gcp')
+    _assert_selection('test', seed, must_include, must_exclude)
+
+
+@pytest.mark.parametrize(
+    'requested_steps, must_include, must_exclude',
+    [
+        ({'default_ns'}, {'default_ns'}, {'create_initial_user', 'delete_auth_tables'}),
+        ({'auth_database'}, {'auth_database'}, {'delete_auth_tables'}),
+        ({'monitoring_database'}, {'monitoring_database'}, {'delete_monitoring_tables'}),
+        (
+            {'create_initial_user'},
+            {'create_initial_user', 'default_ns', 'deploy_auth', 'hailgenetics_hailtop_image'},
+            set(),
+        ),
+        (
+            {'deploy_batch', 'add_developers'},
+            {'deploy_batch', 'add_developers', 'default_ns', 'deploy_auth'},
+            set(),
+        ),
+        (
+            {'hailgenetics_vep_grch38_95_image', 'hailgenetics_vep_grch37_85_image'},
+            {'hailgenetics_vep_grch38_95_image', 'hailgenetics_vep_grch37_85_image'},
+            {'test_hail_python_service_backend_gcp', 'test_hail_python_service_backend_gcp_fs'},
+        ),
+    ],
+    ids=[
+        '-s default_ns',
+        '-s auth_database',
+        '-s monitoring_database',
+        '-s create_initial_user',
+        '-s deploy_batch,add_developers',
+        '-s vep_images',
+    ],
+)
+def test_select_steps_dev_deploy(requested_steps, must_include, must_exclude):
+    _assert_selection('dev', requested_steps, must_include, must_exclude)
+
+
+@pytest.mark.parametrize(
+    'requested_steps, must_include, must_exclude',
+    [
+        ({'deploy_batch'}, {'deploy_batch'}, {'test_batch'}),
+        ({'deploy_ci'}, {'deploy_ci'}, {'test_ci'}),
+        ({'deploy_monitoring'}, {'deploy_monitoring'}, {'test_monitoring'}),
+        ({'deploy_batch', 'deploy_ci'}, {'deploy_batch', 'deploy_ci'}, {'test_batch', 'test_ci'}),
+    ],
+    ids=[
+        'DEPLOY_STEPS=deploy_batch',
+        'DEPLOY_STEPS=deploy_ci',
+        'DEPLOY_STEPS=deploy_monitoring',
+        'DEPLOY_STEPS=deploy_batch,deploy_ci',
+    ],
+)
+def test_select_steps_merge_deploy(requested_steps, must_include, must_exclude):
+    _assert_selection('deploy', requested_steps, must_include, must_exclude)
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
## Change Description

Fixes a number of issues introduced by the recent `after` change:

- `always_run_steps` were included in calculating the "and descendants" list
  - Specifically, `merge code` => everything depends on it => everything got picked for every PR
- `runIfRequested` steps were not included in the "and ancestors" calculation
  - So we were missing out on any upstream dependencies of the `runIfRequested` steps were were asking to run
- Steps in the wrong scope were no longer being excluded properly
- Steps in dev/deploy scopes were bring in descendants instead of stopping at the requested step
  - So dev deploys were incorrectly bringing in a whole bunch of test - and shutdown! - steps as well as (eg) `deploy_batch`

And added a bunch of end-to-end test cases against the real build.yaml
- eg: if I changed file x, which test steps should be added
- eg: if I request dev deploy step y, which steps should be added

## Security Assessment

Delete all except the correct answer:
- This change potentially impacts the Hail Batch instance as deployed by Broad Institute in GCP

### Impact Rating

- This change has a low security impact

### Impact Description

Fixes a number of bugs in how the deploy and test batch graph is calculated, and adds some tests

### Appsec Review

- [x] Required: The impact has been assessed and approved by appsec
